### PR TITLE
BISERVER-11828 Editing a MSSQL JDBC connection inside PUC's Datasource Wizard automatically adds "instance" parameter in the "Options" panel

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/controllers/ConnectionController.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/controllers/ConnectionController.java
@@ -120,7 +120,6 @@ public class ConnectionController extends AbstractXulEventHandler {
     target.setStreamingResults( source.isStreamingResults() );
     target.setDataTablespace( source.getDataTablespace() );
     target.setIndexTablespace( source.getIndexTablespace() );
-    target.setSQLServerInstance( source.getSQLServerInstance() );
     target.setUsingDoubleDecimalAsSchemaTableSeparator( source.isUsingDoubleDecimalAsSchemaTableSeparator() );
     target.setInformixServername( source.getInformixServername() );
     //target.addExtraOption(String databaseTypeCode, String option, String value);

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/controllers/WizardConnectionController.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/controllers/WizardConnectionController.java
@@ -114,7 +114,6 @@ public class WizardConnectionController extends AbstractXulEventHandler {
     target.setStreamingResults( source.isStreamingResults() );
     target.setDataTablespace( source.getDataTablespace() );
     target.setIndexTablespace( source.getIndexTablespace() );
-    target.setSQLServerInstance( source.getSQLServerInstance() );
     target.setUsingDoubleDecimalAsSchemaTableSeparator( source.isUsingDoubleDecimalAsSchemaTableSeparator() );
     target.setInformixServername( source.getInformixServername() );
     //target.addExtraOption(String databaseTypeCode, String option, String value);

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/models/GuiStateModel.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/models/GuiStateModel.java
@@ -82,7 +82,7 @@ public class GuiStateModel extends XulEventSourceAdapter {
     conn.setPartitioningInformation( connection.getPartitioningInformation() );
     conn.setPassword( connection.getPassword() );
     conn.setQuoteAllFields( connection.isQuoteAllFields() );
-    conn.setSQLServerInstance( connection.getSQLServerInstance() );
+    conn.setExtraOptions( connection.getExtraOptions() );
     conn.setStreamingResults( connection.isStreamingResults() );
     conn.setUsername( connection.getUsername() );
     conn.setUsingConnectionPool( connection.isUsingConnectionPool() );
@@ -90,9 +90,8 @@ public class GuiStateModel extends XulEventSourceAdapter {
 
     //Force an update of any views on the connection list.
     if ( !oldName.equals( newName ) ) {
-      List<IDatabaseConnection> empty = java.util.Collections.EMPTY_LIST;
-      this.firePropertyChange( "connections", previousValue, empty ); //$NON-NLS-1$
-      previousValue = empty;
+      this.firePropertyChange( "connections", previousValue, Collections.emptyList() ); //$NON-NLS-1$
+      previousValue = Collections.emptyList();
     }
     this.firePropertyChange( "connections", previousValue, connections ); //$NON-NLS-1$
   }


### PR DESCRIPTION
code formatting, fixing (setServerInstance was deleted because it was copied as extra options)

dependent on https://github.com/pentaho/pentaho-commons-database/pull/54
