### PR TITLE
BISERVER-10792 - IE8/IE9 -Xaction Cancel button causes IE to crash or give stack overflow error

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditor.gwt.xml
+++ b/src/org/pentaho/platform/dataaccess/datasource/DatasourceEditor.gwt.xml
@@ -88,9 +88,11 @@ This module serves as the Debuging environment and default implementation for in
 
     </source>
    <public path="wizard/public"/>
-   
-    <add-linker name="xsiframe"/>
-    <set-configuration-property name="devModeRedirectEnabled" value="true"/>
+
+<!-- **SuperDevMode** == Uncomment this and re-build to get a SuperDevMode compatible build
+  <add-linker name="xsiframe"/>
+  <set-configuration-property name="devModeRedirectEnabled" value="true"/>
+**SuperDevMode** -->
    
     <entry-point class="org.pentaho.platform.dataaccess.datasource.wizard.GwtDatasourceEditorEntryPoint"/>
    <!--


### PR DESCRIPTION
BISERVER-10792 - IE8/IE9 -Xaction Cancel button causes IE to crash or give stack overflow error
