### PR TITLE
BISERVER-10486 - Can't delete PME model that contains slash "\" in the I...

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/ui/importing/MetadataImportDialogController.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/importing/MetadataImportDialogController.java
@@ -21,6 +21,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 import com.google.gwt.user.client.ui.*;
+import org.pentaho.gwt.widgets.client.utils.NameUtils;
 import org.pentaho.gwt.widgets.client.utils.i18n.ResourceBundle;
 import org.pentaho.platform.dataaccess.datasource.wizard.DatasourceMessages;
 import org.pentaho.ui.xul.binding.Binding;
@@ -272,6 +273,7 @@ public class MetadataImportDialogController extends AbstractXulDialogController<
     String msg = results;
     int code = new Integer(results).intValue();
     String messageId;
+    String[] parameters = new String[0];
     switch (code) {
       case 1: //PUBLISH_TO_SERVER_FAILED = 1;
         messageId = "Metadata.PUBLISH_TO_SERVER_FAILED";
@@ -291,11 +293,15 @@ public class MetadataImportDialogController extends AbstractXulDialogController<
       case 8: //PUBLISH_SCHEMA_EXISTS_ERROR
         messageId = "Metadata.OVERWRITE_EXISTING_SCHEMA";
         break;
+      case 10: //PUBLISH_PROHIBITED_SYMBOLS_ERROR
+        messageId = "Metadata.PUBLISH_PROHIBITED_SYMBOLS_ERROR";
+        parameters = new String[]{ NameUtils.reservedCharListForDisplay( ", " ) };
+        break;
       default:
         messageId = "Metadata.ERROR";
         break;
     }
-    msg = messages.getString(messageId);
+    msg = messages.getString(messageId, parameters);
     return msg + " Metadata File: " + fileName;
   }
 

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/importDialog.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/importDialog.properties
@@ -35,5 +35,6 @@ Metadata.PUBLISH_DATASOURCE_ERROR=Datasource error
 Metadata.PUBLISH_USERNAME_PASSWORD_FAIL=Invalid credentials
 Metadata.PUBLISH_XMLA_CATALOG_EXISTS=XML/A Catalog already exists
 Metadata.OVERWRITE_EXISTING_SCHEMA=Existing Metadata file. Overwrite file in Repository?
+Metadata.PUBLISH_PROHIBITED_SYMBOLS_ERROR=Invalid characters entered. The following characters cannot be used: {0}
 Metadata.SUCCESS=SUCCESS
 Metadata.ERROR=ERROR

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java
@@ -295,7 +295,7 @@ public class DatasourceResource {
     if(!canAdminister()) {
       return Response.status(UNAUTHORIZED).build();
     }
-    metadataDomainRepository.removeDomain(metadataId);
+    metadataDomainRepository.removeDomain( fixEncodedSlashParam( metadataId ) );
     return Response.ok().build();
   }
 
@@ -313,7 +313,7 @@ public class DatasourceResource {
     if(!canAdminister()) {
       return Response.status(UNAUTHORIZED).build();
     }
-    mondrianCatalogService.removeCatalog(analysisId, PentahoSessionHolder.getSession());
+    mondrianCatalogService.removeCatalog( fixEncodedSlashParam( analysisId ), PentahoSessionHolder.getSession() );
     return Response.ok().build();
   }
 
@@ -331,6 +331,7 @@ public class DatasourceResource {
     if(!canAdminister()) {
       return Response.status(UNAUTHORIZED).build();
     }
+    dswId = fixEncodedSlashParam( dswId );
     Domain domain = metadataDomainRepository.getDomain(dswId);
     ModelerWorkspace model = new ModelerWorkspace(new GwtModelerWorkspaceHelper());
     model.setDomain(domain);
@@ -429,5 +430,16 @@ public class DatasourceResource {
     return policy
         .isAllowed(RepositoryReadAction.NAME) && policy.isAllowed(RepositoryCreateAction.NAME)
         && (policy.isAllowed(AdministerSecurityAction.NAME));
+  }
+
+  /**
+   * Fix for "%5C" and "%2F" in datasource name ("/" and "\" are omitted and %5C, %2F are decoded
+   *    in PentahoPathDecodingFilter.EncodingAwareHttpServletRequestWrapper)
+   *
+   * @param param pathParam
+   * @return correct param
+   */
+  private String fixEncodedSlashParam( String param ) {
+    return param.replaceAll( "\\\\", "%5C" ).replaceAll( "/", "%2F" );
   }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages.properties
@@ -100,3 +100,4 @@ ConnectionServiceHelper.ERROR_0001_UNABLE_TO_GET_CONNECTION_PASSWORD=Unable to g
 
 MetadataDatasourceService.ERROR_001_METADATA_DATASOURCE_ERROR=Error creating Metadata datasource. Check the provided XMI file.
 MetadataDatasourceService.ERROR_002_PROPERTY_FILES_ERROR=The following property files do not appear to be in text format:
+MetadataDatasourceService.ERROR_003_PROHIBITED_SYMBOLS_ERROR=Invalid characters entered: "{0}". The following characters cannot be used: {1}


### PR DESCRIPTION
...D title

deny to add metadata with prohibited symbols

Needs in https://github.com/pentaho/pentaho-platform/pull/1678
