### PR TITLE
BISERVER-8010 Made gwt specific implementation for info center help link

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/modeler/GwtUriHandler.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/modeler/GwtUriHandler.java
@@ -1,0 +1,23 @@
+package org.pentaho.platform.dataaccess.datasource.modeler;
+
+import org.pentaho.agilebi.modeler.IUriHandler;
+
+public class GwtUriHandler implements IUriHandler {
+
+  @Override
+  public void openUri(String uri) {
+    openUriInPuc("Infocenter Help", uri);
+  }
+  
+  private native static void openUriInPuc(String title, String uri)/*-{
+    if (typeof(window) === "object"
+    &&  typeof(window.top) === "object"
+    &&  typeof(window.top.urlCommand) === "function"
+    ) {
+      window.top.urlCommand(uri, title, false, 0, 0);
+    }
+    else {
+      window.open(uri);
+    }
+  }-*/;
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/modeler/ModelerDialog.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/modeler/ModelerDialog.java
@@ -183,6 +183,7 @@ public class ModelerDialog extends AbstractXulDialogController<Domain> implement
     IModelerWorkspaceHelper workspacehelper = model.getWorkspaceHelper();
 
     controller = new ModelerController(model);
+    controller.setUriHandler(new GwtUriHandler());
     controller.setWorkspaceHelper(workspacehelper);
 //    controller.setMessages(messages);
     final BindingFactory bf = new GwtBindingFactory(container.getDocumentRoot());

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/GwtDatasourceEditorEntryPoint.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/GwtDatasourceEditorEntryPoint.java
@@ -36,6 +36,7 @@ import org.pentaho.metadata.model.Domain;
 import org.pentaho.platform.dataaccess.datasource.IDatasourceInfo;
 import org.pentaho.platform.dataaccess.datasource.beans.LogicalModelSummary;
 import org.pentaho.platform.dataaccess.datasource.modeler.ModelerDialog;
+import org.pentaho.platform.dataaccess.datasource.modeler.GwtUriHandler;
 import org.pentaho.platform.dataaccess.datasource.ui.admindialog.GwtDatasourceAdminDialog;
 import org.pentaho.platform.dataaccess.datasource.ui.importing.AnalysisImportDialogController;
 import org.pentaho.platform.dataaccess.datasource.ui.importing.AnalysisImportDialogModel;
@@ -116,6 +117,7 @@ public class GwtDatasourceEditorEntryPoint implements EntryPoint {
   private Timer timer;
   private GwtXulAsyncDatabaseConnectionService connService = new GwtXulAsyncDatabaseConnectionService();
   private GwtXulAsyncDatabaseDialectService dialectService = new GwtXulAsyncDatabaseDialectService();
+  private GwtUriHandler uriHandler = new GwtUriHandler();
 
   private IServiceFactory serviceFactory = new ServiceFactory();
 
@@ -420,7 +422,7 @@ public class GwtDatasourceEditorEntryPoint implements EntryPoint {
           modelerPerspective = ModelerPerspective.valueOf(modelPerspective);
         } catch (IllegalArgumentException e) {
           modelerPerspective = ModelerPerspective.REPORTING;
-  }
+        }
         dialog.addDialogListener(listener);
         dialog.showDialog(domainId, modelId, modelerPerspective);
       }

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.properties
@@ -1,4 +1,4 @@
-modeler.title=Data Source Model
+modeler.title=Data Source Model Editor
 ModelEditor.ERROR=Modeler Error
 ModelEditor.ERROR_0001_SAVING_MODELS=Error Saving Models. Check your server log for details.
 ModelEditor.ERROR_0002_LOADING_DOMAIN=Error loading model from server. Check your server log for details.
@@ -150,6 +150,7 @@ more=More...
 geo_role=Geography Type
 time_level_type=Time Level Type
 time_format=Time Format
+time_format_help_tooltip=View data formatting documentation in Pentaho Infocenter.
 time_format_help_url=http://infocenter.pentaho.com/help/index.jsp?topic=%2Fanalysis_guide%2Fconcept_relative_date_filters.html
 none=None
 geo.location=Lat/Long

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.xul
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.xul
@@ -456,7 +456,8 @@
           <label id="time_level_format_label" value="${time_format}:"/>
           <button
             image="images/help_link2.png"
-            tooltiptext="View data formatting documentation in Pentaho Infocenter."
+            tooltiptext="${time_format_help_tooltip}"
+            onclick="modeler.showHelp('${time_format_help_url}')"
           />
         </hbox>
         <menulist id="time_level_format" editable="true">


### PR DESCRIPTION
BISERVER-8141 Changed modeler dialog title.

BISERVER-8141: Changed title from "Data Source Model" to "Data Source Model Editor".

BISERVER-8010: Added gwt specifif uri handler, modified the entry point to pull in the uri handler, modified the dialog to set the uri handler instance unto the modeler controller, modified xul and properties to perform the help action.
BISERVER-8141: changed the modeler's dialog title.
