### PR TITLE
fixes for BISERVER-7185 & BISERVER-7189

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MultitableDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MultitableDatasourceService.java
@@ -100,7 +100,9 @@ public class MultitableDatasourceService extends PentahoBase implements IGwtJoin
 		
 		IDatabaseConnection iDatabaseConnection = this.connectionServiceImpl.convertFromConnection(connection);
 		iDatabaseConnection.setPassword(ConnectionServiceHelper.getConnectionPassword(connection.getName(), connection.getPassword()));
-		return DatabaseUtil.convertToDatabaseMeta(iDatabaseConnection);
+		DatabaseMeta dbmeta = DatabaseUtil.convertToDatabaseMeta(iDatabaseConnection);
+    dbmeta.getDatabaseInterface().setQuoteAllFields(true);
+    return dbmeta;
   }
 	
 	public List<String> retrieveSchemas(IConnection connection) throws DatasourceServiceException {


### PR DESCRIPTION
BISERVER-7185 -Datasource wizard does not show correct foodmart tables/fields when using the Oracle driver.
BISERVER-7189 -Metadata columns contains invalid characters (space). String needs to be sanitized.
