### PR TITLE
Fix for BISERVER-10589

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/multitable/MultiTableDatasource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/multitable/MultiTableDatasource.java
@@ -255,6 +255,7 @@ public class MultiTableDatasource extends AbstractXulEventHandler implements IWi
 	@Override
 	public void reset() {
 		this.joinGuiModel.reset();
+		this.tablesSelectionStep.setDatasourceDTO( null );
 	}
 
 	@Bindable


### PR DESCRIPTION
DSW - Selected tables in multi-table datasource aren't cleared out when
a new datasource is created.
