### PR TITLE
BISERVER-9358 - Buttons in IE do not respect padding defined in theme cs...

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/datasourceEditorDialog.css
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/datasourceEditorDialog.css
@@ -144,6 +144,12 @@ aggregation-dialog-checkbox-label {
     border-collapse: collapse;
 }
 
+.IE .dialogContent,
+.IE .dialog-content {
+    border-spacing: inherit;
+    border-collapse: inherit;
+}
+
 .dialog-content {
     border-collapse: expression('separate', cellSpacing = '0px');  /* IE hack  */
     border-collapse: separate;


### PR DESCRIPTION
...s and position at the very bottom of dialogs

fixed styles
