### PR TITLE
BISERVER-8947 - New default theme for the user console

### DIFF
--- a/package-res/plugin.xml
+++ b/package-res/plugin.xml
@@ -79,4 +79,14 @@
     id="metadataServiceDA"
     type="xml,gwt"
     class="org.pentaho.platform.dataaccess.metadata.service.MetadataService"/>
+
+  <external-resources>
+    <!--
+     **  Need these css includes here. adding them to the gwt module definition makes the load order unpredictable.
+     **  This unpredictability allows them to supercede the theme css files in some cases.
+     -->
+    <file context="global">content/data-access/resources/gwt/datasourceEditorDialog.css</file>
+    <file context="global">content/data-access/resources/gwt/datasourceAdminDialog.css</file>
+  </external-resources>
+
 </plugin>

--- a/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditor.gwt.xml
+++ b/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditor.gwt.xml
@@ -87,8 +87,6 @@ This module serves as the Debuging environment and default implementation for in
         <exclude name="**/MultitableDatasourceService*"/>
 
     </source>
-   <stylesheet src="datasourceEditorDialog.css"/>
-   <stylesheet src="datasourceAdminDialog.css"/>
    <public path="wizard/public"/>
     <entry-point class="org.pentaho.platform.dataaccess.datasource.wizard.GwtDatasourceEditorEntryPoint"/>
    <!--

--- a/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditorDebug.gwt.xml
+++ b/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditorDebug.gwt.xml
@@ -87,8 +87,6 @@ This module serves as the Debuging environment and default implementation for in
         <exclude name="**/MultitableDatasourceService*"/>
 
     </source>
-   <stylesheet src="datasourceEditorDialog.css"/>
-   <stylesheet src="datasourceAdminDialog.css"/>
    <public path="wizard/public"/>
     <entry-point class="org.pentaho.platform.dataaccess.datasource.wizard.GwtDatasourceEditorEntryPoint"/>
    <!--

--- a/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditorModule.gwt.xml
+++ b/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditorModule.gwt.xml
@@ -81,8 +81,6 @@
 
 
   </source>
-  <stylesheet src="datasourceEditorDialog.css"/>
-  <stylesheet src="datasourceAdminDialog.css"/>
   <public path="wizard/public"/>
   <servlet path="/ConnectionService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.ConnectionDebugGwtServlet" />
   <servlet path="/DatasourceService" class="org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.DatasourceDebugGwtServlet" />


### PR DESCRIPTION
removed css includes from data-access gwt module definitions and moved them into external resources in the plugin.xml file.

**adding them to the gwt module definition makes the load order unpredictable. This unpredictability allows them to supercede the theme css files in some cases.
