### PR TITLE
[BISERVER-7317] Restoring old datasource import method to support the datasource import dialog

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MetadataDatasourceServiceGwtImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MetadataDatasourceServiceGwtImpl.java
@@ -36,7 +36,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 @SuppressWarnings("all")
 public class MetadataDatasourceServiceGwtImpl {
 
-  String datasourceUrl = getWebAppRoot() + "plugin/data-access/api/metadata/import?domainId={domainId}&metadataFile={metadataFile}";//$NON-NLS-1$
+  String datasourceUrl = getWebAppRoot() + "plugin/data-access/api/metadata/uploadServletImport?domainId={domainId}&metadataFile={metadataFile}";//$NON-NLS-1$
   
   public void importMetadataDatasource(final String domainId, final String metadataFile, final String localizeBundleEntries, final XulServiceCallback<String> xulCallback) {
     AuthenticatedGwtServiceUtil.invokeCommand(new IAuthenticatedGwtCommand() {


### PR DESCRIPTION
This method is restored, but marked deprecated as it will be removed in future sprints.
