### PR TITLE
Revert "[BACKLOG-26] Temporary disable create datasource for home screen...

### DIFF
--- a/package-res/plugin.xml
+++ b/package-res/plugin.xml
@@ -10,10 +10,9 @@
    </static-paths>
    
    <overlays>
-        <!-- Temporary disabled. See PJ comment in BACKLOG-26.
-         overlay id="launch" resourcebundle="api/repos/data-access/resources/messages/messages" priority="10010">
+        <overlay id="launch" resourcebundle="api/repos/data-access/resources/messages/messages" priority="10010">
             <button id="datasource" label="${newDatasourceEllipsis}" command="window.top.pho.openDatasourceEditor(window.top.datasourceEditorCallback)"/>
-        </overlay-->
+        </overlay>
 	    <overlay id="dataaccess"  resourcebundle="api/repos/data-access/resources/messages/messages" loadatstart="false">
 			<menubar id="filemenu">
 			    <menuitem id="manageDatasourceItem" insertafter="openMenuItem" label="${manageDatasourceEllipsis}" js-command="window.top.pho.showDatasourceManageDialog(window.top.datasourceEditorCallback)" />


### PR DESCRIPTION
.... There is old bug with scrolling. See http://jira.pentaho.com/browse/BACKLOG-26?focusedCommentId=193810&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-193810 for details"

This reverts commit 6036dbd08e33beb6c953e74589ec43373261819d.
