### PR TITLE
[TEST] Adding LegacyDatasourceConvertion.canConvert tests

### DIFF
--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/utils/LegacyDatasourceConverterTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/utils/LegacyDatasourceConverterTest.java
@@ -17,17 +17,21 @@
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl.utils;
 
-import com.thoughtworks.xstream.XStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+
+import junit.framework.Assert;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.MultiTableDatasourceDTO;
+import org.pentaho.platform.dataaccess.datasource.wizard.sources.csv.CsvDatasource;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.StringWriter;
+import com.thoughtworks.xstream.XStream;
 
 public class LegacyDatasourceConverterTest {
 
@@ -62,7 +66,16 @@ public class LegacyDatasourceConverterTest {
 
   @Test
   public void testCanConvert() throws Exception {
-
+    LegacyDatasourceConverter converter = new LegacyDatasourceConverter();
+    MultiTableDatasourceDTO msDS = new MultiTableDatasourceDTO(){
+      @Override
+      public boolean isDoOlap() {
+        return false;
+      }
+    };
+    Assert.assertTrue( converter.canConvert( MultiTableDatasourceDTO.class ) );
+    Assert.assertFalse( converter.canConvert( msDS.getClass() ) );
+    Assert.assertFalse( converter.canConvert( CsvDatasource.class ) );
   }
 
   @Test


### PR DESCRIPTION
What was done:
1) implemented test stub
2) changed tear down logic so that tests could be run under
windows using ant. Without the changes they fail because HSQLDB has a lock file