### PR TITLE
[BACKLOG-407] - Made changes so that connections don't assume that a pas...

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java
@@ -868,7 +868,10 @@ public class DatasourceResource extends DataSourceWizardResource {
       } else {
         savedConn = connectionService.getConnectionByName( conn.getName() );
       }
-      conn.setPassword( savedConn.getPassword() );
+      if ( savedConn != null ) { // The connection might not be in the database because this may be a new
+                                 // hive connection that doesn't require a password
+        conn.setPassword( savedConn.getPassword() );
+      }
     }
   }
 }


### PR DESCRIPTION
...sword is required (as in the case of hive)
