### PR TITLE
[BACKLOG-872] Restructure Data Access to allow for deterministic build

### DIFF
--- a/build-test/README.md
+++ b/build-test/README.md
@@ -1,0 +1,39 @@
+This folder contains scripts for doing automated data-access build validation testing.
+
+The primary script, build.sh will compile data-access 1000 times (configurable in build.sh) and perform the gwt-validation check.
+
+Build status, PASS or FAIL are logged for each iteration along with the current overall build success rate.
+
+The output from each iteration is stored in the output subdirectory and in a file corresponding to the iteration.
+
+For example, build-test/output/1.txt
+This is the output for the first iteration.  If you see any failures, this will make it much easier to check the logs to determine
+what caused the failure.
+
+There is another build script, rebuild.sh which is a convenience build script that will rebuild metadata and the modeler projects and
+publish them locally so that data-access can build against the latest changes.  During development, this was a huge pain point since
+publish-local was not working correctly unless we manually cleaned out portions of the ivy cache.
+
+
+
+Example execution:
+
+```
+mdamour@mike6540:build-test$ ./build.sh
+Resolving data-access...
+Iteration 1: PASS    SUCCESS RATE: 100.000%
+Iteration 2: PASS    SUCCESS RATE: 100.000%
+Iteration 3: PASS    SUCCESS RATE: 100.000%
+Iteration 4: PASS    SUCCESS RATE: 100.000%
+Iteration 5: PASS    SUCCESS RATE: 100.000%
+Iteration 6: PASS    SUCCESS RATE: 100.000%
+Iteration 7: PASS    SUCCESS RATE: 100.000%
+Iteration 8: PASS    SUCCESS RATE: 100.000%
+Iteration 9: PASS    SUCCESS RATE: 100.000%
+Iteration 10: PASS    SUCCESS RATE: 100.000%
+```
+
+If you want to test a build that has failed, you will have to first turn on the HALT_ON_ERROR flag in the build.sh.  Upon failure,
+script execution will stop.  At this point there is no "dist" from the build, so you'll have to call ant dist at the root of the
+data-access project.  Replace the data-access plugin in pentaho-solutions/system with the dist zip.
+

--- a/build-test/build.sh
+++ b/build-test/build.sh
@@ -26,3 +26,4 @@ do
   fi
   echo " SUCCESS RATE: $SUCCESS_RATE%"
 done
+

--- a/build-test/rebuild.sh
+++ b/build-test/rebuild.sh
@@ -3,9 +3,8 @@
 rm -Rf ~/.ivy2/local/
 rm -Rf ~/.ivy2/cache/pentaho/pentaho-modeler
 rm -Rf ~/.ivy2/cache/pentaho/pentaho-metadata
-cd ../../pentaho-metadata-cleanup
+cd ../../pentaho-metadata
 ant clean-all resolve jar publish-local
-cd ../modeler-cleanup
+cd ../modeler
 ant clean-all resolve jar publish-local
-cd ../data-access-cleanup
 

--- a/package-res/plugin.spring.xml
+++ b/package-res/plugin.spring.xml
@@ -206,10 +206,6 @@
        <value>[Lorg.pentaho.metadata.model.SqlPhysicalTable;</value>
        <value>org.pentaho.metadata.model.concept.Concept</value>
        <value>[Lorg.pentaho.metadata.model.concept.Concept;</value>
-       <value>org.pentaho.metadata.model.concept.Property</value>
-<!--
-       <value>[Lorg.pentaho.metadata.model.concept.Property;</value>
--->
        <value>[Lorg.pentaho.metadata.model.concept.IConcept;</value>
        <value>org.pentaho.metadata.model.concept.security.RowLevelSecurity</value>
        <value>org.pentaho.metadata.model.concept.security.RowLevelSecurity$Type</value>
@@ -299,3 +295,4 @@
   </bean>
   
 </beans>
+

--- a/src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardService.java
@@ -35,7 +35,6 @@ import org.pentaho.agilebi.modeler.services.IModelerService;
 import org.pentaho.agilebi.modeler.util.ModelerWorkspaceHelper;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.util.MondrianModelExporter;
 import org.pentaho.metadata.util.XmiParser;
 import org.pentaho.platform.api.engine.IPentahoSession;
@@ -104,11 +103,7 @@ public class DataSourceWizardService extends DatasourceService {
     }
     if ( logicalModel.getProperty( MONDRIAN_CATALOG_REF ) != null ) {
       MondrianCatalogRepositoryHelper helper = createMondrianCatalogRepositoryHelper();
-      Property catalogProperty = logicalModel.getProperty( MONDRIAN_CATALOG_REF );
-      String catalogRef = "";
-      if( catalogProperty != null ) {
-        catalogRef = (String) catalogProperty.getValue();  
-      }
+      String catalogRef = (String) logicalModel.getProperty( MONDRIAN_CATALOG_REF );
       fileData.putAll( helper.getModrianSchemaFiles( catalogRef ) );
       parseMondrianSchemaNameWrapper( dswId, fileData );
     }
@@ -129,11 +124,7 @@ public class DataSourceWizardService extends DatasourceService {
       logicalModel = model.getLogicalModel( ModelerPerspective.REPORTING );
     }
     if ( logicalModel.getProperty( MONDRIAN_CATALOG_REF ) != null ) {
-      Property catalogProperty = logicalModel.getProperty( MONDRIAN_CATALOG_REF );
-      String catalogRef = "";
-      if ( catalogProperty != null ) {
-        catalogRef = (String) logicalModel.getProperty( MONDRIAN_CATALOG_REF ).getValue();  
-      }
+      String catalogRef = (String) logicalModel.getProperty( MONDRIAN_CATALOG_REF );
       try {
         mondrianCatalogService.removeCatalog( catalogRef, getSession() );
       } catch ( MondrianCatalogServiceException e ) {
@@ -157,7 +148,7 @@ public class DataSourceWizardService extends DatasourceService {
         List<LogicalModel> logicalModelList = domain.getLogicalModels();
         if ( logicalModelList != null && logicalModelList.size() >= 1 ) {
           for ( LogicalModel logicalModel : logicalModelList ) {
-            Property property = logicalModel.getProperty( "AGILE_BI_GENERATED_SCHEMA" ); //$NON-NLS-1$
+            Object property = logicalModel.getProperty( "AGILE_BI_GENERATED_SCHEMA" ); //$NON-NLS-1$
             if ( property != null ) {
               datasourceList.add( summary.getDomainId() );
               continue nextModel;
@@ -292,7 +283,7 @@ public class DataSourceWizardService extends DatasourceService {
       throw new IllegalArgumentException( "No analysis model in xmi." );
     }
     // reference schema in xmi
-    olapModel.setProperty( MONDRIAN_CATALOG_REF, new Property<String>( analysisDomainId ) );
+    olapModel.setProperty( MONDRIAN_CATALOG_REF, analysisDomainId );
     // generate schema
     MondrianModelExporter exporter = new MondrianModelExporter( olapModel, locale );
     String mondrianSchema = null;

--- a/src/org/pentaho/platform/dataaccess/datasource/api/DatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/DatasourceService.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
@@ -87,7 +86,7 @@ public class DatasourceService {
     if ( logicalModelList != null && logicalModelList.size() >= 1 ) {
       for ( LogicalModel logicalModel : logicalModelList ) {
         // keep this check for backwards compatibility for now
-        Property property = logicalModel.getProperty( "AGILE_BI_GENERATED_SCHEMA" ); //$NON-NLS-1$
+        Object property = logicalModel.getProperty( "AGILE_BI_GENERATED_SCHEMA" ); //$NON-NLS-1$
         if ( property != null ) {
           return false;
         }

--- a/src/org/pentaho/platform/dataaccess/datasource/modeler/ModelerDialog.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/modeler/ModelerDialog.java
@@ -142,7 +142,7 @@ public class ModelerDialog extends AbstractXulDialogController<Domain> implement
     }
     if ( lModel.getProperty( "MondrianCatalogRef" ) == null
       && ( lModel.getProperty( "DUAL_MODELING_SCHEMA" ) == null || "false"
-        .equals( (String) lModel.getProperty( "DUAL_MODELING_SCHEMA" ).getValue() ) ) ) {
+        .equals( lModel.getProperty( "DUAL_MODELING_SCHEMA" ) ) ) ) {
       doOlap = false;
     }
     service.serializeModels( model.getDomain(), model.getModelName(), doOlap, new XulServiceCallback<String>() {

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/EmbeddedWizard.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/EmbeddedWizard.java
@@ -22,7 +22,6 @@ import org.pentaho.agilebi.modeler.gwt.GwtModelerMessages;
 import org.pentaho.gwt.widgets.client.utils.i18n.IResourceBundleLoadCallback;
 import org.pentaho.gwt.widgets.client.utils.i18n.ResourceBundle;
 import org.pentaho.metadata.model.Domain;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.platform.dataaccess.datasource.modeler.ModelerDialog;
 import org.pentaho.platform.dataaccess.datasource.wizard.controllers.ConnectionController;
 import org.pentaho.platform.dataaccess.datasource.wizard.controllers.FileImportController;
@@ -266,11 +265,7 @@ public class EmbeddedWizard extends AbstractXulDialogController<Domain> implemen
     // biserver-6210
     this.modelerDialogListener = listener;
 
-    Property property = domain.getLogicalModels().get( 0 ).getProperty( "DatasourceType" );
-    String datasourceType = null;
-    if ( property != null ) {
-      datasourceType = (String) property.getValue();
-    } 
+    String datasourceType = (String) domain.getLogicalModels().get( 0 ).getProperty( "DatasourceType" );
 
     // previous versions of Data-access would leave this property blank for Query datasources.
     if ( datasourceType == null ) {

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/controllers/MainWizardController.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/controllers/MainWizardController.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.pentaho.gwt.widgets.client.utils.NameUtils;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.platform.dataaccess.datasource.IDatasourceInfo;
 import org.pentaho.platform.dataaccess.datasource.ui.service.UIDatasourceServiceManager;
 import org.pentaho.platform.dataaccess.datasource.utils.ExceptionParser;
@@ -424,7 +423,7 @@ public class MainWizardController extends AbstractXulEventHandler implements IWi
       public void success( IDatasourceSummary iDatasourceSummary ) {
 
         iDatasourceSummary.getDomain().getLogicalModels().get( 0 )
-          .setProperty( "DatasourceType", new Property<String>( activeDatasource.getId() ) );
+          .setProperty( "DatasourceType", activeDatasource.getId() );
         for ( IWizardListener wizardListener : wizardListeners ) {
           wizardListener.onFinish( iDatasourceSummary );
         }

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImpl.java
@@ -28,7 +28,6 @@ import org.pentaho.agilebi.modeler.ModelerWorkspace;
 import org.pentaho.agilebi.modeler.gwt.GwtModelerWorkspaceHelper;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.dataaccess.datasource.beans.BogoPojo;
 import org.pentaho.platform.dataaccess.datasource.wizard.csv.CsvUtils;
@@ -170,8 +169,8 @@ public class CsvDatasourceServiceImpl extends PentahoBase implements ICsvDatasou
 
         XStream xstream = new XStream();
         String serializedDto = xstream.toXML( datasourceDto );
-        workspaceDomain.getLogicalModels().get( 0 ).setProperty( "datasourceModel", new Property<String>( serializedDto ) );
-        workspaceDomain.getLogicalModels().get( 0 ).setProperty( "DatasourceType", new Property<String>( "CSV" ) );
+        workspaceDomain.getLogicalModels().get( 0 ).setProperty( "datasourceModel", serializedDto );
+        workspaceDomain.getLogicalModels().get( 0 ).setProperty( "DatasourceType", "CSV" );
         prepareForSerialization( workspaceDomain );
 
         modelerService.serializeModels( workspaceDomain, modelerWorkspace.getModelName() );
@@ -204,12 +203,7 @@ public class CsvDatasourceServiceImpl extends PentahoBase implements ICsvDatasou
       File.separatorChar + "system" + File.separatorChar + File.separatorChar + "tmp" + File.separatorChar;
     String sysTmpDir = PentahoSystem.getApplicationContext().getSolutionPath( TMP_FILE_PATH );
     LogicalModel logicalModel = domain.getLogicalModels().get( 0 );
-    
-    String modelState = null;
-    Property property = logicalModel.getProperty( "datasourceModel" ); //$NON-NLS-1$
-    if ( property != null ) {
-      modelState = (String) property.getValue();
-    }
+    String modelState = (String) logicalModel.getProperty( "datasourceModel" ); //$NON-NLS-1$
 
     if ( modelState != null ) {
 
@@ -231,7 +225,7 @@ public class CsvDatasourceServiceImpl extends PentahoBase implements ICsvDatasou
       datasource.setQuery( null );
       // Update datasourceModel with the new modelState
       modelState = xs.toXML( datasource );
-      logicalModel.setProperty( "datasourceModel", new Property<String>( modelState ) );
+      logicalModel.setProperty( "datasourceModel", modelState );
     }
   }
 

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
@@ -41,7 +41,6 @@ import org.pentaho.metadata.model.InlineEtlPhysicalModel;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.model.SqlPhysicalModel;
 import org.pentaho.metadata.model.SqlPhysicalTable;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.repository.DomainAlreadyExistsException;
 import org.pentaho.metadata.repository.DomainIdNullException;
 import org.pentaho.metadata.repository.DomainStorageException;
@@ -141,29 +140,13 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       LogicalModel logicalModelRep = model.getLogicalModel( ModelerPerspective.REPORTING );
       //CSV related data is bounded to reporting model so need to perform some additional clean up here
       if ( logicalModelRep != null ) {
-        String modelState = null;
-        Property property = logicalModelRep.getProperty( "datasourceModel" );
-        if ( property != null ) {
-          modelState = (String) property.getValue();
-        }
+        String modelState = (String) logicalModelRep.getProperty( "datasourceModel" );
 
-        String targetTableStaged = null;
-        Property targetProperty = logicalModelRep.getProperty( LogicalModel.PROPERTY_TARGET_TABLE_STAGED );
-        if ( targetProperty != null ) {
-          targetTableStaged = (String) targetProperty.getValue();
-        }
-        
         // if CSV, drop the staged table
         // TODO: use the edit story's stored info to do this
-        
-        Property datasourceTypeProperty = logicalModelRep.getProperty( "DatasourceType" );
-        String datasourceType = null;
-        if ( datasourceTypeProperty != null ) {
-          datasourceType = (String) datasourceTypeProperty.getValue();
-        }
-        if ( "CSV".equals( datasourceType )
+        if ( "CSV".equals( logicalModelRep.getProperty( "DatasourceType" ) )
           || "true"
-            .equalsIgnoreCase( targetTableStaged ) ) {
+            .equalsIgnoreCase( (String) logicalModelRep.getProperty( LogicalModel.PROPERTY_TARGET_TABLE_STAGED ) ) ) {
           targetTable =
             ( (SqlPhysicalTable) domain.getPhysicalModels().get( 0 ).getPhysicalTables().get( 0 ) ).getTargetTable();
           DatasourceDTO datasource = null;
@@ -195,7 +178,7 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       if ( logicalModel.getProperty( "MondrianCatalogRef" ) != null ) {
         // remove Mondrian schema
         IMondrianCatalogService service = PentahoSystem.get( IMondrianCatalogService.class, null );
-        catalogRef = (String) logicalModel.getProperty( "MondrianCatalogRef" ).getValue();
+        catalogRef = (String) logicalModel.getProperty( "MondrianCatalogRef" );
         // check if the model is not already removed
         if ( service.getCatalog( catalogRef, PentahoSessionHolder.getSession() ) != null ) {
           service.removeCatalog( catalogRef, PentahoSessionHolder.getSession() );
@@ -443,11 +426,7 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       locale = LocaleHelper.getClosestLocale( locale, locales );
 
       for ( LogicalModel model : domain.getLogicalModels() ) {
-        String vis = null;
-        Property property = model.getProperty( "visible" );
-        if ( property != null ) {
-          vis = (String) property.getValue();
-        }
+        String vis = (String) model.getProperty( "visible" );
         if ( vis != null ) {
           String[] visibleContexts = vis.split( "," );
           boolean visibleToContext = false;
@@ -553,8 +532,8 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       modelerWorkspace.getWorkspaceHelper().autoModelRelationalFlat( modelerWorkspace );
       modelerWorkspace.setModelName( datasourceDTO.getDatasourceName() );
       modelerWorkspace.getWorkspaceHelper().populateDomain( modelerWorkspace );
-      domain.getLogicalModels().get( 0 ).setProperty( "datasourceModel", new Property<String>( serializeModelState( datasourceDTO ) ) );
-      domain.getLogicalModels().get( 0 ).setProperty( "DatasourceType", new Property<String>( "SQL-DS" ) );
+      domain.getLogicalModels().get( 0 ).setProperty( "datasourceModel", serializeModelState( datasourceDTO ) );
+      domain.getLogicalModels().get( 0 ).setProperty( "DatasourceType", "SQL-DS" );
 
       QueryDatasourceSummary summary = new QueryDatasourceSummary();
       prepareForSerializaton( domain );
@@ -600,11 +579,7 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       String.valueOf( FileUtils.DEFAULT_RELATIVE_UPLOAD_FILE_PATH ) ); //$NON-NLS-1$
     String path = PentahoSystem.getApplicationContext().getSolutionPath( relativePath );
     LogicalModel logicalModel = domain.getLogicalModels().get( 0 );
-    String modelState = null;
-    Property property = logicalModel.getProperty( "datasourceModel" );
-    if ( property != null ) {
-      modelState = (String) property.getValue();
-    }
+    String modelState = (String) logicalModel.getProperty( "datasourceModel" );
 
     if ( modelState != null ) {
       XStream xs = new XStream();
@@ -639,7 +614,7 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       }
       // Update datasourceModel with the new modelState
       modelState = xs.toXML( datasource );
-      logicalModel.setProperty( "datasourceModel", new Property<String> ( modelState  ) );
+      logicalModel.setProperty( "datasourceModel", modelState );
     }
   }
 

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DebugModelerService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DebugModelerService.java
@@ -24,7 +24,6 @@ import org.pentaho.agilebi.modeler.gwt.GwtModelerWorkspaceHelper;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.model.SqlPhysicalModel;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.model.concept.types.LocalizedString;
 import org.pentaho.platform.api.engine.IApplicationContext;
 import org.pentaho.platform.api.engine.IPentahoObjectFactory;
@@ -88,7 +87,7 @@ public class DebugModelerService extends ModelerService {
 
       LogicalModel lModel = domain.getLogicalModels().get( 0 );
       String catName = lModel.getName( LocalizedString.DEFAULT_LOCALE );
-      lModel.setProperty( "MondrianCatalogRef", new Property<String>( catName ) ); //$NON-NLS-1$
+      lModel.setProperty( "MondrianCatalogRef", catName ); //$NON-NLS-1$
 
       // Serialize domain to xmi.
       /*

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/InMemoryDSWDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/InMemoryDSWDatasourceServiceImpl.java
@@ -40,7 +40,6 @@ import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.InlineEtlPhysicalModel;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.model.SqlPhysicalModel;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.repository.DomainAlreadyExistsException;
 import org.pentaho.metadata.repository.DomainIdNullException;
 import org.pentaho.metadata.repository.DomainStorageException;
@@ -292,11 +291,7 @@ public class InMemoryDSWDatasourceServiceImpl implements IDSWDatasourceService {
       locale = LocaleHelper.getClosestLocale( locale, locales );
 
       for ( LogicalModel model : domain.getLogicalModels() ) {
-        String vis = null;
-        Property property = model.getProperty( "visible" );
-        if( property != null ) {
-          vis = (String) property.getValue();
-        }
+        String vis = (String) model.getProperty( "visible" );
         if ( vis != null ) {
           String[] visibleContexts = vis.split( "," );
           boolean visibleToContext = false;
@@ -367,8 +362,8 @@ public class InMemoryDSWDatasourceServiceImpl implements IDSWDatasourceService {
       modelerWorkspace.getWorkspaceHelper().autoModelFlat( modelerWorkspace );
       modelerWorkspace.setModelName( datasourceDTO.getDatasourceName() );
       modelerWorkspace.getWorkspaceHelper().populateDomain( modelerWorkspace );
-      domain.getLogicalModels().get( 0 ).setProperty( "datasourceModel", new Property<String>( serializeModelState( datasourceDTO ) ) );
-      domain.getLogicalModels().get( 0 ).setProperty( "DatasourceType", new Property<String>( "SQL-DS" ) );
+      domain.getLogicalModels().get( 0 ).setProperty( "datasourceModel", serializeModelState( datasourceDTO ) );
+      domain.getLogicalModels().get( 0 ).setProperty( "DatasourceType", "SQL-DS" );
 
       QueryDatasourceSummary summary = new QueryDatasourceSummary();
       modelerService.serializeModels( domain, modelerWorkspace.getModelName() );

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ModelerService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ModelerService.java
@@ -40,7 +40,6 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.model.SqlPhysicalModel;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.metadata.util.MondrianModelExporter;
 import org.pentaho.platform.api.engine.IPentahoSession;
@@ -161,8 +160,8 @@ public class ModelerService extends PentahoBase implements IModelerService {
             if ( lModel == null ) {
               lModel = model.getLogicalModel( ModelerPerspective.REPORTING );
             }
-            lModel.setProperty( "AGILE_BI_GENERATED_SCHEMA", new Property<String>( "TRUE" ) );
-            lModel.setProperty( "WIZARD_GENERATED_SCHEMA", new Property<String>(  "TRUE" ) );
+            lModel.setProperty( "AGILE_BI_GENERATED_SCHEMA", "TRUE" );
+            lModel.setProperty( "WIZARD_GENERATED_SCHEMA", "TRUE" );
 
             String catName = lModel.getName( Locale.getDefault().toString() );
 
@@ -170,7 +169,7 @@ public class ModelerService extends PentahoBase implements IModelerService {
             catName = catName.replace( BaseModelerWorkspaceHelper.OLAP_SUFFIX, "" );
 
             if ( doOlap ) {
-              lModel.setProperty( "MondrianCatalogRef", new Property<String>( catName ) ); //$NON-NLS-1$
+              lModel.setProperty( "MondrianCatalogRef", catName ); //$NON-NLS-1$
             }
 
             // Stores metadata into JCR.      

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MultitableDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MultitableDatasourceService.java
@@ -37,7 +37,6 @@ import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.model.concept.Concept;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.model.concept.security.Security;
 import org.pentaho.metadata.model.concept.security.SecurityOwner;
 import org.pentaho.platform.dataaccess.datasource.utils.DataAccessPermissionUtil;
@@ -150,8 +149,8 @@ public class MultitableDatasourceService extends PentahoBase implements IGwtJoin
 
       String modelState = serializeModelState( dto );
       for ( LogicalModel lm : domain.getLogicalModels() ) {
-        lm.setProperty( "datasourceModel", new Property<String>( modelState ) );
-        lm.setProperty( "DatasourceType", new Property<String>( "MULTI-TABLE-DS" ) );
+        lm.setProperty( "datasourceModel", modelState );
+        lm.setProperty( "DatasourceType", "MULTI-TABLE-DS" );
 
         // BISERVER-6450 - add security settings to the logical model
         applySecurity( lm );
@@ -251,7 +250,7 @@ public class MultitableDatasourceService extends PentahoBase implements IGwtJoin
         SecurityOwner owner = new SecurityOwner( SecurityOwner.OwnerType.ROLE, role );
         security.putOwnerRights( owner, getDefaultAcls() );
       }
-      logicalModel.setProperty( Concept.SECURITY_PROPERTY, new Property<Security>( security ) );
+      logicalModel.setProperty( Concept.SECURITY_PROPERTY, security );
     }
   }
 

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/utils/InlineSqlModelerSource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/utils/InlineSqlModelerSource.java
@@ -24,7 +24,6 @@ import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.model.SqlPhysicalModel;
 import org.pentaho.metadata.model.SqlPhysicalTable;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.util.ThinModelConverter;
 import org.pentaho.platform.dataaccess.datasource.beans.BusinessData;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.DatasourceServiceException;
@@ -82,11 +81,7 @@ public class InlineSqlModelerSource implements ISpoonModelerSource {
     SqlPhysicalModel model = (SqlPhysicalModel) domain.getPhysicalModels().get( 0 );
     SqlPhysicalTable table = model.getPhysicalTables().get( 0 );
 
-    String targetTable = null;
-    Property property = table.getProperty( "target_table" ); //$NON-NLS-1$
-    if ( property != null ) {
-      targetTable = (String) property.getValue();
-    }
+    String targetTable = (String) table.getProperty( "target_table" ); //$NON-NLS-1$
     if ( !StringUtils.isEmpty( targetTable ) ) {
       domain.setId( targetTable );
     }
@@ -97,7 +92,7 @@ public class InlineSqlModelerSource implements ISpoonModelerSource {
 
   public void serializeIntoDomain( Domain d ) {
     LogicalModel lm = d.getLogicalModels().get( 0 );
-    lm.setProperty( "source_type", new Property<String> ( SOURCE_TYPE ) ); //$NON-NLS-1$
+    lm.setProperty( "source_type", SOURCE_TYPE ); //$NON-NLS-1$
   }
 
   public DatabaseMeta getDatabaseMeta() {

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/csv/CsvDatasource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/csv/CsvDatasource.java
@@ -203,7 +203,7 @@ public class CsvDatasource extends AbstractXulEventHandler implements IWizardDat
   @Override
   public void restoreSavedDatasource( Domain previousDomain, final XulServiceCallback<Void> callback ) {
 
-    String serializedDatasource = (String) previousDomain.getLogicalModels().get( 0 ).getProperty( "datasourceModel" ).getValue();
+    String serializedDatasource = (String) previousDomain.getLogicalModels().get( 0 ).getProperty( "datasourceModel" );
 
     datasourceService.deSerializeModelState( serializedDatasource, new XulServiceCallback<DatasourceDTO>() {
       public void success( DatasourceDTO datasourceDTO ) {

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/multitable/MultiTableDatasource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/multitable/MultiTableDatasource.java
@@ -222,7 +222,7 @@ public class MultiTableDatasource extends AbstractXulEventHandler implements IWi
   @Override
   public void restoreSavedDatasource( final Domain previousDomain, final XulServiceCallback<Void> callback ) {
     tablesSelectionStep.setDomain( previousDomain );
-    String serializedDatasource = (String) previousDomain.getLogicalModels().get( 0 ).getProperty( "datasourceModel" ).getValue();
+    String serializedDatasource = (String) previousDomain.getLogicalModels().get( 0 ).getProperty( "datasourceModel" );
     joinSelectionServiceGwtImpl.deSerializeModelState( serializedDatasource,
       new XulServiceCallback<MultiTableDatasourceDTO>() {
 

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/multitable/MultitableGuiModel.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/multitable/MultitableGuiModel.java
@@ -30,7 +30,6 @@ import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalColumn;
 import org.pentaho.metadata.model.LogicalRelationship;
 import org.pentaho.metadata.model.LogicalTable;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.model.concept.types.LocalizedString;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.MultiTableDatasourceDTO;
 import org.pentaho.ui.xul.XulEventSourceAdapter;
@@ -372,12 +371,7 @@ public class MultitableGuiModel extends XulEventSourceAdapter {
   Outter:
     for ( JoinTableModel table : availableTables ) {
       for ( LogicalTable tbl : domain.getLogicalModels().get( 0 ).getLogicalTables() ) {
-        Property targetTableProperty = tbl.getPhysicalTable().getProperty( "target_table" );
-        String targetTable = null;
-        if ( targetTableProperty != null ) {
-          targetTable = (String) targetTableProperty.getValue();
-        }
-        if ( ( targetTable ).equals( table.getName() ) ) {
+        if ( tbl.getPhysicalTable().getProperty( "target_table" ).equals( table.getName() ) ) {
           for ( LogicalColumn col : tbl.getLogicalColumns() ) {
             JoinFieldModel field = new JoinFieldModel();
             field.setName( col.getName( locale ) );

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/query/QueryDatasource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/sources/query/QueryDatasource.java
@@ -115,7 +115,7 @@ public class QueryDatasource extends AbstractXulEventHandler implements IWizardD
   @Override
   public void restoreSavedDatasource( Domain previousDomain, final XulServiceCallback<Void> callback ) {
 
-    String serializedDatasource = (String) previousDomain.getLogicalModels().get( 0 ).getProperty( "datasourceModel" ).getValue();
+    String serializedDatasource = (String) previousDomain.getLogicalModels().get( 0 ).getProperty( "datasourceModel" );
 
     datasourceService.deSerializeModelState( serializedDatasource, new XulServiceCallback<DatasourceDTO>() {
       public void success( DatasourceDTO datasourceDTO ) {

--- a/src/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtil.java
+++ b/src/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtil.java
@@ -31,7 +31,6 @@ import org.pentaho.metadata.model.IPhysicalColumn;
 import org.pentaho.metadata.model.LogicalColumn;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.model.concept.Concept;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.model.concept.types.AggregationType;
 import org.pentaho.metadata.model.concept.types.Alignment;
 import org.pentaho.metadata.model.concept.types.DataType;
@@ -39,8 +38,8 @@ import org.pentaho.metadata.model.concept.types.FieldType;
 import org.pentaho.metadata.model.concept.types.LocalizedString;
 import org.pentaho.metadata.query.model.CombinationType;
 import org.pentaho.metadata.query.model.Constraint;
-import org.pentaho.metadata.query.model.Order.Type;
 import org.pentaho.metadata.query.model.Selection;
+import org.pentaho.metadata.query.model.Order.Type;
 import org.pentaho.metadata.query.model.util.QueryXmlHelper;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.dataaccess.metadata.messages.Messages;
@@ -195,17 +194,13 @@ public class MetadataServiceUtil extends PentahoBase {
     // set the alignment
     DataType dataType = c.getDataType();
     FieldType fieldType = c.getFieldType();
-    Property property = c.getProperty( "alignment" ); //$NON-NLS-1$
-    Object value = null;
-    if( property != null ) {
-      value = property.getValue();
-    }
-    if ( value instanceof Alignment ) {
-      if ( value == Alignment.LEFT ) {
+    Object obj = c.getProperty( "alignment" ); //$NON-NLS-1$
+    if ( obj instanceof Alignment ) {
+      if ( obj == Alignment.LEFT ) {
         col.setHorizontalAlignment( Alignment.LEFT.toString() );
-      } else if ( value == Alignment.RIGHT ) {
+      } else if ( obj == Alignment.RIGHT ) {
         col.setHorizontalAlignment( Alignment.RIGHT.toString() );
-      } else if ( value == Alignment.CENTERED ) {
+      } else if ( obj == Alignment.CENTERED ) {
         col.setHorizontalAlignment( Alignment.CENTERED.toString() );
       }
     } else if ( fieldType == FieldType.FACT ) {
@@ -216,9 +211,9 @@ public class MetadataServiceUtil extends PentahoBase {
       col.setHorizontalAlignment( Alignment.LEFT.toString() );
     }
     // set the format mask
-    property = c.getProperty( "mask" ); //$NON-NLS-1$
-    if ( property != null ) {
-      col.setFormatMask( (String) property.getValue() );
+    obj = c.getProperty( "mask" ); //$NON-NLS-1$
+    if ( obj != null ) {
+      col.setFormatMask( (String) obj );
     }
     return col;
   }
@@ -360,7 +355,7 @@ public class MetadataServiceUtil extends PentahoBase {
       DataType type = logicalColumn.getDataType();
       String[] value = parameter.getValue();
       org.pentaho.metadata.query.model.Parameter fullParam =
-        new org.pentaho.metadata.query.model.Parameter( parameter.getColumn(), type, new Property<String>( value[ 0 ] ) );
+        new org.pentaho.metadata.query.model.Parameter( parameter.getColumn(), type, value[ 0 ] );
       parameters.add( fullParam );
     }
     return dest;

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardServiceTest.java
@@ -25,7 +25,6 @@ import org.pentaho.agilebi.modeler.ModelerWorkspace;
 import org.pentaho.agilebi.modeler.services.IModelerService;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.metadata.util.XmiParser;
 import org.pentaho.platform.api.engine.IPentahoSession;
@@ -49,6 +48,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 
 public class DataSourceWizardServiceTest {
 
@@ -75,7 +75,7 @@ public class DataSourceWizardServiceTest {
     ModelerWorkspace mockModelerWorkspace = mock( ModelerWorkspace.class );
     MondrianCatalogRepositoryHelper mockMondrianCatalogRepositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
     LogicalModel mockLogicalModel = mock( LogicalModel.class );
-    Property mockObject = new Property( "not null" );
+    String mockObject = "not null";
     String dswId = "dswId";
 
     doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
@@ -118,7 +118,7 @@ public class DataSourceWizardServiceTest {
     IPentahoSession mockIPentahoSession = mock( IPentahoSession.class );
     ModelerWorkspace mockModelerWorkspace = mock( ModelerWorkspace.class );
     LogicalModel mockLogicalModel = mock( LogicalModel.class );
-    Property mockObject = new Property( "not null" );
+    String mockObject = "not null";
     String dswId = "dswId";
 
     doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
@@ -144,7 +144,7 @@ public class DataSourceWizardServiceTest {
     IPentahoSession mockIPentahoSession = mock( IPentahoSession.class );
     ModelerWorkspace mockModelerWorkspace = mock( ModelerWorkspace.class );
     LogicalModel mockLogicalModel = mock( LogicalModel.class );
-    Property mockObject = new Property( "not null" );
+    String mockObject = "not null";
     String dswId = "dswId";
 
     doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
@@ -172,7 +172,7 @@ public class DataSourceWizardServiceTest {
     IPentahoSession mockIPentahoSession = mock( IPentahoSession.class );
     ModelerWorkspace mockModelerWorkspace = mock( ModelerWorkspace.class );
     LogicalModel mockLogicalModel = mock( LogicalModel.class );
-    Property mockObject = new Property( "not null" );
+    String mockObject = "not null";
     String dswId = "dswId";
 
     //Test 1
@@ -214,7 +214,7 @@ public class DataSourceWizardServiceTest {
     List<LogicalModel> mockLogicalModelList = new ArrayList<LogicalModel>();
     LogicalModel mockLogicalModel = mock( LogicalModel.class );
     mockLogicalModelList.add( mockLogicalModel );
-    Property mockObject = mock( Property.class );
+    Object mockObject = mock( Object.class );
 
     List<String> datasourceList = new ArrayList<String>();
     datasourceList.add( mockLogicalModelSummary.getDomainId() );

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/csv/SerializeMultiTableServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/csv/SerializeMultiTableServiceTest.java
@@ -18,10 +18,6 @@
 
 package org.pentaho.platform.dataaccess.datasource.wizard.csv;
 
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -45,7 +41,6 @@ import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.metadata.model.Domain;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.model.olap.OlapDimension;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.data.IDBDatasourceService;
@@ -100,6 +95,9 @@ import org.springframework.security.userdetails.User;
 import org.springframework.security.userdetails.UserDetails;
 import org.springframework.security.userdetails.UserDetailsService;
 import org.springframework.security.userdetails.UsernameNotFoundException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.anyString;
 
 /**
  * Integration test. Tests {@link DefaultUnifiedRepository} and
@@ -216,12 +214,12 @@ public class SerializeMultiTableServiceTest {
     dimension.setName("test");//$NON-NLS-1$
     dimension.setTimeDimension(false);
     olapDimensions.add(dimension);
-    domain.getLogicalModels().get(0).setProperty("olap_dimensions", new Property<List<OlapDimension>>( olapDimensions ) );//$NON-NLS-1$
+    domain.getLogicalModels().get(0).setProperty("olap_dimensions", olapDimensions);//$NON-NLS-1$
 
     ModelerService service = new ModelerService();
     service.serializeModels(domain, "test_file");//$NON-NLS-1$
 
-    Assert.assertEquals( ( String) domain.getLogicalModels().get(0).getProperty("MondrianCatalogRef").getValue(), "SampleData");
+    Assert.assertEquals( ( String) domain.getLogicalModels().get(0).getProperty("MondrianCatalogRef"), "SampleData");
 
   }
 

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/csv/SerializeServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/csv/SerializeServiceTest.java
@@ -42,7 +42,6 @@ import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.metadata.model.Domain;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.model.olap.OlapDimension;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.data.IDBDatasourceService;
@@ -213,7 +212,7 @@ public class SerializeServiceTest {
     model.getWorkspaceHelper().populateDomain(model);
     service.serializeModels(domain, "test_file");//$NON-NLS-1$
 
-    Assert.assertEquals( ( String) domain.getLogicalModels().get(1).getProperty("MondrianCatalogRef").getValue(), model.getModelName());
+    Assert.assertEquals(domain.getLogicalModels().get(1).getProperty("MondrianCatalogRef"), model.getModelName());
   }
 
   private Domain generateModel() {
@@ -241,7 +240,7 @@ public class SerializeServiceTest {
       dimension.setName("test");//$NON-NLS-1$
       dimension.setTimeDimension(false);
       olapDimensions.add(dimension);
-      domain.getLogicalModels().get(1).setProperty("olap_dimensions", new Property<List<OlapDimension>>( olapDimensions ) );//$NON-NLS-1$
+      domain.getLogicalModels().get(1).setProperty("olap_dimensions", olapDimensions);//$NON-NLS-1$
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceTest.java
@@ -1,7 +1,7 @@
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,10 +27,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.pentaho.agilebi.modeler.ModelerWorkspace;
 import org.pentaho.agilebi.modeler.gwt.GwtModelerWorkspaceHelper;
 import org.pentaho.agilebi.modeler.util.TableModelerSource;
@@ -39,7 +36,6 @@ import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Props;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.metadata.model.Domain;
-import org.pentaho.metadata.model.concept.Property;
 import org.pentaho.metadata.model.olap.OlapDimension;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.data.IDBDatasourceService;
@@ -318,7 +314,7 @@ public class DatasourceResourceTest {
       dimension.setName( "test" ); //$NON-NLS-1$
       dimension.setTimeDimension( false );
       olapDimensions.add( dimension );
-      domain.getLogicalModels().get( 1 ).setProperty( "olap_dimensions", new Property<List<OlapDimension>>( olapDimensions ) ); //$NON-NLS-1$
+      domain.getLogicalModels().get( 1 ).setProperty( "olap_dimensions", olapDimensions ); //$NON-NLS-1$
 
     } catch ( Exception e ) {
       e.printStackTrace();


### PR DESCRIPTION
@e-cuellar This commit reverts the use of "Property" but contains all other refactoring done to the thin model, avoiding changes to the API.  I have run nearly 600 iterations of the data-access build and it's 100% success rate is looking good.
