### PR TITLE
[BISERVER-11829] - Several text where translation text is not found.

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/main_wizard_panel.xul
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/main_wizard_panel.xul
@@ -290,8 +290,7 @@
 				          <listbox id="rightKeyField" pen:binding="name" disabled="false" height="150" width="300"/>
 				        </vbox>
 				      </hbox>
-					  <hbox>
-					    <spacer width="530"/>
+					  <hbox align="end">
 					    <button id="createJoinButton" label="${multitable.CREATE_JOIN}" pen:disabledimage="" tooltiptext="" onclick="joinDefinitionStepController.createJoin()" disabled="false"/>
 					  </hbox>
 				      <hbox>
@@ -300,8 +299,7 @@
 				          <listbox id="joins" pen:binding="name" disabled="false" height="100" width="610"/>
 				        </vbox>
 				      </hbox>
-			          <hbox>
-					    <spacer width="530"/>
+			          <hbox align="end">
 					    <button id="deleteJoinButton" label="${multitable.DELETE_JOIN}" pen:disabledimage="" tooltiptext="" onclick="joinDefinitionStepController.deleteJoin()" disabled="false"/>
 					  </hbox>
 				    </vbox>

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.properties
@@ -169,3 +169,5 @@ ColResolverController.caption_column_selection_dialog=Select Caption Column
 dialog.OK=OK
 dialog.CANCEL=Cancel
 dialog.CLOSE=Close
+
+chooseColumn=Choose a column from the available list

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.xul
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.xul
@@ -646,7 +646,7 @@
   <dialog xmlns:pen="http://www.pentaho.org/2008/xul" width="300" height="400" id="resolveColumnsDialog" title="Resolve Missing Columns"
     ondialogaccept="colResolver.done()" ondialogcancel="colResolver.cancel()" onload="colResolver.init()"  buttons="accept, cancel" buttonalign="right" buttonlabelaccept="${dialog.OK}" buttonlabelcancel="${dialog.cancel}">
     <groupbox flex="1">
-    <caption label="Choose a column from the available list"/>
+    <caption label="${chooseColumn}"/>
       <tree id="resolveColumnsTree" flex="1" editable="false" hiddenrootnode="true" preserveselection="false" height="400" width="295" >
         <treecols>
           <treecol flex="1" label="" primary="true"


### PR DESCRIPTION
- Data Access, Data Source Wizard, Data Source Model Editor, select a field and click the pencil for the "add column", "Choose a colum from the available  list" translation not found
