### PR TITLE
[BACKLOG-779] PUC Data Source Wizard title is incorrect.

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/main_wizard_panel.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/main_wizard_panel.properties
@@ -1,4 +1,4 @@
-WIZARD_TITLE=Manage Data Sources
+WIZARD_TITLE=Data Source Wizard
 CURRENT_STEP=Current Step
 PREVIEW=Preview
 BACK=&lt; Back


### PR DESCRIPTION
Reverting [BISERVER-11833] Change dialog title as it was applied to the incorrect place
