### PR TITLE
BISERVER-8769: Unable to create a CSV data source

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/agile/StagingTransformGenerator.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/agile/StagingTransformGenerator.java
@@ -423,7 +423,7 @@ public abstract class StagingTransformGenerator extends PentahoBase {
 
     try {
       RowMetaInterface prev = transMeta.getPrevStepFields(TABLE_OUTPUT);
-      SQLStatement sqlStatement = meta.getSQLStatements(transMeta, stepMeta, prev);
+      SQLStatement sqlStatement = meta.getSQLStatements(transMeta, stepMeta, prev, null, false, null);
       if (!sqlStatement.hasError()) {
         if (sqlStatement.hasSQL()) {
           // now we can execute the SQL


### PR DESCRIPTION
The method that was replaced was in BaseStepMeta, deprecated and does not return SQL.  The change will ensure that TableOuputMeta's method is called.  The null, false, null parameters have to do with autoincrement columns and keys.  The staging table for a CSV does not need a PK and should not have autoincrement columns.
