### PR TITLE
BISERVER-8348

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.xul
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.xul
@@ -248,6 +248,11 @@
               <caption label="${details}"/>
               <label value="${dimension_name}:"/>
               <textbox id="dimension_name"/>
+              <hbox flex="1">
+                <checkbox id="is_time_dimension" />
+                <label value="${is_time_dimension}" />
+                <spacer flex="1"/>
+              </hbox>
             </groupbox>
 
           </vbox>
@@ -396,11 +401,64 @@
               <caption label="${details}"/>
               <label value="${level_name}:"/>
               <textbox id="level_name"/>
+              <hbox flex="1">
+                <checkbox id="has_unique_members" />
+                <label value="${has_unique_members}" />
+                <spacer flex="1"/>
+              </hbox>
+
+              <label value="${source_column}:" flex="1"/>
+
+              <label value="${ordinal_column}:" flex="1"/>
+              <hbox flex="1">
+                <vbox flex="1">
+                  <label id="level_ordinal_col" value=""/>
+                </vbox>
+                <vbox>
+                  <button
+                    image="images/edit.png"
+                    onclick="modeler.changeOrdinalColumn()"
+                    />
+                </vbox>
+                <vbox>
+                  <button
+                    id="clear_ordinal_column"
+                    image="images/remove.png"
+                    onclick="modeler.clearOrdinalColumn()"
+                    />
+                </vbox>
+              </hbox>
 
               <label value="${geo_role}:" />
               <menulist id="level_geo_role" pen:binding="displayName">
                   <menupopup/>
               </menulist>
+
+              <vbox id="time_level_elements">
+                <label id="time_level_type_label" value="${time_level_type}:" />
+                <menulist id="time_level_type" pen:binding="name">
+                  <menupopup/>
+                </menulist>
+
+                <hbox>
+                  <label id="time_level_format_label" value="${time_format}:"/>
+                  <button
+                    image="images/help_link2.png"
+                    tooltiptext="${time_format_help_tooltip}"
+                    onclick="modeler.showHelp('${time_format_help_url}')"
+                    />
+                </hbox>
+                <menulist id="time_level_format" editable="true">
+                  <menupopup>
+                    <menuitem label=""/>
+                    <menuitem label="yyyy"/>
+                    <menuitem label="q"/>
+                    <menuitem label="M"/>
+                    <menuitem label="w"/>
+                    <menuitem label="yyyy-MM-dd"/>
+                  </menupopup>
+                </menulist>
+              </vbox>
 
             </groupbox>
           </vbox>


### PR DESCRIPTION
BISERVER-8348 - putting in UI elements that were referenced from the forms in ModelerUIHelper. Null references were causing an exception that was getting swallowed and preventing the modeler dialog from opening. These UI elements were previously added to cubeForms.xul.
