### PR TITLE
[BISERVER-8686] IE9 - Unable to add new data source

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceServiceManagerGwtImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceServiceManagerGwtImpl.java
@@ -37,7 +37,8 @@ public class DatasourceServiceManagerGwtImpl implements IXulAsyncDatasourceServi
   public void getAnalysisDatasourceIds(final XulServiceCallback<List<String>> xulCallback) {
     AuthenticatedGwtServiceUtil.invokeCommand(new IAuthenticatedGwtCommand() {
       public void execute(final AsyncCallback callback) {
-        RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, getAnalysisDatasourceIdsURL);
+    	String cacheBuster = "?ts=" + new java.util.Date().getTime();
+        RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, getAnalysisDatasourceIdsURL + cacheBuster);
         try {
           requestBuilder.sendRequest(null, new RequestCallback() {
             @Override
@@ -74,7 +75,8 @@ public class DatasourceServiceManagerGwtImpl implements IXulAsyncDatasourceServi
   public void getMetadataDatasourceIds(final XulServiceCallback<List<String>> xulCallback) {
     AuthenticatedGwtServiceUtil.invokeCommand(new IAuthenticatedGwtCommand() {
       public void execute(final AsyncCallback callback) {
-        RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, getMetadataDatasourceIdsURL);
+    	String cacheBuster = "?ts=" + new java.util.Date().getTime();
+        RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, getMetadataDatasourceIdsURL + cacheBuster);
         try {
           requestBuilder.sendRequest(null, new RequestCallback() {
             @Override
@@ -189,7 +191,8 @@ public class DatasourceServiceManagerGwtImpl implements IXulAsyncDatasourceServi
   public void getDSWDatasourceIds(final XulServiceCallback<List<String>> xulCallback) {
     AuthenticatedGwtServiceUtil.invokeCommand(new IAuthenticatedGwtCommand() {
       public void execute(final AsyncCallback callback) {
-        RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, getDSWDatasourceIdsURL);
+    	String cacheBuster = "?ts=" + new java.util.Date().getTime();
+        RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, getDSWDatasourceIdsURL + cacheBuster);
         try {
           requestBuilder.sendRequest(null, new RequestCallback() {
             @Override


### PR DESCRIPTION
added a ts=(timestamp) request param to prevent IE9 from caching REST calls 

> plugin/data-access/api/datasource/analysis/ids
> plugin/data-access/api/datasource/metadata/ids
> plugin/data-access/api/datasource/dsw/ids
