### PR TITLE
[BACKLOG-290] REST: Overhaul the data-access APIs

### DIFF
--- a/package-res/plugin.spring.xml
+++ b/package-res/plugin.spring.xml
@@ -17,10 +17,6 @@
   <bean id="api" class="org.pentaho.platform.web.servlet.JAXRSPluginServlet"/>
   <bean class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.PlatformStagingDatabaseResource"/>
   <bean class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.DatasourceResource"/>  
-  <bean class="org.pentaho.platform.dataaccess.datasource.api.resources.AnalysisResource"/>  
-  <bean class="org.pentaho.platform.dataaccess.datasource.api.resources.MetadataResource"/>
-  <bean class="org.pentaho.platform.dataaccess.datasource.api.resources.DataSourceWizardResource"/>
-  <bean class="org.pentaho.platform.dataaccess.datasource.api.resources.JDBCDatasourceResource"/>
   <bean class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.AnalysisDatasourceService"/>
   <bean class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.MetadataDatasourceService"/>
   <bean class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.ConnectionService"/>

--- a/src/org/pentaho/platform/dataaccess/datasource/api/resources/JDBCDatasourceResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/resources/JDBCDatasourceResource.java
@@ -34,7 +34,7 @@ import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServi
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.ConnectionService;
 import org.pentaho.ui.database.event.IDatabaseConnectionList;
 
-@Path( "/data-access/api/jdbc" )
+@Path( "/data-access/api" )
 public class JDBCDatasourceResource {
 
   private ConnectionService service;
@@ -53,7 +53,7 @@ public class JDBCDatasourceResource {
    * @throws ConnectionServiceException
    */
   @DELETE
-  @Path( "/delete" )
+  @Path( "/datasource/jdbc/delete" )
   public Response deleteConnectionByName( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
     return service.deleteConnectionByName( name );
   }
@@ -66,7 +66,7 @@ public class JDBCDatasourceResource {
    * @throws ConnectionServiceException
    */
   @GET
-  @Path( "/list" )
+  @Path( "/datasource/jdbc/list" )
   @Produces( { APPLICATION_JSON } )
   public IDatabaseConnectionList getConnections() throws ConnectionServiceException {
     return service.getConnections();
@@ -82,30 +82,27 @@ public class JDBCDatasourceResource {
    * @throws ConnectionServiceException
    */
   @GET
-  @Path( "/get" )
+  @Path( "/datasource/jdbc/get" )
   @Produces( { APPLICATION_JSON } )
   public IDatabaseConnection getConnectionByName( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
     return service.getConnectionByName( name );
   }
 
   /**
-   * Create a database connection
+   * Add a database connection
    *
-   * @param driver
-   *          String name of the driver to use
-   * @param url
-   *          String name of the url used to create the connection.
+   * @param connection A database connection object to add
+   * @return Response indicating the success of this operation
    *
-   * @return IDatabaseConnection for the given parameters
+   * @throws ConnectionServiceException
    */
-  @GET
-  @Path( "/create" )
-  @Produces( { APPLICATION_JSON } )
-  public IDatabaseConnection createDatabaseConnection( @QueryParam( "driver" ) String driver,
-      @QueryParam( "url" ) String url ) {
-    return service.createDatabaseConnection( driver, url );
+  @POST
+  @Path( "/datasource/jdbc/add" )
+  @Consumes( {APPLICATION_JSON} )
+  public Response addConnection( DatabaseConnection connection ) throws ConnectionServiceException {
+    return service.addConnection( connection );
   }
-
+  
   /**
    * Update an existing database connection
    *
@@ -116,7 +113,7 @@ public class JDBCDatasourceResource {
    * @throws ConnectionServiceException
    */
   @POST
-  @Path( "/update" )
+  @Path( "/datasource/jdbc/update" )
   @Consumes( { APPLICATION_JSON } )
   public Response updateConnection( DatabaseConnection connection ) throws ConnectionServiceException {
     return service.updateConnection( connection );

--- a/src/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResource.java
@@ -24,6 +24,7 @@ import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -37,10 +38,15 @@ import javax.ws.rs.core.Response;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.dataaccess.datasource.api.DatasourceService;
 import org.pentaho.platform.dataaccess.datasource.api.MetadataService;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.messages.Messages;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.services.importer.PlatformImportException;
+import org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter;
 import org.pentaho.platform.web.http.api.resources.FileResource;
 import org.pentaho.platform.web.http.api.resources.JaxbList;
 
@@ -48,18 +54,42 @@ import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataBodyPart;
 import com.sun.jersey.multipart.FormDataParam;
 
-@Path( "/data-access/api/datasource/metadata" )
+@Path( "/data-access/api" )
 public class MetadataResource {
 
-  private MetadataService service;
   private static final Log logger = LogFactory.getLog( MetadataResource.class );
   private static final String OVERWRITE_IN_REPOS = "overwrite";
   private static final String SUCCESS = "3";
 
+  private MetadataService service;
+  private IMetadataDomainRepository metadataDomainRepository;
+  
   public MetadataResource() {
     service = new MetadataService();
+    metadataDomainRepository = PentahoSystem.get( IMetadataDomainRepository.class, PentahoSessionHolder.getSession() );
   }
 
+  /**
+   * Download the metadata files for a given metadataId
+   *
+   * @param metadataId String Id of the metadata to retrieve
+   *
+   * @return Response containing the file data
+   */
+  @GET
+  @Path( "/datasource/metadata/{metadataId : .+}/download" )
+  @Produces( WILDCARD )
+  public Response doGetMetadataFilesAsDownload( @PathParam( "metadataId" ) String metadataId ) {
+    if( !DatasourceService.canAdminister() ) {
+      return Response.status( UNAUTHORIZED ).build();
+    }
+    if ( !( metadataDomainRepository instanceof IPentahoMetadataDomainRepositoryExporter ) ) {
+      return Response.serverError().build();
+    }
+    Map<String, InputStream> fileData = ( (IPentahoMetadataDomainRepositoryExporter) metadataDomainRepository ).getDomainFilesData( metadataId );
+    return ResourceUtil.createAttachment( fileData, metadataId );
+  }  
+  
   /**
    * Remove the metadata for a given metadata ID
    *
@@ -69,7 +99,7 @@ public class MetadataResource {
    * @return Response ok if successful
    */
   @POST
-  @Path( "/{metadataId : .+}/remove" )
+  @Path( "/datasource/metadata/{metadataId : .+}/remove" )
   @Produces( WILDCARD )
   public Response doRemoveMetadata( @PathParam( "metadataId" ) String metadataId ) {
     try {
@@ -86,7 +116,7 @@ public class MetadataResource {
    * @return JaxbList<String> of metadata IDs
    */
   @GET
-  @Path( "/ids" )
+  @Path( "/datasource/metadata/ids" )
   @Produces( { APPLICATION_XML, APPLICATION_JSON } )
   public JaxbList<String> getMetadataDatasourceIds() {
     return new JaxbList<String>( service.getMetadataDatasourceIds() );
@@ -112,7 +142,7 @@ public class MetadataResource {
    *           Thrown when validation of access fails
    */
   @PUT
-  @Path( "/import" )
+  @Path( "/datasource/metadata/import" )
   @Consumes( MediaType.MULTIPART_FORM_DATA )
   @Produces( "text/plain" )
   public Response importMetadataDatasource( @FormDataParam( "domainId" ) String domainId,

--- a/src/org/pentaho/platform/dataaccess/datasource/api/resources/ResourceUtil.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/resources/ResourceUtil.java
@@ -1,0 +1,105 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.dataaccess.datasource.api.resources;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
+import org.apache.commons.io.IOUtils;
+import org.pentaho.platform.repository2.unified.fileio.RepositoryFileInputStream;
+
+public class ResourceUtil {
+
+  public static final String APPLICATION_ZIP = "application/zip"; //$NON-NLS-1$
+
+  public static Response createAttachment( Map<String, InputStream> fileData, String domainId ) {
+    String quotedFileName = null;
+    final InputStream is;
+    if ( fileData.size() > 1 ) { // we've got more than one file so we want to zip them up and send them
+      File zipFile = null;
+      try {
+        zipFile = File.createTempFile( "datasourceExport", ".zip" ); //$NON-NLS-1$ //$NON-NLS-2$
+        zipFile.deleteOnExit();
+        ZipOutputStream zos = new ZipOutputStream( new FileOutputStream( zipFile ) );
+        for ( String fileName : fileData.keySet() ) {
+          InputStream zipEntryIs = null;
+          try { 
+            ZipEntry entry = new ZipEntry( fileName );
+            zos.putNextEntry( entry );
+            zipEntryIs = fileData.get( fileName );
+            IOUtils.copy( zipEntryIs, zos );
+          } catch ( Exception e ) {
+            continue;
+          } finally {
+            zos.closeEntry();
+            if ( zipEntryIs != null ) {
+              zipEntryIs.close();
+            }
+          }
+        }
+        zos.close();
+        is = new FileInputStream( zipFile );
+      } catch ( IOException ioe ) {
+        return Response.serverError().entity( ioe.toString() ).build();
+      }
+      StreamingOutput streamingOutput = new StreamingOutput() {
+        public void write( OutputStream output ) throws IOException {
+          IOUtils.copy( is, output );
+        }
+      };
+      final int xmiIndex = domainId.lastIndexOf( ".xmi" );//$NON-NLS-1$
+      quotedFileName = "\"" + ( xmiIndex > 0 ? domainId.substring( 0, xmiIndex ) : domainId ) + ".zip\""; //$NON-NLS-1$//$NON-NLS-2$
+      return Response.ok( streamingOutput, APPLICATION_ZIP ).header( "Content-Disposition", "attachment; filename=" + quotedFileName ).build(); //$NON-NLS-1$ //$NON-NLS-2$
+    } else if ( fileData.size() == 1 ) {  // we've got a single metadata file so we just return that.
+      String fileName = (String) fileData.keySet().toArray()[0];
+      quotedFileName = "\"" + fileName + "\""; //$NON-NLS-1$ //$NON-NLS-2$
+      is = fileData.get( fileName );
+      String mimeType = MediaType.TEXT_PLAIN;
+      if (is instanceof RepositoryFileInputStream) {
+        mimeType = ( (RepositoryFileInputStream)is ).getMimeType();
+      }
+      StreamingOutput streamingOutput = new StreamingOutput() {
+        public void write( OutputStream output ) throws IOException {
+          IOUtils.copy( is, output );
+        }
+      };
+      return Response.ok( streamingOutput, mimeType ).header( "Content-Disposition", "attachment; filename=" + quotedFileName ).build(); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    return Response.serverError().build();
+  }
+
+  public static void parseMondrianSchemaName( String dswId, Map<String, InputStream> fileData ) {
+    final String keySchema = "schema.xml";//$NON-NLS-1$
+    if ( fileData.containsKey( keySchema ) ) {
+      final int xmiIndex = dswId.lastIndexOf( ".xmi" );//$NON-NLS-1$
+      fileData.put( ( xmiIndex > 0 ? dswId.substring( 0, xmiIndex ) : dswId ) + ".mondrian.xml", fileData.get( keySchema ) );//$NON-NLS-1$
+      fileData.remove( keySchema );
+    }
+  }  
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
@@ -32,13 +32,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.dataaccess.datasource.api.AnalysisService;
+import org.pentaho.platform.dataaccess.datasource.api.resources.AnalysisResource;
 import org.pentaho.platform.plugin.services.importer.PlatformImportException;
 
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataParam;
 
-@Path("/data-access/api/mondrian")
-public class AnalysisDatasourceService {
+@Path( "/data-access/api" )
+public class AnalysisDatasourceService extends AnalysisResource {
 
   private static final String XMLA_ENABLED_FLAG = "xmlaEnabledFlag";
 
@@ -77,37 +78,37 @@ public class AnalysisDatasourceService {
    * @throws PentahoAccessControlException
    */
   @PUT
-  @Path("/putSchema")
-  @Consumes(MediaType.MULTIPART_FORM_DATA)
-  @Produces("text/plain")
+  @Path( "/mondrian/putSchema" )
+  @Consumes( MediaType.MULTIPART_FORM_DATA )
+  @Produces( "text/plain" )
   public Response putMondrianSchema(
-      @FormDataParam(UPLOAD_ANALYSIS) InputStream dataInputStream,
-      @FormDataParam(UPLOAD_ANALYSIS)FormDataContentDisposition schemaFileInfo,
-      @FormDataParam(CATALOG_NAME) String catalogName, //Optional
-      @FormDataParam(ORIG_CATALOG_NAME) String origCatalogName, //Optional
-      @FormDataParam(DATASOURCE_NAME) String datasourceName, //Optional
-      @FormDataParam(OVERWRITE_IN_REPOS) String overwrite,
-      @FormDataParam(XMLA_ENABLED_FLAG) String xmlaEnabledFlag,
-      @FormDataParam(PARAMETERS) String parameters) throws PentahoAccessControlException {
+      @FormDataParam( UPLOAD_ANALYSIS ) InputStream dataInputStream,
+      @FormDataParam( UPLOAD_ANALYSIS )FormDataContentDisposition schemaFileInfo,
+      @FormDataParam( CATALOG_NAME ) String catalogName, //Optional
+      @FormDataParam( ORIG_CATALOG_NAME ) String origCatalogName, //Optional
+      @FormDataParam( DATASOURCE_NAME ) String datasourceName, //Optional
+      @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
+      @FormDataParam( XMLA_ENABLED_FLAG ) String xmlaEnabledFlag,
+      @FormDataParam( PARAMETERS ) String parameters) throws PentahoAccessControlException {
     Response response = null;
     int statusCode = PlatformImportException.PUBLISH_GENERAL_ERROR;
     try {
       AnalysisService service = new AnalysisService();
       service.putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, datasourceName, overwrite, xmlaEnabledFlag, parameters );
       statusCode = SUCCESS;
-    } catch (PentahoAccessControlException pac) {
+    } catch ( PentahoAccessControlException pac ) {
       logger.error(pac.getMessage());
       statusCode = PlatformImportException.PUBLISH_USERNAME_PASSWORD_FAIL;
     } catch (PlatformImportException pe) {
       statusCode = pe.getErrorStatus();
-      logger.error("Error putMondrianSchema " + pe.getMessage() + " status = " + statusCode);
+      logger.error( "Error putMondrianSchema " + pe.getMessage() + " status = " + statusCode );
     } catch (Exception e) {
-      logger.error("Error putMondrianSchema " + e.getMessage());
+      logger.error( "Error putMondrianSchema " + e.getMessage() );
       statusCode = PlatformImportException.PUBLISH_GENERAL_ERROR;
     }
 
-    response = Response.ok().status(statusCode).type(MediaType.TEXT_PLAIN).build();
-    logger.debug("putMondrianSchema Response " + response);
+    response = Response.ok().status( statusCode ).type( MediaType.TEXT_PLAIN ).build();
+    logger.debug( "putMondrianSchema Response " + response );
     return response;
   }
 
@@ -126,25 +127,24 @@ public class AnalysisDatasourceService {
    * @throws PentahoAccessControlException
    */
   @POST
-  @Path("/postAnalysis")
-  @Consumes(MediaType.MULTIPART_FORM_DATA)
-  @Produces({"text/plain","text/html"})
-
+  @Path( "/mondrian/postAnalysis" )
+  @Consumes( MediaType.MULTIPART_FORM_DATA )
+  @Produces( {"text/plain","text/html" } )
   public Response postMondrainSchema(
-      @FormDataParam(UPLOAD_ANALYSIS) InputStream dataInputStream,
-      @FormDataParam(UPLOAD_ANALYSIS)FormDataContentDisposition schemaFileInfo,
-      @FormDataParam(CATALOG_NAME) String catalogName, //Optional
-      @FormDataParam(ORIG_CATALOG_NAME) String origCatalogName, //Optional
-      @FormDataParam(DATASOURCE_NAME) String datasourceName, //Optional
-      @FormDataParam(OVERWRITE_IN_REPOS) String overwrite,
-      @FormDataParam(XMLA_ENABLED_FLAG) String xmlaEnabledFlag,
-      @FormDataParam(PARAMETERS) String parameters) throws PentahoAccessControlException {
+      @FormDataParam( UPLOAD_ANALYSIS ) InputStream dataInputStream,
+      @FormDataParam( UPLOAD_ANALYSIS )FormDataContentDisposition schemaFileInfo,
+      @FormDataParam( CATALOG_NAME ) String catalogName, //Optional
+      @FormDataParam( ORIG_CATALOG_NAME ) String origCatalogName, //Optional
+      @FormDataParam( DATASOURCE_NAME ) String datasourceName, //Optional
+      @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
+      @FormDataParam( XMLA_ENABLED_FLAG ) String xmlaEnabledFlag,
+      @FormDataParam( PARAMETERS ) String parameters) throws PentahoAccessControlException {
      //use existing Jersey post method - but translate into text/html for PUC Client
      ResponseBuilder responseBuilder;
-     Response response = this.putMondrianSchema(dataInputStream, schemaFileInfo, catalogName, origCatalogName, datasourceName, overwrite, xmlaEnabledFlag, parameters);
+     Response response = this.putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, datasourceName, overwrite, xmlaEnabledFlag, parameters );
      responseBuilder=  Response.ok();
-     responseBuilder.entity(String.valueOf(response.getStatus()));
-     responseBuilder.status(200);
+     responseBuilder.entity( String.valueOf( response.getStatus() ) );
+     responseBuilder.status( 200 );
      return responseBuilder.build();
   }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
@@ -34,8 +34,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.pentaho.database.IDatabaseDialect;
 import org.pentaho.database.dialect.GenericDatabaseDialect;
 import org.pentaho.database.model.DatabaseConnection;
@@ -44,9 +42,9 @@ import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnectionPoolParameter;
 import org.pentaho.database.service.DatabaseDialectService;
 import org.pentaho.database.util.DatabaseUtil;
-import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.dataaccess.datasource.api.resources.JDBCDatasourceResource;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.messages.Messages;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -59,15 +57,16 @@ import org.pentaho.ui.database.event.DefaultDatabaseConnectionPoolParameterList;
 import org.pentaho.ui.database.event.IDatabaseConnectionList;
 import org.pentaho.ui.database.event.IDatabaseConnectionPoolParameterList;
 
-@Path("/data-access/api/connection")
-public class ConnectionService {
+@Path( "/data-access/api" )
+public class ConnectionService extends JDBCDatasourceResource {
+  
   private ConnectionServiceImpl service;
   private DatabaseDialectService dialectService;
   GenericDatabaseDialect genericDialect = new GenericDatabaseDialect();
   
   public ConnectionService() {
     service = new ConnectionServiceImpl();
-    this.dialectService = new DatabaseDialectService(true);
+    this.dialectService = new DatabaseDialectService( true );
   }
 
   /**
@@ -78,15 +77,15 @@ public class ConnectionService {
    * @throws ConnectionServiceException
    */
   @GET
-  @Path("/list")
-  @Produces({APPLICATION_JSON})
+  @Path( "/connection/list" )
+  @Produces( {APPLICATION_JSON} )
   public IDatabaseConnectionList getConnections() throws ConnectionServiceException {
     IDatabaseConnectionList databaseConnections = new DefaultDatabaseConnectionList();
     List<IDatabaseConnection> conns = service.getConnections();
     for (IDatabaseConnection conn : conns) {
-      hidePassword(conn);
+      hidePassword( conn );
     }
-    databaseConnections.setDatabaseConnections(conns);
+    databaseConnections.setDatabaseConnections( conns );
     return databaseConnections;
   }
 
@@ -99,11 +98,11 @@ public class ConnectionService {
    * @throws ConnectionServiceException
    */
   @GET
-  @Path("/get")
-  @Produces({APPLICATION_JSON})
-  public IDatabaseConnection getConnectionByName(@QueryParam("name") String name) throws ConnectionServiceException {
-    IDatabaseConnection conn = service.getConnectionByName(name);
-    hidePassword(conn);
+  @Path( "/connection/get" )
+  @Produces( {APPLICATION_JSON} )
+  public IDatabaseConnection getConnectionByName( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
+    IDatabaseConnection conn = service.getConnectionByName( name );
+    hidePassword( conn );
     return conn;
   }
 
@@ -116,17 +115,17 @@ public class ConnectionService {
    * @throws ConnectionServiceException
    */
   @GET
-  @Path("/checkexists")
-  @Produces({APPLICATION_JSON})
-  public Response isConnectionExist(@QueryParam("name") String name) throws ConnectionServiceException {
-    boolean exists = service.isConnectionExist(name);
+  @Path( "/connection/checkexists" )
+  @Produces( {APPLICATION_JSON} )
+  public Response isConnectionExist( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
+    boolean exists = service.isConnectionExist( name );
     try {
-      if (exists) {
+      if ( exists ) {
         return Response.ok().build();
       } else {
         return Response.notModified().build();
       }
-    } catch (Throwable t) {
+    } catch ( Throwable t ) {
       t.printStackTrace();
       return Response.serverError().build();
     }
@@ -137,17 +136,17 @@ public class ConnectionService {
    * use getEntity(Connection.class) and getStatus() to determine success
    */
   @GET
-  @Path("/getresponse")
-  @Produces({APPLICATION_JSON})
-  public Response getConnectionByNameWithResponse(@QueryParam("name") String name) throws ConnectionServiceException {
+  @Path( "/connection/getresponse" )
+  @Produces( {APPLICATION_JSON} )
+  public Response getConnectionByNameWithResponse( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
     IDatabaseConnection conn = null;
     Response response;
     try{
-     conn =service.getConnectionByName(name);
+     conn =service.getConnectionByName( name );
      hidePassword(conn);
-     response = Response.ok().entity(conn).build();
-    }catch(Exception ex){
-      response =  Response.serverError().entity(ex.getMessage()).build();
+     response = Response.ok().entity( conn ).build();
+    } catch ( Exception ex ) {
+      response =  Response.serverError().entity( ex.getMessage() ).build();
     }    
      return response;
   }
@@ -161,18 +160,18 @@ public class ConnectionService {
    * @throws ConnectionServiceException
    */
   @POST
-  @Path("/add")
-  @Consumes({APPLICATION_JSON})
-  public Response addConnection(DatabaseConnection connection) throws ConnectionServiceException {
+  @Path( "/connection/add" )
+  @Consumes( {APPLICATION_JSON} )
+  public Response addConnection( DatabaseConnection connection ) throws ConnectionServiceException {
     try {
       validateAccess();
-      boolean success = service.addConnection(connection);
+      boolean success = service.addConnection( connection );
       if (success) {
         return Response.ok().build();
       } else {
         return Response.notModified().build();
       }
-    } catch (Throwable t) {
+    } catch ( Throwable t ) {
       t.printStackTrace();
       return Response.serverError().build();
     }
@@ -187,13 +186,13 @@ public class ConnectionService {
    * @throws ConnectionServiceException
    */
   @POST
-  @Path("/update")
-  @Consumes({APPLICATION_JSON})
-  public Response updateConnection(DatabaseConnection connection) throws ConnectionServiceException {
+  @Path( "/connection/update" )
+  @Consumes( {APPLICATION_JSON} )
+  public Response updateConnection( DatabaseConnection connection ) throws ConnectionServiceException {
     try {
-      applySavedPassword(connection);
-      boolean success = service.updateConnection(connection);
-      if (success) {
+      applySavedPassword( connection );
+      boolean success = service.updateConnection( connection );
+      if ( success ) {
         return Response.ok().build();
       } else {
         return Response.notModified().build();
@@ -213,17 +212,17 @@ public class ConnectionService {
    * @throws ConnectionServiceException
    */
   @DELETE
-  @Path("/delete")
-  @Consumes({APPLICATION_JSON})
-  public Response deleteConnection(DatabaseConnection connection) throws ConnectionServiceException {
+  @Path( "/connection/delete" )
+  @Consumes( {APPLICATION_JSON} )
+  public Response deleteConnection( DatabaseConnection connection ) throws ConnectionServiceException {
     try {
-      boolean success = service.deleteConnection(connection);
-      if (success) {
+      boolean success = service.deleteConnection( connection );
+      if ( success ) {
         return Response.ok().build();
       } else {
         return Response.notModified().build();
       }
-    } catch (Throwable t) {
+    } catch ( Throwable t ) {
       t.printStackTrace();
       return Response.serverError().build();
     }
@@ -237,16 +236,16 @@ public class ConnectionService {
    * @throws ConnectionServiceException
    */
   @DELETE
-  @Path("/deletebyname")
-  public Response deleteConnectionByName(@QueryParam("name")String name) throws ConnectionServiceException {
+  @Path( "/connection/deletebyname" )
+  public Response deleteConnectionByName( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
     try {
-      boolean success = service.deleteConnection(name);
-      if (success) {
-      return Response.ok().build();
+      boolean success = service.deleteConnection( name );
+      if ( success ) {
+        return Response.ok().build();
       } else {
         return Response.notModified().build();
       }
-    } catch (Throwable t) {
+    } catch ( Throwable t ) {
       return Response.serverError().build();
     }
   }
@@ -259,46 +258,46 @@ public class ConnectionService {
    * @throws ConnectionServiceException
    */
   @PUT
-  @Path("/test")
-  @Consumes({APPLICATION_JSON})
-  @Produces({TEXT_PLAIN})
-  public Response testConnection(DatabaseConnection connection) throws ConnectionServiceException {
+  @Path( "/connection/test" )
+  @Consumes( {APPLICATION_JSON} )
+  @Produces( {TEXT_PLAIN} )
+  public Response testConnection( DatabaseConnection connection ) throws ConnectionServiceException {
     boolean success = false;
-    applySavedPassword(connection);
+    applySavedPassword( connection );
     success = service.testConnection( connection );
-    if (success) { 
-      return Response.ok(Messages.getString("ConnectionServiceImpl.INFO_0001_CONNECTION_SUCCEED"
-          , connection.getDatabaseName())).build();
+    if ( success ) { 
+      return Response.ok( Messages.getString( "ConnectionServiceImpl.INFO_0001_CONNECTION_SUCCEED"
+          , connection.getDatabaseName() ) ).build();
     } else {
-      return Response.serverError().entity(Messages.getErrorString("ConnectionServiceImpl.ERROR_0009_CONNECTION_FAILED"
-          , connection.getDatabaseName())).build();  
+      return Response.serverError().entity( Messages.getErrorString( "ConnectionServiceImpl.ERROR_0009_CONNECTION_FAILED"
+          , connection.getDatabaseName() ) ).build();  
     }
   }
     
   private static final DatabaseConnectionPoolParameter[] poolingParameters = new DatabaseConnectionPoolParameter[] {
-    new DatabaseConnectionPoolParameter("defaultAutoCommit", "true", "The default auto-commit state of connections created by this pool."), 
-    new DatabaseConnectionPoolParameter("defaultReadOnly", null, "The default read-only state of connections created by this pool.\nIf not set then the setReadOnly method will not be called.\n (Some drivers don't support read only mode, ex: Informix)"), 
-    new DatabaseConnectionPoolParameter("defaultTransactionIsolation", null, "the default TransactionIsolation state of connections created by this pool. One of the following: (see javadoc)\n\n  * NONE\n  * READ_COMMITTED\n  * READ_UNCOMMITTED\n  * REPEATABLE_READ  * SERIALIZABLE\n"), 
-    new DatabaseConnectionPoolParameter("defaultCatalog", null, "The default catalog of connections created by this pool."),
+    new DatabaseConnectionPoolParameter( "defaultAutoCommit", "true", "The default auto-commit state of connections created by this pool." ), 
+    new DatabaseConnectionPoolParameter( "defaultReadOnly", null, "The default read-only state of connections created by this pool.\nIf not set then the setReadOnly method will not be called.\n (Some drivers don't support read only mode, ex: Informix)" ), 
+    new DatabaseConnectionPoolParameter( "defaultTransactionIsolation", null, "the default TransactionIsolation state of connections created by this pool. One of the following: (see javadoc)\n\n  * NONE\n  * READ_COMMITTED\n  * READ_UNCOMMITTED\n  * REPEATABLE_READ  * SERIALIZABLE\n" ), 
+    new DatabaseConnectionPoolParameter( "defaultCatalog", null, "The default catalog of connections created by this pool." ),
     
-    new DatabaseConnectionPoolParameter("initialSize", "0", "The initial number of connections that are created when the pool is started."), 
-    new DatabaseConnectionPoolParameter("maxActive", "8", "The maximum number of active connections that can be allocated from this pool at the same time, or non-positive for no limit."), 
-    new DatabaseConnectionPoolParameter("maxIdle", "8", "The maximum number of connections that can remain idle in the pool, without extra ones being released, or negative for no limit."), 
-    new DatabaseConnectionPoolParameter("minIdle", "0", "The minimum number of connections that can remain idle in the pool, without extra ones being created, or zero to create none."), 
-    new DatabaseConnectionPoolParameter("maxWait", "-1", "The maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned before throwing an exception, or -1 to wait indefinitely."),
+    new DatabaseConnectionPoolParameter( "initialSize", "0", "The initial number of connections that are created when the pool is started." ), 
+    new DatabaseConnectionPoolParameter( "maxActive", "8", "The maximum number of active connections that can be allocated from this pool at the same time, or non-positive for no limit." ), 
+    new DatabaseConnectionPoolParameter( "maxIdle", "8", "The maximum number of connections that can remain idle in the pool, without extra ones being released, or negative for no limit." ), 
+    new DatabaseConnectionPoolParameter( "minIdle", "0", "The minimum number of connections that can remain idle in the pool, without extra ones being created, or zero to create none." ), 
+    new DatabaseConnectionPoolParameter( "maxWait", "-1", "The maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned before throwing an exception, or -1 to wait indefinitely." ),
     
-    new DatabaseConnectionPoolParameter("validationQuery", null, "The SQL query that will be used to validate connections from this pool before returning them to the caller.\nIf specified, this query MUST be an SQL SELECT statement that returns at least one row."), 
-    new DatabaseConnectionPoolParameter("testOnBorrow", "true", "The indication of whether objects will be validated before being borrowed from the pool.\nIf the object fails to validate, it will be dropped from the pool, and we will attempt to borrow another.\nNOTE - for a true value to have any effect, the validationQuery parameter must be set to a non-null string."), 
-    new DatabaseConnectionPoolParameter("testOnReturn", "false", "The indication of whether objects will be validated before being returned to the pool.\nNOTE - for a true value to have any effect, the validationQuery parameter must be set to a non-null string."), 
-    new DatabaseConnectionPoolParameter("testWhileIdle", "false", "The indication of whether objects will be validated by the idle object evictor (if any). If an object fails to validate, it will be dropped from the pool.\nNOTE - for a true value to have any effect, the validationQuery parameter must be set to a non-null string."), 
-    new DatabaseConnectionPoolParameter("timeBetweenEvictionRunsMillis", null, "The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run."),
+    new DatabaseConnectionPoolParameter( "validationQuery", null, "The SQL query that will be used to validate connections from this pool before returning them to the caller.\nIf specified, this query MUST be an SQL SELECT statement that returns at least one row." ), 
+    new DatabaseConnectionPoolParameter( "testOnBorrow", "true", "The indication of whether objects will be validated before being borrowed from the pool.\nIf the object fails to validate, it will be dropped from the pool, and we will attempt to borrow another.\nNOTE - for a true value to have any effect, the validationQuery parameter must be set to a non-null string." ), 
+    new DatabaseConnectionPoolParameter( "testOnReturn", "false", "The indication of whether objects will be validated before being returned to the pool.\nNOTE - for a true value to have any effect, the validationQuery parameter must be set to a non-null string." ), 
+    new DatabaseConnectionPoolParameter( "testWhileIdle", "false", "The indication of whether objects will be validated by the idle object evictor (if any). If an object fails to validate, it will be dropped from the pool.\nNOTE - for a true value to have any effect, the validationQuery parameter must be set to a non-null string." ), 
+    new DatabaseConnectionPoolParameter( "timeBetweenEvictionRunsMillis", null, "The number of milliseconds to sleep between runs of the idle object evictor thread. When non-positive, no idle object evictor thread will be run." ),
     
-    new DatabaseConnectionPoolParameter("poolPreparedStatements", "false", "Enable prepared statement pooling for this pool."), 
-    new DatabaseConnectionPoolParameter("maxOpenPreparedStatements", "-1", "The maximum number of open statements that can be allocated from the statement pool at the same time, or zero for no limit."), 
-    new DatabaseConnectionPoolParameter("accessToUnderlyingConnectionAllowed", "false", "Controls if the PoolGuard allows access to the underlying connection."), 
-    new DatabaseConnectionPoolParameter("removeAbandoned", "false", "Flag to remove abandoned connections if they exceed the removeAbandonedTimout.\nIf set to true a connection is considered abandoned and eligible for removal if it has been idle longer than the removeAbandonedTimeout. Setting this to true can recover db connections from poorly written applications which fail to close a connection."), 
-    new DatabaseConnectionPoolParameter("removeAbandonedTimeout", "300", "Timeout in seconds before an abandoned connection can be removed."), 
-    new DatabaseConnectionPoolParameter("logAbandoned", "false", "Flag to log stack traces for application code which abandoned a Statement or Connection.\nLogging of abandoned Statements and Connections adds overhead for every Connection open or new Statement because a stack trace has to be generated."), 
+    new DatabaseConnectionPoolParameter( "poolPreparedStatements", "false", "Enable prepared statement pooling for this pool." ), 
+    new DatabaseConnectionPoolParameter( "maxOpenPreparedStatements", "-1", "The maximum number of open statements that can be allocated from the statement pool at the same time, or zero for no limit." ), 
+    new DatabaseConnectionPoolParameter( "accessToUnderlyingConnectionAllowed", "false", "Controls if the PoolGuard allows access to the underlying connection." ), 
+    new DatabaseConnectionPoolParameter( "removeAbandoned", "false", "Flag to remove abandoned connections if they exceed the removeAbandonedTimout.\nIf set to true a connection is considered abandoned and eligible for removal if it has been idle longer than the removeAbandonedTimeout. Setting this to true can recover db connections from poorly written applications which fail to close a connection." ), 
+    new DatabaseConnectionPoolParameter( "removeAbandonedTimeout", "300", "Timeout in seconds before an abandoned connection can be removed." ), 
+    new DatabaseConnectionPoolParameter( "logAbandoned", "false", "Flag to log stack traces for application code which abandoned a Statement or Connection.\nLogging of abandoned Statements and Connections adds overhead for every Connection open or new Statement because a stack trace has to be generated." ), 
   };
 
   /**
@@ -307,15 +306,15 @@ public class ConnectionService {
    * @return IDatabaseConnectionPoolParameterList a list of the pooling parameters
    */
   @GET
-  @Path("/poolingParameters")
-  @Produces({APPLICATION_JSON})
+  @Path( "/connection/poolingParameters" )
+  @Produces( {APPLICATION_JSON} )
   public IDatabaseConnectionPoolParameterList getPoolingParameters() {
     IDatabaseConnectionPoolParameterList value = new DefaultDatabaseConnectionPoolParameterList();
     List<IDatabaseConnectionPoolParameter> paramList = new ArrayList<IDatabaseConnectionPoolParameter>();
-    for(DatabaseConnectionPoolParameter param : poolingParameters) {
-      paramList.add(param);
+    for( DatabaseConnectionPoolParameter param : poolingParameters ) {
+      paramList.add( param );
     }
-    value.setDatabaseConnectionPoolParameters(paramList);
+    value.setDatabaseConnectionPoolParameters( paramList );
     return value; 
   }
 
@@ -328,14 +327,14 @@ public class ConnectionService {
    * @return IDatabaseConnection for the given parameters
    */
   @GET
-  @Path("/createDatabaseConnection")
-  @Produces({APPLICATION_JSON})
-  public IDatabaseConnection createDatabaseConnection(@QueryParam("driver") String driver, @QueryParam("url") String url) {
-    for (IDatabaseDialect dialect : dialectService.getDatabaseDialects()) {
-      if (dialect.getNativeDriver() != null && 
-          dialect.getNativeDriver().equals(driver)) {
-        if (dialect.getNativeJdbcPre() != null && url.startsWith(dialect.getNativeJdbcPre())) {
-          return dialect.createNativeConnection(url);
+  @Path( "/connection/createDatabaseConnection" )
+  @Produces( {APPLICATION_JSON} )
+  public IDatabaseConnection createDatabaseConnection( @QueryParam( "driver" ) String driver, @QueryParam( "url" ) String url ) {
+    for ( IDatabaseDialect dialect : dialectService.getDatabaseDialects() ) {
+      if ( dialect.getNativeDriver() != null && 
+          dialect.getNativeDriver().equals( driver ) ) {
+        if ( dialect.getNativeJdbcPre() != null && url.startsWith( dialect.getNativeJdbcPre() ) ) {
+          return dialect.createNativeConnection( url );
         }
       }
     }
@@ -343,7 +342,7 @@ public class ConnectionService {
     // if no native driver was found, create a custom dialect object.
     
     IDatabaseConnection conn = genericDialect.createNativeConnection(url);
-    conn.getAttributes().put(GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS, driver);
+    conn.getAttributes().put( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS, driver );
     
     return conn;    
   }
@@ -356,15 +355,15 @@ public class ConnectionService {
    * @return array containing the database connection metadata
    */
   @POST
-  @Path("/checkParams")
-  @Consumes({APPLICATION_JSON})
-  @Produces({APPLICATION_JSON})
-  public StringArrayWrapper checkParameters(DatabaseConnection connection) {
+  @Path( "/connection/checkParams" )
+  @Consumes( {APPLICATION_JSON} )
+  @Produces( {APPLICATION_JSON} )
+  public StringArrayWrapper checkParameters( DatabaseConnection connection ) {
     StringArrayWrapper array = null;
-    String[] rawValues = DatabaseUtil.convertToDatabaseMeta(connection).checkParameters();
-    if (rawValues.length > 0) {
+    String[] rawValues = DatabaseUtil.convertToDatabaseMeta( connection ).checkParameters();
+    if ( rawValues.length > 0 ) {
       array = new StringArrayWrapper();
-      array.setArray(rawValues);
+      array.setArray( rawValues );
     }
     return array;
   }
@@ -374,21 +373,21 @@ public class ConnectionService {
    * @throws PentahoAccessControlException
    */
   private void validateAccess() throws PentahoAccessControlException {
-    IAuthorizationPolicy policy = PentahoSystem.get(IAuthorizationPolicy.class);
-    boolean isAdmin = policy.isAllowed(RepositoryReadAction.NAME)
-        && policy.isAllowed(RepositoryCreateAction.NAME)
-        && (policy.isAllowed(AdministerSecurityAction.NAME)
-        || policy.isAllowed(PublishAction.NAME));
-    if (!isAdmin) {
-      throw new PentahoAccessControlException("Access Denied");
+    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
+    boolean isAdmin = policy.isAllowed( RepositoryReadAction.NAME )
+        && policy.isAllowed( RepositoryCreateAction.NAME )
+        && (policy.isAllowed( AdministerSecurityAction.NAME )
+        || policy.isAllowed( PublishAction.NAME ) );
+    if ( !isAdmin ) {
+      throw new PentahoAccessControlException( "Access Denied" );
     }
   }
   
   /**
    * Hides password for connections for return to user.
    */
-  private void hidePassword(IDatabaseConnection conn) {
-    conn.setPassword(null);
+  private void hidePassword( IDatabaseConnection conn ) {
+    conn.setPassword( null );
   }
   
   /**
@@ -396,10 +395,10 @@ public class ConnectionService {
    * change password. Since we cleaned password during sending to UI, we need
    * to use stored password.
    */
-  private void applySavedPassword(IDatabaseConnection conn) throws ConnectionServiceException {
-    if (StringUtils.isBlank(conn.getPassword())) {
-      IDatabaseConnection savedConn = service.getConnectionById(conn.getId());
-      conn.setPassword(savedConn.getPassword());
+  private void applySavedPassword( IDatabaseConnection conn ) throws ConnectionServiceException {
+    if ( StringUtils.isBlank( conn.getPassword() ) ) {
+      IDatabaseConnection savedConn = service.getConnectionById( conn.getId() );
+      conn.setPassword( savedConn.getPassword() );
     }
   }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java
@@ -19,66 +19,57 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 
 import static javax.ws.rs.core.MediaType.WILDCARD;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Map;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 
-import org.apache.commons.io.IOUtils;
-import org.pentaho.agilebi.modeler.ModelerPerspective;
-import org.pentaho.agilebi.modeler.ModelerWorkspace;
-import org.pentaho.agilebi.modeler.gwt.GwtModelerWorkspaceHelper;
-import org.pentaho.agilebi.modeler.services.IModelerService;
-import org.pentaho.metadata.model.Domain;
-import org.pentaho.metadata.model.LogicalModel;
-import org.pentaho.metadata.repository.IMetadataDomainRepository;
-import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
-import org.pentaho.platform.dataaccess.datasource.api.DatasourceService;
-import org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.IDSWDatasourceService;
+import org.pentaho.platform.dataaccess.datasource.api.resources.AnalysisResource;
+import org.pentaho.platform.dataaccess.datasource.api.resources.DataSourceWizardResource;
+import org.pentaho.platform.dataaccess.datasource.api.resources.MetadataResource;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
-import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
-import org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter;
-import org.pentaho.platform.repository2.unified.fileio.RepositoryFileInputStream;
+import org.pentaho.platform.web.http.api.resources.JaxbList;
 
 
-@Path("/data-access/api/datasource")
-public class DatasourceResource {
+@Path( "/data-access/api" )
+public class DatasourceResource extends DataSourceWizardResource {
 
-  private static final String MONDRIAN_CATALOG_REF = "MondrianCatalogRef"; //$NON-NLS-1$
-  public static final String APPLICATION_ZIP = "application/zip"; //$NON-NLS-1$
-  
-  protected IMetadataDomainRepository metadataDomainRepository;
-  protected IMondrianCatalogService mondrianCatalogService;
-  IDSWDatasourceService dswService;
-  IModelerService modelerService;
-  public static final String METADATA_EXT = ".xmi"; //$NON-NLS-1$
-  
   public DatasourceResource() {
     super();
-    metadataDomainRepository = PentahoSystem.get(IMetadataDomainRepository.class, PentahoSessionHolder.getSession());
-    mondrianCatalogService = PentahoSystem.get(IMondrianCatalogService.class, PentahoSessionHolder.getSession());
-    dswService = new DSWDatasourceServiceImpl();
-    modelerService = new ModelerService();
   }
 
+  /**
+   * Get list of IDs of analysis datasource
+   *
+   * @return JaxbList<String> of analysis IDs
+   */
+  public JaxbList<String> getAnalysisDatasourceIds() {
+    return new AnalysisResource().getAnalysisDatasourceIds();
+  }
+  
+  /**
+   * Get the Metadata datasource IDs
+   *
+   * @return JaxbList<String> of metadata IDs
+   */
+  public JaxbList<String> getMetadataDatasourceIds() {
+    return new MetadataResource().getMetadataDatasourceIds();
+  }
+  
+  /**
+   * Returns a list of datasource IDs from datasource wizard
+   *
+   * @return JaxbList<String> list of datasource IDs
+   */
+  public JaxbList<String> getDSWDatasourceIds() {
+    return new DataSourceWizardResource().getDSWDatasourceIds();
+  }
+  
   /**
    * Download the metadata files for a given metadataId
    *
@@ -86,18 +77,8 @@ public class DatasourceResource {
    *
    * @return Response containing the file data
    */
-  @GET
-  @Path("/metadata/{metadataId : .+}/download")
-  @Produces(WILDCARD)
-  public Response doGetMetadataFilesAsDownload(@PathParam("metadataId") String metadataId) {
-    if(!DatasourceService.canAdminister()) {
-      return Response.status(UNAUTHORIZED).build();
-    }
-    if (! (metadataDomainRepository instanceof IPentahoMetadataDomainRepositoryExporter)) {
-      return Response.serverError().build();
-    }
-    Map<String, InputStream> fileData = ((IPentahoMetadataDomainRepositoryExporter)metadataDomainRepository).getDomainFilesData(metadataId);
-    return createAttachment(fileData, metadataId);
+  public Response doGetMetadataFilesAsDownload( @PathParam( "metadataId" ) String metadataId ) {
+    return new MetadataResource().doGetMetadataFilesAsDownload( metadataId );
   }
 
   /**
@@ -107,18 +88,8 @@ public class DatasourceResource {
    *
    * @return Response containing the file data
    */
-  @GET
-  @Path("/analysis/{analysisId : .+}/download")
-  @Produces(WILDCARD)
-  public Response doGetAnalysisFilesAsDownload(@PathParam("analysisId") String analysisId) {
-    if(!DatasourceService.canAdminister()) {
-      return Response.status(UNAUTHORIZED).build();
-    }
-    MondrianCatalogRepositoryHelper helper = new MondrianCatalogRepositoryHelper(PentahoSystem.get(IUnifiedRepository.class));
-    Map<String, InputStream> fileData = helper.getModrianSchemaFiles(analysisId);
-    parseMondrianSchemaName(analysisId, fileData);
-
-    return createAttachment(fileData, analysisId);
+  public Response doGetAnalysisFilesAsDownload( @PathParam( "analysisId" ) String analysisId ) {
+    return new AnalysisResource().doGetAnalysisFilesAsDownload( analysisId );
   }
 
   /**
@@ -128,43 +99,44 @@ public class DatasourceResource {
    *
    * @return Response containing the file data
    */
-  @GET
-  @Path("/dsw/{dswId : .+}/download")
-  @Produces(WILDCARD)
-  public Response doGetDSWFilesAsDownload(@PathParam("dswId") String dswId) {
-    if(!DatasourceService.canAdminister()) {
-      return Response.status(UNAUTHORIZED).build();
-    }
-    // First get the metadata files;
-    Map<String, InputStream> fileData = ((IPentahoMetadataDomainRepositoryExporter)metadataDomainRepository).getDomainFilesData(dswId); 
+  public Response doGetDSWFilesAsDownload( @PathParam( "dswId" ) String dswId ) {
+    return new DataSourceWizardResource().doGetDSWFilesAsDownload( dswId );
+  }
+
   
-    // Then get the corresponding mondrian files
-    Domain domain = metadataDomainRepository.getDomain(dswId);
-    ModelerWorkspace model = new ModelerWorkspace(new GwtModelerWorkspaceHelper());
-    model.setDomain(domain);
-    LogicalModel logicalModel = model.getLogicalModel(ModelerPerspective.ANALYSIS);
-    if (logicalModel == null) {
-      logicalModel = model.getLogicalModel(ModelerPerspective.REPORTING);
-    }
-    if (logicalModel.getProperty(MONDRIAN_CATALOG_REF) != null) {
-      MondrianCatalogRepositoryHelper helper = new MondrianCatalogRepositoryHelper(PentahoSystem.get(IUnifiedRepository.class));
-      String catalogRef = (String)logicalModel.getProperty(MONDRIAN_CATALOG_REF);
-      fileData.putAll(helper.getModrianSchemaFiles(catalogRef));
-      parseMondrianSchemaName( dswId, fileData );
-    }
-
-    return createAttachment(fileData, dswId);
+  /**
+   * Remove the metadata for a given metadata ID
+   *
+   * @param metadataId String ID of the metadata to remove
+   *
+   * @return Response ok if successful
+   */
+  public Response doRemoveMetadata( @PathParam( "metadataId" ) String metadataId ) {
+    return new MetadataResource().doRemoveMetadata( metadataId );
   }
-
-  private void parseMondrianSchemaName( String dswId, Map<String, InputStream> fileData ) {
-    final String keySchema = "schema.xml";//$NON-NLS-1$
-    if ( fileData.containsKey( keySchema ) ) {
-      final int xmiIndex = dswId.lastIndexOf( ".xmi" );//$NON-NLS-1$
-      fileData.put( ( xmiIndex > 0 ? dswId.substring( 0, xmiIndex ) : dswId ) + ".mondrian.xml", fileData.get( keySchema ) );//$NON-NLS-1$
-      fileData.remove( keySchema );
-    }
+  
+  /**
+   * Remove the analysis data for a given analysis ID
+   *
+   * @param analysisId String ID of the analysis data to remove
+   *
+   * @return Response ok if successful
+   */
+  public Response doRemoveAnalysis( @PathParam( "analysisId" ) String analysisId ) {
+    return new AnalysisResource().doRemoveAnalysis( analysisId );
   }
-
+  
+  /**
+   * Remove the datasource wizard data for a given datasource wizard ID
+   *
+   * @param dswId String ID of the datasource wizard data to remove
+   *
+   * @return Response ok if successful
+   */
+  public Response doRemoveDSW( @PathParam( "dswId" ) String dswId ) {
+    return new DataSourceWizardResource().doRemoveDSW( dswId );
+  }
+  
   /**
    * Get the data source wizard info (parameters) for a specific data source wizard id
    *
@@ -173,67 +145,13 @@ public class DatasourceResource {
    * @return Response containing the parameter list
    */
   @GET
-  @Path("/{dswId : .+}/getAnalysisDatasourceInfo")
+  @Path( "/datasource/{dswId : .+}/getAnalysisDatasourceInfo" )
   @Produces(WILDCARD)
-  public Response getAnalysisDatasourceInfo(@PathParam("dswId") String dswId) {
-	MondrianCatalog catalog = mondrianCatalogService.getCatalog(dswId, PentahoSessionHolder.getSession());
-	String parameters = catalog.getDataSourceInfo();
-	return Response.ok().entity(parameters).build();
+  public Response getAnalysisDatasourceInfo( @PathParam( "dswId" ) String dswId ) {
+    IMondrianCatalogService mondrianCatalogService = PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
+	  MondrianCatalog catalog = mondrianCatalogService.getCatalog( dswId, PentahoSessionHolder.getSession() );
+	  String parameters = catalog.getDataSourceInfo();
+	  return Response.ok().entity( parameters ).build();
   }  
 
-  private Response createAttachment(Map<String, InputStream> fileData, String domainId) {
-    String quotedFileName = null;
-    final InputStream is;
-    if (fileData.size() > 1) { // we've got more than one file so we want to zip them up and send them
-      File zipFile = null;
-      try {
-        zipFile = File.createTempFile("datasourceExport", ".zip"); //$NON-NLS-1$ //$NON-NLS-2$
-        zipFile.deleteOnExit();
-        ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile));
-        for (String fileName : fileData.keySet()) {
-          InputStream zipEntryIs = null;
-          try {
-            ZipEntry entry = new ZipEntry(fileName);
-            zos.putNextEntry(entry);
-            zipEntryIs = fileData.get(fileName);
-            IOUtils.copy(zipEntryIs, zos);
-          } catch (Exception e) {
-            continue;
-          } finally {
-            zos.closeEntry();
-            if (zipEntryIs != null) {
-              zipEntryIs.close();
-            }
-          }
-        }
-        zos.close();
-        is = new FileInputStream(zipFile);
-      } catch (IOException ioe) {
-        return Response.serverError().entity(ioe.toString()).build();
-      }
-      StreamingOutput streamingOutput = new StreamingOutput() {
-        public void write(OutputStream output) throws IOException {
-          IOUtils.copy(is, output);
-        }
-      };
-      final int xmiIndex = domainId.lastIndexOf( ".xmi" );//$NON-NLS-1$
-      quotedFileName = "\"" + ( xmiIndex > 0 ? domainId.substring( 0, xmiIndex ) : domainId ) + ".zip\""; //$NON-NLS-1$//$NON-NLS-2$
-      return Response.ok(streamingOutput, APPLICATION_ZIP).header("Content-Disposition", "attachment; filename=" + quotedFileName).build(); //$NON-NLS-1$ //$NON-NLS-2$
-    } else if (fileData.size() == 1) {  // we've got a single metadata file so we just return that.
-      String fileName = (String) fileData.keySet().toArray()[0];
-      quotedFileName = "\"" + fileName + "\""; //$NON-NLS-1$ //$NON-NLS-2$
-      is = fileData.get(fileName);
-      String mimeType = MediaType.TEXT_PLAIN;
-      if (is instanceof RepositoryFileInputStream) {
-        mimeType = ((RepositoryFileInputStream)is).getMimeType();
-      }
-      StreamingOutput streamingOutput = new StreamingOutput() {
-        public void write(OutputStream output) throws IOException {
-          IOUtils.copy(is, output);
-        }
-      };
-      return Response.ok(streamingOutput, mimeType).header("Content-Disposition", "attachment; filename=" + quotedFileName).build(); //$NON-NLS-1$ //$NON-NLS-2$
-    }
-    return Response.serverError().build();
-  }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MetadataDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MetadataDatasourceService.java
@@ -45,6 +45,7 @@ import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.dataaccess.datasource.api.DatasourceService;
 import org.pentaho.platform.dataaccess.datasource.api.MetadataService;
+import org.pentaho.platform.dataaccess.datasource.api.resources.MetadataResource;
 import org.pentaho.platform.dataaccess.datasource.wizard.csv.CsvUtils;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.messages.Messages;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
@@ -57,25 +58,25 @@ import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataBodyPart;
 import com.sun.jersey.multipart.FormDataParam;
 
-@Path("/data-access/api/metadata")
-public class MetadataDatasourceService {
+@Path( "/data-access/api" )
+public class MetadataDatasourceService extends MetadataResource {
 
 	private static final String LANG = "[a-z]{2}";
 	private static final String LANG_CC = LANG + "_[A-Z]{2}";
 	private static final String LANG_CC_EXT = LANG_CC + "_[^/]+";
-	private static final List<String> ENCODINGS = Arrays.asList("", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Shift_JIS", "ISO-2022-JP", "ISO-2022-CN", "ISO-2022-KR", "GB18030", "Big5", "EUC-JP", "EUC-KR", "ISO-8859-1", "ISO-8859-2", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "windows-1251", "windows-1256", "KOI8-R", "ISO-8859-9");
-	private static final Log logger = LogFactory.getLog(MetadataDatasourceService.class);
+	private static final List<String> ENCODINGS = Arrays.asList( "", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Shift_JIS", "ISO-2022-JP", "ISO-2022-CN", "ISO-2022-KR", "GB18030", "Big5", "EUC-JP", "EUC-KR", "ISO-8859-1", "ISO-8859-2", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "windows-1251", "windows-1256", "KOI8-R", "ISO-8859-9" );
+	private static final Log logger = LogFactory.getLog( MetadataDatasourceService.class );
 
   private static final String OVERWRITE_IN_REPOS = "overwrite";
   private static final String SUCCESS = "3";
 
 	private static final Pattern[] patterns = new Pattern[] {
-	    Pattern.compile("(" + LANG + ").properties$"),
-	    Pattern.compile("(" + LANG_CC + ").properties$"),
-	    Pattern.compile("(" + LANG_CC_EXT + ").properties$"),
-	    Pattern.compile("([^/]+)_(" + LANG + ")\\.properties$"),
-	    Pattern.compile("([^/]+)_(" + LANG_CC + ")\\.properties$"),
-	    Pattern.compile("([^/]+)_(" + LANG_CC_EXT + ")\\.properties$"),
+	    Pattern.compile( "(" + LANG + ").properties$" ),
+	    Pattern.compile( "(" + LANG_CC + ").properties$" ),
+	    Pattern.compile( "(" + LANG_CC_EXT + ").properties$" ),
+	    Pattern.compile( "([^/]+)_(" + LANG + ")\\.properties$" ),
+	    Pattern.compile( "([^/]+)_(" + LANG_CC + ")\\.properties$" ),
+	    Pattern.compile( "([^/]+)_(" + LANG_CC_EXT + ")\\.properties$" ),
 	};
 
 	
@@ -94,22 +95,22 @@ public class MetadataDatasourceService {
    * a http form which requires a post.
    */
   @POST
-  @Path("/postimport")
-  @Consumes(MediaType.MULTIPART_FORM_DATA)
-  @Produces("text/html")
-  public Response importMetadataDatasourceWithPost( @FormDataParam("domainId") String domainId,
-                                            @FormDataParam("metadataFile") InputStream metadataFile,
-                                            @FormDataParam("metadataFile") FormDataContentDisposition metadataFileInfo,
-                                            @FormDataParam(OVERWRITE_IN_REPOS) String overwrite,
-                                            @FormDataParam("localeFiles") List<FormDataBodyPart> localeFiles,
-                                            @FormDataParam("localeFiles") List<FormDataContentDisposition> localeFilesInfo)
+  @Path( "/metadata/postimport" )
+  @Consumes( MediaType.MULTIPART_FORM_DATA )
+  @Produces( "text/html" )
+  public Response importMetadataDatasourceWithPost( @FormDataParam( "domainId" ) String domainId,
+                                            @FormDataParam( "metadataFile" ) InputStream metadataFile,
+                                            @FormDataParam( "metadataFile" ) FormDataContentDisposition metadataFileInfo,
+                                            @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
+                                            @FormDataParam( "localeFiles" ) List<FormDataBodyPart> localeFiles,
+                                            @FormDataParam( "localeFiles" ) List<FormDataContentDisposition> localeFilesInfo )
       throws PentahoAccessControlException {
-    Response response = importMetadataDatasource(domainId, metadataFile, metadataFileInfo, overwrite, localeFiles,
-        localeFilesInfo);
+    Response response = importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles,
+        localeFilesInfo );
     ResponseBuilder responseBuilder;
     responseBuilder = Response.ok();
-    responseBuilder.entity(String.valueOf(response.getStatus()));
-    responseBuilder.status(200);
+    responseBuilder.entity( String.valueOf( response.getStatus() ) );
+    responseBuilder.status( 200 );
     return responseBuilder.build();
   }
 
@@ -126,24 +127,24 @@ public class MetadataDatasourceService {
    * @throws PentahoAccessControlException Thrown when validation of access fails
    */
   @PUT
-	@Path("/import")
-  @Consumes(MediaType.MULTIPART_FORM_DATA)
-  @Produces("text/plain")
-	public Response importMetadataDatasource( @FormDataParam("domainId") String domainId,
-                                            @FormDataParam("metadataFile") InputStream metadataFile,
-                                            @FormDataParam("metadataFile") FormDataContentDisposition metadataFileInfo,
-                                            @FormDataParam(OVERWRITE_IN_REPOS) String overwrite,
-                                            @FormDataParam("localeFiles") List<FormDataBodyPart> localeFiles,
-                                            @FormDataParam("localeFiles") List<FormDataContentDisposition> localeFilesInfo)
+	@Path( "/metadata/import" )
+  @Consumes( MediaType.MULTIPART_FORM_DATA )
+  @Produces( "text/plain" )
+	public Response importMetadataDatasource( @FormDataParam( "domainId" ) String domainId,
+                                            @FormDataParam( "metadataFile" ) InputStream metadataFile,
+                                            @FormDataParam( "metadataFile" ) FormDataContentDisposition metadataFileInfo,
+                                            @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
+                                            @FormDataParam( "localeFiles" ) List<FormDataBodyPart> localeFiles,
+                                            @FormDataParam( "localeFiles" ) List<FormDataContentDisposition> localeFilesInfo )
       throws PentahoAccessControlException {
     MetadataService service = new MetadataService();
     try {
       service.importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo );
       return Response.ok().status( new Integer( SUCCESS ) ).type( MediaType.TEXT_PLAIN ).build();
-    } catch (PentahoAccessControlException e) {
+    } catch ( PentahoAccessControlException e ) {
       return Response.serverError().entity( e.toString() ).build();
     } catch (PlatformImportException e) {
-      if ( e.getErrorStatus() == PlatformImportException.PUBLISH_PROHIBITED_SYMBOLS_ERROR) {
+      if ( e.getErrorStatus() == PlatformImportException.PUBLISH_PROHIBITED_SYMBOLS_ERROR ) {
         FileResource fr = new FileResource();
         return Response.status( PlatformImportException.PUBLISH_PROHIBITED_SYMBOLS_ERROR ).entity(
             Messages.getString( "MetadataDatasourceService.ERROR_003_PROHIBITED_SYMBOLS_ERROR", domainId, (String) fr
@@ -177,64 +178,64 @@ public class MetadataDatasourceService {
    * @throws PentahoAccessControlException Thrown when validation of access fails
    */
   @PUT
-  @Path("/uploadServletImport")
-  @Consumes({ TEXT_PLAIN })
-  @Produces("text/plain")
+  @Path( "/metadata/uploadServletImport" )
+  @Consumes( { TEXT_PLAIN } )
+  @Produces( "text/plain" )
   @Deprecated
-  public Response uploadServletImportMetadataDatasource(String localizeBundleEntries, @QueryParam("domainId") String domainId, @QueryParam("metadataFile") String metadataFile) throws PentahoAccessControlException {
+  public Response uploadServletImportMetadataDatasource( String localizeBundleEntries, @QueryParam("domainId") String domainId, @QueryParam( "metadataFile" ) String metadataFile ) throws PentahoAccessControlException {
     try {
       DatasourceService.validateAccess();
-    } catch (PentahoAccessControlException e) {
-      return Response.serverError().entity(e.toString()).build();
+    } catch ( PentahoAccessControlException e ) {
+      return Response.serverError().entity( e.toString() ).build();
     }
 
-    IMetadataDomainRepository metadataDomainRepository = PentahoSystem.get(IMetadataDomainRepository.class, PentahoSessionHolder.getSession());
-    PentahoMetadataDomainRepository metadataImporter = new PentahoMetadataDomainRepository(PentahoSystem.get(IUnifiedRepository.class));
+    IMetadataDomainRepository metadataDomainRepository = PentahoSystem.get( IMetadataDomainRepository.class, PentahoSessionHolder.getSession() );
+    PentahoMetadataDomainRepository metadataImporter = new PentahoMetadataDomainRepository( PentahoSystem.get( IUnifiedRepository.class ) );
     CsvUtils csvUtils = new CsvUtils();
     boolean validPropertyFiles = true;
     StringBuffer invalidFiles = new StringBuffer();
     try {
       String TMP_FILE_PATH = File.separatorChar + "system" + File.separatorChar + "tmp" + File.separatorChar;
-      String sysTmpDir = PentahoSystem.getApplicationContext().getSolutionPath(TMP_FILE_PATH);
-      FileInputStream metadataInputStream = new FileInputStream(sysTmpDir + File.separatorChar + metadataFile);
-      metadataImporter.storeDomain(metadataInputStream, domainId, true);
-      metadataDomainRepository.getDomain(domainId);
+      String sysTmpDir = PentahoSystem.getApplicationContext().getSolutionPath( TMP_FILE_PATH );
+      FileInputStream metadataInputStream = new FileInputStream( sysTmpDir + File.separatorChar + metadataFile );
+      metadataImporter.storeDomain( metadataInputStream, domainId, true );
+      metadataDomainRepository.getDomain( domainId );
 
-      StringTokenizer bundleEntriesParam = new StringTokenizer(localizeBundleEntries, ";");
-      while (bundleEntriesParam.hasMoreTokens()) {
+      StringTokenizer bundleEntriesParam = new StringTokenizer( localizeBundleEntries, ";" );
+      while ( bundleEntriesParam.hasMoreTokens() ) {
         String localizationBundleElement = bundleEntriesParam.nextToken();
-        StringTokenizer localizationBundle = new StringTokenizer(localizationBundleElement, "=");
+        StringTokenizer localizationBundle = new StringTokenizer( localizationBundleElement, "=" );
         String localizationFileName = localizationBundle.nextToken();
         String localizationFile = localizationBundle.nextToken();
 
-        if (localizationFileName.endsWith(".properties")) {
-          String encoding = csvUtils.getEncoding(localizationFile);
-          if(ENCODINGS.contains(encoding)) {
-            for (final Pattern propertyBundlePattern : patterns) {
-              final Matcher propertyBundleMatcher = propertyBundlePattern.matcher(localizationFileName);
-              if (propertyBundleMatcher.matches()) {
-                FileInputStream bundleFileInputStream = new FileInputStream(sysTmpDir + File.separatorChar + localizationFile);
-                metadataImporter.addLocalizationFile(domainId, propertyBundleMatcher.group(2), bundleFileInputStream, true);
+        if ( localizationFileName.endsWith( ".properties" ) ) {
+          String encoding = csvUtils.getEncoding( localizationFile );
+          if( ENCODINGS.contains( encoding ) ) {
+            for ( final Pattern propertyBundlePattern : patterns ) {
+              final Matcher propertyBundleMatcher = propertyBundlePattern.matcher( localizationFileName );
+              if ( propertyBundleMatcher.matches() ) {
+                FileInputStream bundleFileInputStream = new FileInputStream( sysTmpDir + File.separatorChar + localizationFile );
+                metadataImporter.addLocalizationFile( domainId, propertyBundleMatcher.group( 2 ), bundleFileInputStream, true );
                 break;
               }
             }
           } else {
             validPropertyFiles =  false;
-            invalidFiles.append(localizationFileName);
+            invalidFiles.append( localizationFileName );
           }
         } else {
           validPropertyFiles =  false;
-          invalidFiles.append(localizationFileName);
+          invalidFiles.append( localizationFileName );
         }
       }
 
-      if(!validPropertyFiles) {
-        return Response.serverError().entity(Messages.getString("MetadataDatasourceService.ERROR_002_PROPERTY_FILES_ERROR") + invalidFiles.toString()).build();
+      if( !validPropertyFiles ) {
+        return Response.serverError().entity( Messages.getString( "MetadataDatasourceService.ERROR_002_PROPERTY_FILES_ERROR" ) + invalidFiles.toString() ).build();
       }
-      return Response.ok("SUCCESS").type(MediaType.TEXT_PLAIN).build();
-    } catch (Exception e) {
-      metadataImporter.removeDomain(domainId);
-      return Response.serverError().entity(Messages.getString("MetadataDatasourceService.ERROR_001_METADATA_DATASOURCE_ERROR")).build();
+      return Response.ok( "SUCCESS" ).type( MediaType.TEXT_PLAIN ).build();
+    } catch ( Exception e ) {
+      metadataImporter.removeDomain( domainId );
+      return Response.serverError().entity( Messages.getString( "MetadataDatasourceService.ERROR_001_METADATA_DATASOURCE_ERROR" ) ).build();
     }
   }
 
@@ -247,19 +248,19 @@ public class MetadataDatasourceService {
    * @throws PentahoAccessControlException Thrown when validation of access fails
    */
   @PUT
-	@Path("/storeDomain")
-	@Consumes({ MediaType.APPLICATION_OCTET_STREAM, TEXT_PLAIN })
-	@Produces("text/plain")
-	public Response storeDomain(InputStream metadataFile, @QueryParam("domainId") String domainId) throws PentahoAccessControlException {
+	@Path( "/metadata/storeDomain" )
+	@Consumes( { MediaType.APPLICATION_OCTET_STREAM, TEXT_PLAIN } )
+	@Produces( "text/plain" )
+	public Response storeDomain( InputStream metadataFile, @QueryParam( "domainId" ) String domainId ) throws PentahoAccessControlException {
 		try {
 		  DatasourceService.validateAccess();
-			PentahoMetadataDomainRepository metadataImporter = new PentahoMetadataDomainRepository(PentahoSystem.get(IUnifiedRepository.class));
-			metadataImporter.storeDomain(metadataFile, domainId, true);
-			return Response.ok("SUCCESS").type(MediaType.TEXT_PLAIN).build();
-		} catch (PentahoAccessControlException e) {
-			return Response.serverError().entity(e.toString()).build();
-		} catch(Exception e) {
-			return Response.serverError().entity(Messages.getString("MetadataDatasourceService.ERROR_001_METADATA_DATASOURCE_ERROR")).build();
+			PentahoMetadataDomainRepository metadataImporter = new PentahoMetadataDomainRepository( PentahoSystem.get( IUnifiedRepository.class ) );
+			metadataImporter.storeDomain( metadataFile, domainId, true );
+			return Response.ok( "SUCCESS" ).type( MediaType.TEXT_PLAIN ).build();
+		} catch ( PentahoAccessControlException e ) {
+			return Response.serverError().entity( e.toString() ).build();
+		} catch( Exception e ) {
+			return Response.serverError().entity( Messages.getString( "MetadataDatasourceService.ERROR_001_METADATA_DATASOURCE_ERROR") ).build();
 		}
 	}
 
@@ -273,19 +274,19 @@ public class MetadataDatasourceService {
    * @throws PentahoAccessControlException Thrown when validation of access fails
    */
 	@PUT
-	@Path("/addLocalizationFile")
-	@Consumes({ MediaType.APPLICATION_OCTET_STREAM, TEXT_PLAIN })
-	@Produces("text/plain")
-	public Response addLocalizationFile(@QueryParam("domainId") String domainId, @QueryParam("locale") String locale, InputStream propertiesFile) throws PentahoAccessControlException {
+	@Path( "/metadata/addLocalizationFile" )
+	@Consumes( { MediaType.APPLICATION_OCTET_STREAM, TEXT_PLAIN } )
+	@Produces( "text/plain" )
+	public Response addLocalizationFile( @QueryParam( "domainId" ) String domainId, @QueryParam( "locale" ) String locale, InputStream propertiesFile ) throws PentahoAccessControlException {
 		try {
 			DatasourceService.validateAccess();
-			PentahoMetadataDomainRepository metadataImporter = new PentahoMetadataDomainRepository(PentahoSystem.get(IUnifiedRepository.class));
-			metadataImporter.addLocalizationFile(domainId, locale, propertiesFile, true);
-			return Response.ok("SUCCESS").type(MediaType.TEXT_PLAIN).build();
-		} catch (PentahoAccessControlException e) {
-			return Response.serverError().entity(e.toString()).build();
-		} catch(Exception e) {
-			return Response.serverError().entity(Messages.getString("MetadataDatasourceService.ERROR_001_METADATA_DATASOURCE_ERROR")).build();
+			PentahoMetadataDomainRepository metadataImporter = new PentahoMetadataDomainRepository( PentahoSystem.get( IUnifiedRepository.class ) );
+			metadataImporter.addLocalizationFile( domainId, locale, propertiesFile, true );
+			return Response.ok("SUCCESS").type( MediaType.TEXT_PLAIN ).build();
+		} catch ( PentahoAccessControlException e ) {
+			return Response.serverError().entity( e.toString() ).build();
+		} catch( Exception e ) {
+			return Response.serverError().entity( Messages.getString( "MetadataDatasourceService.ERROR_001_METADATA_DATASOURCE_ERROR" ) ).build();
 		}
 	}
 }


### PR DESCRIPTION
-backed out changes to plugin.spring.xml
-workaround for not having spring beans for new resources
-cleanup and code formatting update for any touched files
-fixed unused import issues
-restored existing data-access REST class methods from an API and removed their annotations if the @Path is now managed by a new Resource
-standardized the REST @Path across all datasource types (eg /data-access/api/datasource/analysis)
