### PR TITLE
[BISERVER-7270] JSON fix for Sugar.

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -72,9 +72,9 @@
                 conf="default->default" changing="true"/>
 
     <dependency org="dom4j" name="dom4j" rev="1.6.1"/>
-    <dependency org="com.thoughtworks.xstream" name="xstream" rev="1.3.1"/>
+    <dependency org="com.thoughtworks.xstream" name="xstream" rev="1.4.2"/>
     <dependency org="stax" name="stax" rev="1.2.0"/>
-    <dependency org="org.codehaus.jettison" name="jettison" rev="1.0.1"/>
+    <dependency org="org.codehaus.jettison" name="jettison" rev="1.3.1"/>
     <dependency org="jaxen" name="jaxen" rev="1.1" transitive="false" conf="default->default"/>
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0.7" conf="test->default"/>
     <dependency org="mysql" name="mysql-connector-java" rev="5.1.17" conf="runtime->default"/>


### PR DESCRIPTION
Update versions of XStream to 1.4.2 and Jettison to 1.2
