### PR TITLE
[PPP-3272] - Update all current "infocenter" references to "mind touch"

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.properties
@@ -157,8 +157,8 @@ is_time_dimension=Time Dimension
 has_unique_members=Contains only unique members
 time_level_type=Time Level Type
 time_format=Source Column Format
-time_format_help_tooltip=View formatting documentation in Pentaho Infocenter.
-time_format_help_url=http://infocenter.pentaho.com/help/topic/puc_user_guide/reference_time_level_format.html
+time_format_help_tooltip=View formatting documentation in Pentaho InfoCenter.
+time_format_help_url=http://help.pentaho.com
 
 ColResolverController.source_column_selection_dialog=Select Source Column
 ColResolverController.ordinal_column_selection_dialog=Select Ordinal Column


### PR DESCRIPTION
- Updated link references from infocenter.pentaho.com to help.pentaho.com.
- Tweaked references to InfoCenter to be consistently spelled (casing)
  InfoCenter is how the Doc team wants to refer to the help documentation at this point. No reference to MindTouch since it is only the implementation vehicle.
