### PR TITLE
BISERVER-7840 - Cannot add measures and dimensions to the model in Data Source Model window

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -39,4 +39,4 @@ dependency.jettison.revision=1.2
 
 dependency.gwt.revision=2.4.0
 dependency.gwt-incubator.revision=2.1.0
-dependency.gwt-dnd.revision=3.1.1
+dependency.gwt-dnd.revision=3.1.2

--- a/data-access.iml
+++ b/data-access.iml
@@ -1,5 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="gwt" name="GWT">
+      <configuration>
+        <setting name="compilerMaxHeapSize" value="256" />
+        <setting name="gwtScriptOutputStyle" value="DETAILED" />
+        <setting name="gwtSdkUrl" value="file://$USER_HOME$/jars/gwt-2.4.0" />
+        <setting name="webFacet" value="Web" />
+        <packaging>
+          <module name="org.pentaho.platform.dataaccess.datasource.DatasourceEditorDebug" enabled="false" />
+          <module name="org.pentaho.platform.dataaccess.datasource.DatasourceEditorModule" enabled="false" />
+        </packaging>
+      </configuration>
+    </facet>
+    <facet type="web" name="Web">
+      <configuration>
+        <descriptors>
+          <deploymentDescriptor name="web.xml" url="file://$MODULE_DIR$/web2/WEB-INF/web.xml" />
+        </descriptors>
+        <webroots>
+          <root url="file://$MODULE_DIR$/war" relative="/" />
+        </webroots>
+        <sourceRoots>
+          <root url="file://$MODULE_DIR$/src" />
+        </sourceRoots>
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
@@ -10,26 +37,8 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="api" />
-    <orderEntry type="module" module-name="core" />
-    <orderEntry type="module" module-name="extensions" />
-    <orderEntry type="module" module-name="repository" />
-    <orderEntry type="module" module-name="scheduler" />
-    <orderEntry type="module-library" scope="TEST">
-      <library name="test-lib">
-        <CLASSES>
-          <root url="file://$MODULE_DIR$/test-lib" />
-          <root url="file://$MODULE_DIR$/test-lib" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="file://$MODULE_DIR$/test-lib" />
-          <root url="file://$MODULE_DIR$/test-lib" />
-        </SOURCES>
-        <jarDirectory url="file://$MODULE_DIR$/test-lib" recursive="false" />
-        <jarDirectory url="file://$MODULE_DIR$/test-lib" recursive="false" type="SOURCES" />
-      </library>
-    </orderEntry>
+    <orderEntry type="module" module-name="pentaho-xul-gwt" />
+    <orderEntry type="module" module-name="pentaho-modeler" />
     <orderEntry type="module-library">
       <library name="lib">
         <CLASSES>
@@ -45,6 +54,22 @@
         <jarDirectory url="file://$MODULE_DIR$/war/WEB-INF/lib" recursive="false" type="SOURCES" />
       </library>
     </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library name="test-lib">
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/test-lib" />
+          <root url="file://$MODULE_DIR$/test-lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="file://$MODULE_DIR$/test-lib" />
+          <root url="file://$MODULE_DIR$/test-lib" />
+        </SOURCES>
+        <jarDirectory url="file://$MODULE_DIR$/test-lib" recursive="false" />
+        <jarDirectory url="file://$MODULE_DIR$/test-lib" recursive="false" type="SOURCES" />
+      </library>
+    </orderEntry>
+    <orderEntry type="library" name="gwt-user" level="project" />
   </component>
   <component name="org.twodividedbyzero.idea.findbugs">
     <option name="_basePreferences">

--- a/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditor.gwt.xml
+++ b/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditor.gwt.xml
@@ -26,7 +26,7 @@ This module serves as the Debuging environment and default implementation for in
   <inherits name="org.pentaho.ui.database.DatabaseDialog"/>
   <inherits name="org.pentaho.database.Database"/>
   <inherits name="org.pentaho.reporting.libraries.base.Util" />
-    <source path="">    
+    <source path="">
         <exclude name="**/MQLEditorDebugGwtServlet*"/>
         <exclude name="**/SwingMqlEditor*"/>
         <exclude name="**/MQLEditorServiceDeligate*"/>
@@ -35,7 +35,7 @@ This module serves as the Debuging environment and default implementation for in
         <exclude name="**/ModelSerializer*"/>
         <exclude name="**/CWMStartup*"/>
         <exclude name="**/ConnectionDebugGwtServlet*"/>
-        <exclude name="**/DatasourceDebugGwtServlet*"/>
+        <!--<exclude name="**/DatasourceDebugGwtServlet*"/>-->
         <exclude name="**/SwingDatasourceEditor*"/>
         <exclude name="**/SwingDatasourceSelectionDialog*"/>
         <exclude name="**/ConnectionServiceImpl*"/>
@@ -88,11 +88,13 @@ This module serves as the Debuging environment and default implementation for in
    <stylesheet src="datasourceEditorDialog.css"/>
    <stylesheet src="datasourceAdminDialog.css"/>
    <public path="wizard/public"/>
+
     <entry-point class="org.pentaho.platform.dataaccess.datasource.wizard.GwtDatasourceEditorEntryPoint"/>
-   <!--
-  <servlet path="/databaseConnectionService" class="org.pentaho.ui.database.gwt.GwtDatabaseConnectionServlet" />
-  <servlet path="/ConnectionService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.ConnectionDebugGwtServlet" />
-  <servlet path="/DatasourceService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.DatasourceDebugGwtServlet" />
-  <servlet path="/UploadService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.UploadFileDebugServlet" />
-  -->
+
+<!--
+      <servlet path="/databaseConnectionService" class="org.pentaho.ui.database.gwt.GwtDatabaseConnectionServlet" />
+      <servlet path="/ConnectionService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.ConnectionDebugGwtServlet" />
+      <servlet path="/DatasourceService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.DSWDatasourceDebugGwtServlet" />
+      <servlet path="/UploadService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.UploadFileDebugServlet" />
+    -->
  </module>

--- a/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditorDebug.gwt.xml
+++ b/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditorDebug.gwt.xml
@@ -36,7 +36,7 @@ This module serves as the Debuging environment and default implementation for in
         <exclude name="**/ModelSerializer*"/>
         <exclude name="**/CWMStartup*"/>
         <exclude name="**/ConnectionDebugGwtServlet*"/>
-        <exclude name="**/DatasourceDebugGwtServlet*"/>
+        <!--<exclude name="**/DatasourceDebugGwtServlet*"/>-->
         <exclude name="**/SwingDatasourceEditor*"/>
         <exclude name="**/SwingDatasourceSelectionDialog*"/>
         <exclude name="**/ConnectionServiceImpl*"/>
@@ -63,6 +63,7 @@ This module serves as the Debuging environment and default implementation for in
         <exclude name="**/ConnectionServiceHelper*"/>
         <exclude name="**/DatasourceServiceHelper*"/>
     	<exclude name="**/DataAccessDatabaseConnectionService*"/>
+    	<exclude name="**/DataAccessDatabaseDialectService*"/>
         <exclude name="**/Messages*"/>
         <exclude name="**/service/agile/*"/>
         <exclude name="**/service/impl/utils/*"/>
@@ -88,7 +89,7 @@ This module serves as the Debuging environment and default implementation for in
    <stylesheet src="datasourceEditorDialog.css"/>
    <stylesheet src="datasourceAdminDialog.css"/>
    <public path="wizard/public"/>
-    <entry-point class="org.pentaho.platform.dataaccess.datasource.wizard.GwtDatasourceEditorEntryPoint"/>
+    <entry-point class="org.pentaho.platform.dataaccess.datasource.wizard.debug.DebugGwtDatasourceEditorEntryPoint"/>
    <!--
   <servlet path="/databaseConnectionService" class="org.pentaho.ui.database.gwt.GwtDatabaseConnectionServlet" />
   <servlet path="/ConnectionService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.ConnectionDebugGwtServlet" />

--- a/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditorModule.gwt.xml
+++ b/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditorModule.gwt.xml
@@ -29,7 +29,7 @@
         <exclude name="**/ModelSerializer*"/>
         <exclude name="**/CWMStartup*"/>
         <exclude name="**/ConnectionDebugGwtServlet*"/>
-        <exclude name="**/DatasourceDebugGwtServlet*"/>
+        <!--<exclude name="**/DatasourceDebugGwtServlet*"/>-->
         <exclude name="**/SwingDatasourceEditor*"/>
         <exclude name="**/SwingDatasourceSelectionDialog*"/>
         <exclude name="**/ConnectionServiceImpl*"/>
@@ -82,7 +82,7 @@
   <stylesheet src="datasourceEditorDialog.css"/>
   <stylesheet src="datasourceAdminDialog.css"/>
   <public path="wizard/public"/>
-  <servlet path="/ConnectionService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.ConnectionDebugGwtServlet" />
-  <servlet path="/DatasourceService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.DatasourceDebugGwtServlet" />
-  <servlet path="/UploadService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.UploadFileDebugServlet" />
+  <!--<servlet path="/ConnectionService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.ConnectionDebugGwtServlet" />-->
+  <!--<servlet path="/DatasourceService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.DSWDatasourceDebugGwtServlet" />-->
+  <!--<servlet path="/UploadService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.UploadFileDebugServlet" />-->
 </module>

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/GwtDatasourceEditorEntryPoint.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/GwtDatasourceEditorEntryPoint.java
@@ -117,15 +117,22 @@ public class GwtDatasourceEditorEntryPoint implements EntryPoint {
   private GwtXulAsyncDatabaseConnectionService connService = new GwtXulAsyncDatabaseConnectionService();
   private GwtXulAsyncDatabaseDialectService dialectService = new GwtXulAsyncDatabaseDialectService();
 
+  private IServiceFactory serviceFactory = new ServiceFactory();
+
+  protected IServiceFactory getServiceFactory() {
+    return serviceFactory;
+  }
+
   public void onModuleLoad() {
-    datasourceServiceManager = new DatasourceServiceManagerGwtImpl();
+    datasourceServiceManager = getServiceFactory().createDatasourceServiceManager();
     datasourceServiceManager.isAdmin(new XulServiceCallback<Boolean>() {
       public void error(String message, Throwable error) {
+
       }
       public void success(Boolean retVal) {
         isAdmin = retVal;
-        datasourceService = new DSWDatasourceServiceGwtImpl();
-        modelerService = new GwtModelerServiceImpl();
+        datasourceService = getServiceFactory().createDatasourceService();
+        modelerService = getServiceFactory().createModelerService();
         BogoPojo bogo = new BogoPojo();
         modelerService.gwtWorkaround(bogo, new XulServiceCallback<BogoPojo>(){
           public void success(BogoPojo retVal) {
@@ -177,7 +184,12 @@ public class GwtDatasourceEditorEntryPoint implements EntryPoint {
     manager.registerService(new MondrianUIDatasourceService(datasourceServiceManager));
     manager.registerService(new MetadataUIDatasourceService(datasourceServiceManager));
     manager.registerService(new DSWUIDatasourceService(datasourceServiceManager));
-    manager.getIds(null);
+
+    try {
+      manager.getIds(null);
+    } catch (NullPointerException npe) {
+      // when in debug mode, there are no dbs
+    }
     
   }
   private native static void loadOverlay( String overlayId) /*-{
@@ -453,6 +465,8 @@ public class GwtDatasourceEditorEntryPoint implements EntryPoint {
       }
     };
 
+    showWizardEdit(domainId, modelId, perspective, relationalOnlyValid, listener);
+
   }
 
 
@@ -637,7 +651,7 @@ public class GwtDatasourceEditorEntryPoint implements EntryPoint {
 
 		        @Override
 		        public void onDialogError(String errorMessage) {
-		        	listener.onDialogError(errorMessage);		          
+		        	listener.onDialogError(errorMessage);
 		        }
 		      };
 		  

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/IServiceFactory.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/IServiceFactory.java
@@ -1,0 +1,17 @@
+package org.pentaho.platform.dataaccess.datasource.wizard;
+
+import org.pentaho.agilebi.modeler.services.IModelerServiceAsync;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.IXulAsyncDSWDatasourceService;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.IXulAsyncDatasourceServiceManager;
+
+/**
+ * User: RFellows
+ * Date: 12/14/12
+ */
+public interface IServiceFactory {
+
+  public IXulAsyncDatasourceServiceManager createDatasourceServiceManager();
+  public IModelerServiceAsync createModelerService();
+  public IXulAsyncDSWDatasourceService createDatasourceService();
+
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/ServiceFactory.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/ServiceFactory.java
@@ -1,0 +1,30 @@
+package org.pentaho.platform.dataaccess.datasource.wizard;
+
+import org.pentaho.agilebi.modeler.services.IModelerServiceAsync;
+import org.pentaho.agilebi.modeler.services.impl.GwtModelerServiceImpl;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.IXulAsyncDSWDatasourceService;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.IXulAsyncDatasourceServiceManager;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.DSWDatasourceServiceGwtImpl;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.DatasourceServiceManagerGwtImpl;
+
+/**
+ * User: RFellows
+ * Date: 12/14/12
+ */
+public class ServiceFactory implements IServiceFactory {
+
+  @Override
+  public IXulAsyncDatasourceServiceManager createDatasourceServiceManager() {
+    return new DatasourceServiceManagerGwtImpl();
+  }
+
+  @Override
+  public IModelerServiceAsync createModelerService() {
+    return new GwtModelerServiceImpl();
+  }
+
+  @Override
+  public IXulAsyncDSWDatasourceService createDatasourceService() {
+    return new DSWDatasourceServiceGwtImpl();
+  }
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/debug/DebugDatasourceServiceManagerGwtImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/debug/DebugDatasourceServiceManagerGwtImpl.java
@@ -1,0 +1,17 @@
+package org.pentaho.platform.dataaccess.datasource.wizard.debug;
+
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.DatasourceServiceManagerGwtImpl;
+import org.pentaho.ui.xul.XulServiceCallback;
+
+/**
+ * User: RFellows
+ * Date: 12/17/12
+ */
+public class DebugDatasourceServiceManagerGwtImpl extends DatasourceServiceManagerGwtImpl {
+
+  @Override
+  public void isAdmin(final XulServiceCallback<Boolean> xulCallback) {
+    xulCallback.success(true);
+  }
+
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/debug/DebugGwtDatasourceEditorEntryPoint.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/debug/DebugGwtDatasourceEditorEntryPoint.java
@@ -1,0 +1,17 @@
+package org.pentaho.platform.dataaccess.datasource.wizard.debug;
+
+import org.pentaho.platform.dataaccess.datasource.wizard.GwtDatasourceEditorEntryPoint;
+import org.pentaho.platform.dataaccess.datasource.wizard.IServiceFactory;
+
+/**
+ * User: RFellows
+ * Date: 12/17/12
+ */
+public class DebugGwtDatasourceEditorEntryPoint extends GwtDatasourceEditorEntryPoint {
+
+  private IServiceFactory serviceFactory = new DebugServiceFactory();
+
+  protected IServiceFactory getServiceFactory() {
+    return serviceFactory;
+  }
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/debug/DebugServiceFactory.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/debug/DebugServiceFactory.java
@@ -1,0 +1,16 @@
+package org.pentaho.platform.dataaccess.datasource.wizard.debug;
+
+import org.pentaho.platform.dataaccess.datasource.wizard.ServiceFactory;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.IXulAsyncDatasourceServiceManager;
+
+/**
+ * User: RFellows
+ * Date: 12/14/12
+ */
+public class DebugServiceFactory extends ServiceFactory {
+
+  @Override
+  public IXulAsyncDatasourceServiceManager createDatasourceServiceManager() {
+    return new DebugDatasourceServiceManagerGwtImpl();
+  }
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/gwt/ModelerServiceDebugServlet.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/gwt/ModelerServiceDebugServlet.java
@@ -56,7 +56,12 @@ public class ModelerServiceDebugServlet extends RemoteServiceServlet implements 
   public Domain loadDomain(String id) throws Exception{
     XmiParser parser = new XmiParser();
     try {
-      return parser.parseXmi(new FileInputStream(new File("test-res/" + id + ".xmi")));
+      // can set this with so it's available at runtime with a commandline arg ==> -Dtest-res-path=/somePath/to/test-res
+      String path = System.getProperty("test-res-path");
+
+      if(path == null) path = "test-res";
+
+      return parser.parseXmi(new FileInputStream(new File(path + "/" + id + ".xmi")));
     } catch (Exception e) {
       e.printStackTrace();
       throw e;


### PR DESCRIPTION
Refactored data-access to allow for debugging (gwt-dev mode)
Added layout suppression during setElements to avoid redundant updateUI calls that were flooding thousands invalid of drop handlers into the drop controller.
Added debug-mode related error handling.
