### PR TITLE
[BISERVER-11217] - Added creatable flag, omit datasource types from crea...

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/DatasourceInfo.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/DatasourceInfo.java
@@ -49,6 +49,8 @@ public class DatasourceInfo extends XulEventSourceAdapter implements IDatasource
   
   boolean exportable;
 
+  boolean creatable;
+
   static transient DatasourceMessages messageBundle;
 
 
@@ -73,6 +75,20 @@ public class DatasourceInfo extends XulEventSourceAdapter implements IDatasource
     this.removable = removable;
     this.importable = importable;
     this.exportable = exportable;
+    this.creatable = true;
+  }
+
+  public DatasourceInfo(String name, String id, String type, boolean editable, boolean removable, boolean importable,
+                        boolean exportable, boolean creatable) {
+    super();
+    this.name = name;
+    this.id = id;
+    this.type = type;
+    this.editable = editable;
+    this.removable = removable;
+    this.importable = importable;
+    this.exportable = exportable;
+    this.creatable = creatable;
   }
   
   @Bindable
@@ -159,6 +175,11 @@ public class DatasourceInfo extends XulEventSourceAdapter implements IDatasource
   @Override
   public boolean isExportable() {
     return this.exportable;
+  }
+
+  @Override
+  public boolean isCreatable(){
+    return this.creatable;
   }
 
   public static void setMessageBundle(DatasourceMessages bundle) {

--- a/src/org/pentaho/platform/dataaccess/datasource/IDatasourceInfo.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/IDatasourceInfo.java
@@ -72,4 +72,10 @@ public interface IDatasourceInfo extends Serializable{
    * @return
    */
   public String getDisplayType();
+
+  /**
+   * Returns whether a datasource can be created
+   * @return
+   */
+  public boolean isCreatable();
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/admindialog/DatasourceAdminDialogController.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/admindialog/DatasourceAdminDialogController.java
@@ -280,7 +280,18 @@ public class DatasourceAdminDialogController extends AbstractXulDialogController
           datasourceTypeMenuPopup.removeComponent(component);
         }
 
+        List<IDatasourceInfo> datasourceInfoList = datasourceAdminDialogModel.getDatasourcesList();
+
         for(String datasourceType:datasourceTypes) {
+
+          boolean creatable = true;
+
+          IUIDatasourceAdminService datasourceAdminService = manager.getService( datasourceType );
+
+          if(!datasourceAdminService.isCreatable()){
+            continue;
+          }
+
           XulMenuitem menuItem;
           try {
             menuItem = (XulMenuitem) document.createElement("menuitem");

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/service/DSWUIDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/service/DSWUIDatasourceService.java
@@ -33,6 +33,7 @@ public class DSWUIDatasourceService implements IUIDatasourceAdminService{
   private boolean removable = true;
   private boolean importable = false;
   private boolean exportable = true;
+  private boolean creatable = true;
   private String newUI = "builtin:";
   private String editUI= "builtin:";
   @Override
@@ -105,4 +106,43 @@ public class DSWUIDatasourceService implements IUIDatasourceAdminService{
     datasourceService.remove(dsInfo, callback);
   }
 
+  /**
+   * Return editable flag
+   * @return
+   */
+  @Override public boolean isEditable() {
+    return editable;
+  }
+
+  /**
+   * Return removable flag
+   * @return
+   */
+  @Override public boolean isRemovable() {
+    return removable;
+  }
+
+  /**
+   * Return importable flag
+   * @return
+   */
+  @Override public boolean isImportable() {
+    return importable;
+  }
+
+  /**
+   * Return exportable flag
+   * @return
+   */
+  @Override public boolean isExportable() {
+    return exportable;
+  }
+
+  /**
+   * Return creatable flag
+   * @return
+   */
+  @Override public boolean isCreatable() {
+    return creatable;
+  }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/service/IUIDatasourceAdminService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/service/IUIDatasourceAdminService.java
@@ -57,4 +57,14 @@ public interface IUIDatasourceAdminService {
 
   public void remove(IDatasourceInfo dsInfo, Object callback);
 
+  public boolean isEditable();
+
+  public boolean isRemovable();
+
+  public boolean isImportable();
+
+  public boolean isExportable();
+
+  public boolean isCreatable();
+
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/service/JSDatasourceInfo.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/service/JSDatasourceInfo.java
@@ -44,7 +44,9 @@ public class JSDatasourceInfo implements IDatasourceInfo{
 
   private final native boolean isDatasourceImportable(JavaScriptObject jsDatasourceInfo) /*-{ return jsDatasourceInfo.importable; }-*/; 
   
-  private final native boolean isDatasourceExportable(JavaScriptObject jsDatasourceInfo) /*-{ return jsDatasourceInfo.exportable; }-*/; 
+  private final native boolean isDatasourceExportable(JavaScriptObject jsDatasourceInfo) /*-{ return jsDatasourceInfo.exportable; }-*/;
+
+  private final native boolean isDatasourceCreatable(JavaScriptObject jsDatasourceInfo) /*-{ return jsDatasourceInfo.creatable; }-*/;
 
   
   @Override
@@ -80,6 +82,11 @@ public class JSDatasourceInfo implements IDatasourceInfo{
   @Override
   public final boolean isExportable() {
     return isDatasourceExportable(this.jsDatasourceInfo);
+  }
+
+  @Override
+  public final boolean isCreatable() {
+    return isDatasourceCreatable(this.jsDatasourceInfo);
   }
 
   @Override

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/service/JSUIDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/service/JSUIDatasourceService.java
@@ -29,6 +29,13 @@ import com.google.gwt.core.client.JsArray;
 
 public class JSUIDatasourceService implements IUIDatasourceAdminService {
   private JavaScriptObject datasourceServiceObject;
+
+  private boolean editable = false;
+  private boolean removable = false;
+  private boolean importable = false;
+  private boolean exportable = false;
+  private boolean creatable = false;
+
   // Overlay types always have protected, zero argument constructors.
   public JSUIDatasourceService(JavaScriptObject datasourceServiceObject) {
     this.datasourceServiceObject = datasourceServiceObject;
@@ -75,6 +82,46 @@ public class JSUIDatasourceService implements IUIDatasourceAdminService {
     getDelegateRemove(this.datasourceServiceObject, dsInfo.getId(), xulServiceCallbackJsObject.getJavascriptObject());
   }
 
+  /**
+   * Return editable flag
+   * @return
+   */
+  @Override public boolean isEditable() {
+    return editable;
+  }
+
+  /**
+   * Return removable flag
+   * @return
+   */
+  @Override public boolean isRemovable() {
+    return removable;
+  }
+
+  /**
+   * Return importable flag
+   * @return
+   */
+  @Override public boolean isImportable() {
+    return importable;
+  }
+
+  /**
+   * Return exportable flag
+   * @return
+   */
+  @Override public boolean isExportable() {
+    return exportable;
+  }
+
+  /**
+   * Return creatable flag
+   * @return
+   */
+  @Override public boolean isCreatable() {
+    return creatable;
+  }
+
 
   private final native JsArray<JavaScriptObject> getDelegateIds(JavaScriptObject datasourceServiceObject) /*-{
     return datasourceServiceObject.getIds();
@@ -98,4 +145,25 @@ public class JSUIDatasourceService implements IUIDatasourceAdminService {
   private final native String getDelegateRemove(JavaScriptObject datasourceServiceObject, String id, JavaScriptObject callback) /*-{
     return datasourceServiceObject.doRemove(id, callback);
   }-*/;
+
+  private final native String getDelegateIsEditable(JavaScriptObject datasourceServiceObject)/*-{
+    return datasourceServiceObject.isEditable();
+  }-*/;
+
+  private final native String getDelegateIsRemovable(JavaScriptObject datasourceServiceObject)/*-{
+    return datasourceServiceObject.isRemovable();
+  }-*/;
+
+  private final native String getDelegateIsImportable(JavaScriptObject datasourceServiceObject)/*-{
+    return datasourceServiceObject.isImportable();
+  }-*/;
+
+  private final native String getDelegateIsExportable(JavaScriptObject datasourceServiceObject)/*-{
+    return datasourceServiceObject.isExportable();
+  }-*/;
+
+  private final native String getDelegateIsCreatable(JavaScriptObject datasourceServiceObject)/*-{
+    return datasourceServiceObject.isCreatable();
+  }-*/;
+
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/service/JdbcDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/service/JdbcDatasourceService.java
@@ -44,6 +44,7 @@ public class JdbcDatasourceService implements IUIDatasourceAdminService{
   private boolean removable = true;
   private boolean importable = true;
   private boolean exportable = true;
+  private boolean creatable = true;
   private String newUI = "builtin:";
   private String editUI = "builtin:";
 
@@ -189,4 +190,43 @@ public class JdbcDatasourceService implements IUIDatasourceAdminService{
 //    connectionService.deleteConnection(dsInfo.getName(), callback);
 //  }
 
+  /**
+   * Return editable flag
+   * @return
+   */
+  @Override public boolean isEditable() {
+    return editable;
+  }
+
+  /**
+   * Return removable flag
+   * @return
+   */
+  @Override public boolean isRemovable() {
+    return removable;
+  }
+
+  /**
+   * Return importable flag
+   * @return
+   */
+  @Override public boolean isImportable() {
+    return importable;
+  }
+
+  /**
+   * Return exportable flag
+   * @return
+   */
+  @Override public boolean isExportable() {
+    return exportable;
+  }
+
+  /**
+   * Return creatable flag
+   * @return
+   */
+  @Override public boolean isCreatable() {
+    return creatable;
+  }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/service/MetadataUIDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/service/MetadataUIDatasourceService.java
@@ -32,6 +32,7 @@ public class MetadataUIDatasourceService implements IUIDatasourceAdminService{
   private boolean removable = true;
   private boolean importable = true;
   private boolean exportable = true;
+  private boolean creatable = true;
   private String newUI = "builtin:";
   private String editUI = "builtin:";
   private IXulAsyncDatasourceServiceManager datasourceService;
@@ -89,6 +90,46 @@ public class MetadataUIDatasourceService implements IUIDatasourceAdminService{
   @Override
   public void remove(IDatasourceInfo dsInfo, Object callback) {
     datasourceService.remove(dsInfo, callback);
+  }
+
+  /**
+   * Return editable flag
+   * @return
+   */
+  @Override public boolean isEditable() {
+    return editable;
+  }
+
+  /**
+   * Return removable flag
+   * @return
+   */
+  @Override public boolean isRemovable() {
+    return removable;
+  }
+
+  /**
+   * Return importable flag
+   * @return
+   */
+  @Override public boolean isImportable() {
+    return importable;
+  }
+
+  /**
+   * Return exportable flag
+   * @return
+   */
+  @Override public boolean isExportable() {
+    return exportable;
+  }
+
+  /**
+   * Return creatable flag
+   * @return
+   */
+  @Override public boolean isCreatable() {
+    return creatable;
   }
 
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/service/MondrianUIDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/service/MondrianUIDatasourceService.java
@@ -32,6 +32,7 @@ public class MondrianUIDatasourceService implements IUIDatasourceAdminService{
   private boolean removable = true;
   private boolean importable = true;
   private boolean exportable = true;
+  private boolean creatable = true;
   private String newUI = "builtin:";
   private String editUI = "builtin:";
   private IXulAsyncDatasourceServiceManager datasourceService;
@@ -89,6 +90,46 @@ public class MondrianUIDatasourceService implements IUIDatasourceAdminService{
   @Override
   public void remove(IDatasourceInfo dsInfo, Object callback) {
     datasourceService.remove(dsInfo, callback);
+  }
+
+  /**
+   * Return editable flag
+   * @return
+   */
+  @Override public boolean isEditable() {
+    return editable;
+  }
+
+  /**
+   * Return removable flag
+   * @return
+   */
+  @Override public boolean isRemovable() {
+    return removable;
+  }
+
+  /**
+   * Return importable flag
+   * @return
+   */
+  @Override public boolean isImportable() {
+    return importable;
+  }
+
+  /**
+   * Return exportable flag
+   * @return
+   */
+  @Override public boolean isExportable() {
+    return exportable;
+  }
+
+  /**
+   * Return creatable flag
+   * @return
+   */
+  @Override public boolean isCreatable() {
+    return creatable;
   }
 
 }


### PR DESCRIPTION
...te new list with creatable flag = false

Some additional notes: We originally only had the isEditable/Importable/() etc. methods for instances of DatasourceInfo and not the types themselves. I added those methods to the interface for the type because we would otherwise have a hard time determining those properties for types unless we had instances of those types present. This was not really an issue until this implementation of the creatable flag.
