### PR TITLE
[BISERVER-11415] Refresh connection before using in Data Source Wizard

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MultitableDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MultitableDatasourceService.java
@@ -75,7 +75,11 @@ public class MultitableDatasourceService extends PentahoBase implements IGwtJoin
 		if(this.connectionServiceImpl == null) {
 			return this.databaseMeta;
 		}
-		
+
+		// DatabaseConnection objects may be de-serialized from the client and missing extra parameters and attributes.
+		// Resolve the connection by name through ConnectionService before use.
+		// All public methods should use getDatabaseMeta to guarantee accurate connection info.
+		connection = connectionServiceImpl.getConnectionByName( connection.getName() );
 		connection.setPassword(ConnectionServiceHelper.getConnectionPassword(connection.getName(), connection.getPassword()));
 		DatabaseMeta dbmeta = DatabaseUtil.convertToDatabaseMeta(connection);
 	    dbmeta.getDatabaseInterface().setQuoteAllFields(true);


### PR DESCRIPTION
DatabaseConnection objects passed to public MultitableDatasourceService methods may be de-serialized from the client.
DTOs from the client should never be used to create DatabaseMeta and may be missing extra parameters and attributes.
Instead, resolve the connection by name through ConnectionService before use. All public methods of MultitableDatasourceService should use getDatabaseMeta to guarantee accurate connection info.

Affected Methods:
- getDatabaseTables
- retrieveSchemas
- getTableFields
- serializeJoins

http://jira.pentaho.com/browse/BISERVER-11415
