### PR TITLE
BISERVER-10272 - Data Source Wizard - unable to fix field settings after error is found, buttons don't work.

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/EmbeddedWizard.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/EmbeddedWizard.java
@@ -163,7 +163,6 @@ public class EmbeddedWizard extends AbstractXulDialogController<Domain> implemen
 
   @Override
   public void onFinish( final IDatasourceSummary summary ) {
-    wizardController.resetSelectedDatasource();
     this.summary = summary;
     if ( wizardModel.isEditing() && summary.getErrorCount() == 0 ) {
       // biserver-6210 - manage modeler dialog listener separate from the wizard's listener
@@ -175,6 +174,7 @@ public class EmbeddedWizard extends AbstractXulDialogController<Domain> implemen
       new XulServiceCallback<IDatasourceSummary>() {
         @Override
         public void error( String s, Throwable throwable ) {
+          wizardController.resetSelectedDatasource();
           MessageHandler.getInstance().closeWaitingDialog();
           MessageHandler.getInstance().showErrorDialog( s, throwable.getMessage() );
         }
@@ -183,12 +183,14 @@ public class EmbeddedWizard extends AbstractXulDialogController<Domain> implemen
         public void success( IDatasourceSummary iDatasourceSummary ) {
           if ( !showModelerDecision ) {
             handleModelerDialog();
+            wizardController.resetSelectedDatasource();
             return;
           } else {
             if ( iDatasourceSummary.isShowModeler() ) {
               showModelEditor();
             } else {
               onDialogAccept();
+              wizardController.resetSelectedDatasource();
             }
           }
           MessageHandler.getInstance().closeWaitingDialog();
@@ -472,10 +474,13 @@ public class EmbeddedWizard extends AbstractXulDialogController<Domain> implemen
     // open up the modeler
     final DialogListener<Domain> listener = new DialogListener<Domain>() {
       public void onDialogCancel() {
+        EmbeddedWizard.this.onDialogAccept();
+        wizardController.resetSelectedDatasource();
       }
 
       public void onDialogAccept( final Domain domain ) {
         EmbeddedWizard.this.onDialogAccept();
+        wizardController.resetSelectedDatasource();
       }
 
       public void onDialogReady() {
@@ -483,8 +488,7 @@ public class EmbeddedWizard extends AbstractXulDialogController<Domain> implemen
 
       @Override
       public void onDialogError( String errorMessage ) {
-        // TODO Auto-generated method stub
-
+        wizardController.resetSelectedDatasource();
       }
     };
     final Domain domain = summary.getDomain();


### PR DESCRIPTION
Problem with disabling finish button was fixed in https://github.com/pentaho/data-access/commit/bb657696b5ca10801cd18892d8acfb15e959a5eb#diff-fbcb56c0ec45668fdd393afbcb17b551

But I was reproducing this issue by steps in description JIRA case, I found 2 problems and fixed it:
1. After clicked Finish button "Overwrite datasource" dialog was showed up and was staying infinitely until I refreshed the page. After that datasource was not saved.
2. If I closed "Customize model now" in "Data Source Created" dialog, dialog "Data Source Model Editor" was showed up. I closed it but in main dialog "Manage Data Sources" my created datasource was not appeared.

@rmansoor verify please
