### PR TITLE
[BACKLOG-1561] - Add the ability to get security/ACL information about a datasource

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/api/DatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/DatasourceService.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api;
@@ -25,39 +25,40 @@ import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
-import org.pentaho.platform.api.engine.ISystemConfig;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
-import org.pentaho.platform.api.repository2.unified.RepositoryFile;
-import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.dataaccess.datasource.utils.DataAccessPermissionUtil;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
-import org.pentaho.platform.repository2.unified.jcr.IAclNodeHelper;
-import org.pentaho.platform.repository2.unified.jcr.JcrAclNodeHelper;
+import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclAdapter;
-import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
 import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
-import org.pentaho.platform.web.http.api.resources.services.FileService;
 
 public class DatasourceService {
-
   protected IMetadataDomainRepository metadataDomainRepository;
   protected IMondrianCatalogService mondrianCatalogService;
-  protected FileService fileService;
-  protected IAclNodeHelper aclHelper;
   protected RepositoryFileAclAdapter repositoryFileAclAdapter;
+  private MondrianCatalogRepositoryHelper mondrianCatalogRepositoryHelper;
 
   public DatasourceService() {
     metadataDomainRepository = PentahoSystem.get( IMetadataDomainRepository.class, PentahoSessionHolder.getSession() );
     mondrianCatalogService = PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
-    fileService = new FileService();
-    final ISystemConfig systemConfig = PentahoSystem.get( ISystemConfig.class );
-    aclHelper = new JcrAclNodeHelper( fileService.getRepository(),
-        systemConfig == null ? null : systemConfig.getProperty( "repository.aclNodeFolder" ) );
     repositoryFileAclAdapter = new RepositoryFileAclAdapter();
+  }
+
+  protected IUnifiedRepository getRepository() {
+    return PentahoSystem.get( IUnifiedRepository.class );
+  }
+
+  protected MondrianCatalogRepositoryHelper getMondrianCatalogRepositoryHelper() {
+    if ( mondrianCatalogRepositoryHelper == null ) {
+      mondrianCatalogRepositoryHelper = new MondrianCatalogRepositoryHelper( getRepository() );
+    }
+    return mondrianCatalogRepositoryHelper;
   }
 
   public static boolean canAdminister() {
@@ -74,6 +75,12 @@ public class DatasourceService {
     if ( !isAdmin ) {
       throw new PentahoAccessControlException( "Access Denied" );
     }
+  }
+
+  protected boolean canManageACL() {
+    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
+    return policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
+      && DataAccessPermissionUtil.hasManageAccess();
   }
 
   /**
@@ -129,12 +136,8 @@ public class DatasourceService {
     }
   }
 
-  protected RepositoryFileAclDto getAcl( String analysisId, IAclNodeHelper.DatasourceType datasourceType ) {
-    RepositoryFileAcl acl = aclHelper.getAclFor( analysisId, datasourceType );
-    if ( acl == null ) {
-      return null;
-    }
-    final RepositoryFile aclFile = fileService.getRepository().getFileById( acl.getId() );
-    return fileService.doGetFileAcl( aclFile.getPath() );
+  protected void flushDataSources() {
+    metadataDomainRepository.flushDomains();
+    mondrianCatalogService.reInit( PentahoSessionHolder.getSession() );
   }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/api/resources/AnalysisResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/resources/AnalysisResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -73,8 +73,12 @@ public class AnalysisResource {
   protected ResourceUtil resourceUtil;
 
   public AnalysisResource() {
-    service = new AnalysisService();
+    service = createAnalysisService();
     resourceUtil = new ResourceUtil();
+  }
+
+  protected AnalysisService createAnalysisService() {
+    return new AnalysisService();
   }
 
   /**

--- a/src/org/pentaho/platform/dataaccess/datasource/api/resources/DataSourceWizardResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/resources/DataSourceWizardResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -61,8 +61,12 @@ public class DataSourceWizardResource {
   protected ResourceUtil resourceUtil;
 
   public DataSourceWizardResource() {
-    service = new DataSourceWizardService();
+    service = createDataSourceWizardService();
     resourceUtil = new ResourceUtil();
+  }
+
+  protected DataSourceWizardService createDataSourceWizardService() {
+    return new DataSourceWizardService();
   }
 
   /**

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MetadataDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MetadataDatasourceService.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;

--- a/test-src/org/pentaho/platform/dataaccess/datasource/DataSourcePublishACLTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/DataSourcePublishACLTest.java
@@ -1,3 +1,20 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+*/
+
 package org.pentaho.platform.dataaccess.datasource;
 
 import com.sun.jersey.api.client.ClientResponse;
@@ -298,6 +315,11 @@ public class DataSourcePublishACLTest extends JerseyTest implements ApplicationC
         .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" )
         .get( ClientResponse.class );
     assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
+
+    final ClientResponse noAccessACLNoDS = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "_not_exist/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
   }
 
   private void checkAnalysis( WebResource webResource, String catalogID, boolean hasAccess ) {
@@ -420,6 +442,11 @@ public class DataSourcePublishACLTest extends JerseyTest implements ApplicationC
         .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
         .get( ClientResponse.class );
     assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
+
+    final ClientResponse noAccessACLNoDS = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "_not_exist/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
   }
 
   private void checkMetadata( WebResource webResource, String domainID, boolean hasAccess ) {
@@ -542,6 +569,11 @@ public class DataSourcePublishACLTest extends JerseyTest implements ApplicationC
         .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
         .get( ClientResponse.class );
     assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
+
+    final ClientResponse noAccessACLNoDS = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "_not_exist/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
   }
 
   private void checkDSW( WebResource webResource, String domainID, boolean hasAccess ) {

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardServiceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api;
@@ -37,15 +37,15 @@ import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
 import org.pentaho.platform.dataaccess.datasource.beans.LogicalModelSummary;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.DatasourceServiceException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.IDSWDatasourceService;
+import org.pentaho.platform.plugin.action.mondrian.catalog.IAclAwareMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogServiceException;
 import org.pentaho.platform.plugin.services.importer.IPlatformImportBundle;
 import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
-import org.pentaho.platform.repository2.unified.jcr.IAclNodeHelper;
+import org.pentaho.platform.plugin.services.metadata.IAclAwarePentahoMetadataDomainRepositoryImporter;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclAdapter;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
-import org.pentaho.platform.web.http.api.resources.services.FileService;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -64,16 +64,29 @@ public class DataSourceWizardServiceTest {
 
   private static DataSourceWizardService dataSourceWizardService;
 
+  private class DataSourceWizardServiceMock extends DataSourceWizardService {
+    @Override protected IUnifiedRepository getRepository() {
+      return mock( IUnifiedRepository.class );
+    }
+
+    @Override protected MondrianCatalogRepositoryHelper getMondrianCatalogRepositoryHelper() {
+      return mock( MondrianCatalogRepositoryHelper.class );
+    }
+
+    @Override protected IDSWDatasourceService getDswDatasourceService() {
+      return mock( IDSWDatasourceService.class );
+    }
+  }
+
   @Before
   public void setUp() {
-    dataSourceWizardService = spy( new DataSourceWizardService() );
+    dataSourceWizardService = spy( new DataSourceWizardServiceMock() );
     dataSourceWizardService.metadataDomainRepository = mock( IMetadataDomainRepository.class );
-    dataSourceWizardService.dswService = mock( IDSWDatasourceService.class );
     dataSourceWizardService.mondrianCatalogService = mock( IMondrianCatalogService.class );
     dataSourceWizardService.datasourceMgmtSvc = mock( IDatasourceMgmtService.class );
     dataSourceWizardService.modelerService = mock( IModelerService.class );
-    dataSourceWizardService.aclHelper = mock( IAclNodeHelper.class );
-    dataSourceWizardService.fileService = mock( FileService.class );
+    dataSourceWizardService.aclAwarePentahoMetadataDomainRepositoryImporter = mock( IAclAwarePentahoMetadataDomainRepositoryImporter.class );
+    dataSourceWizardService.aclAwareMondrianCatalogService = mock( IAclAwareMondrianCatalogService.class );
   }
 
   @After
@@ -387,19 +400,17 @@ public class DataSourceWizardServiceTest {
 
     final RepositoryFileAcl acl = new RepositoryFileAcl.Builder( "owner" ).build();
 
-    doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
-    when( dataSourceWizardService.aclHelper.getAclFor( anyString(), any( IAclNodeHelper.DatasourceType.class ) ) )
-        .thenReturn( acl );
+    doReturn( true ).when( dataSourceWizardService ).canManageACL();
+    when( dataSourceWizardService.aclAwarePentahoMetadataDomainRepositoryImporter.getAclFor( domainId ) ).thenReturn(
+        acl );
     final IUnifiedRepository repository = mock( IUnifiedRepository.class );
-    when( dataSourceWizardService.fileService.getRepository() ).thenReturn( repository );
-    when( dataSourceWizardService.fileService.doGetFileAcl( anyString() ) ).thenReturn( new RepositoryFileAclAdapter().marshal( acl ) );
     final RepositoryFile repositoryFile = mock( RepositoryFile.class );
     when( repository.getFileById( anyString() ) ).thenReturn( repositoryFile );
     doReturn( new HashMap<String, InputStream>() ).when( dataSourceWizardService ).doGetDSWFilesAsDownload( domainId );
 
     final RepositoryFileAclDto aclDto = dataSourceWizardService.getDSWAcl( domainId );
 
-    verify( dataSourceWizardService.aclHelper ).getAclFor( domainId, IAclNodeHelper.DatasourceType.METADATA );
+    verify( dataSourceWizardService.aclAwarePentahoMetadataDomainRepositoryImporter ).getAclFor( eq( domainId ) );
 
     assertEquals( acl, new RepositoryFileAclAdapter().unmarshal( aclDto ) );
   }
@@ -408,14 +419,14 @@ public class DataSourceWizardServiceTest {
   public void testGetDSWAclNoAcl() throws Exception {
     String domainId = "domainId";
 
-    doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
-    when( dataSourceWizardService.aclHelper.getAclFor( anyString(), any( IAclNodeHelper.DatasourceType.class ) ) )
+    doReturn( true ).when( dataSourceWizardService ).canManageACL();
+    when( dataSourceWizardService.aclAwarePentahoMetadataDomainRepositoryImporter.getAclFor( domainId ) )
         .thenReturn( null );
     doReturn( new HashMap<String, InputStream>() ).when( dataSourceWizardService ).doGetDSWFilesAsDownload( domainId );
 
     final RepositoryFileAclDto aclDto = dataSourceWizardService.getDSWAcl( domainId );
 
-    verify( dataSourceWizardService.aclHelper ).getAclFor( domainId, IAclNodeHelper.DatasourceType.METADATA );
+    verify( dataSourceWizardService.aclAwarePentahoMetadataDomainRepositoryImporter ).getAclFor( eq( domainId ) );
 
     assertNull( aclDto );
   }
@@ -423,35 +434,36 @@ public class DataSourceWizardServiceTest {
   @Test
   public void testSetMetadataDatasourceAcl() throws Exception {
     String domainId = "domainId.xmi";
+    String domainIdWithoutExt = "domainId";
 
     final RepositoryFileAclDto aclDto = new RepositoryFileAclDto();
     aclDto.setOwner( "owner" );
     aclDto.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
 
-    doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
+    doReturn( true ).when( dataSourceWizardService ).canManageACL();
     doReturn( new HashMap<String, InputStream>() ).when( dataSourceWizardService ).doGetDSWFilesAsDownload( domainId );
 
     dataSourceWizardService.setDSWAcl( domainId, aclDto );
 
     final RepositoryFileAcl acl = new RepositoryFileAclAdapter().unmarshal( aclDto );
-    verify( dataSourceWizardService.aclHelper ).setAclFor( domainId, IAclNodeHelper.DatasourceType.METADATA,
-        acl );
-    verify( dataSourceWizardService.aclHelper ).setAclFor( domainId.substring( 0, domainId.indexOf( ".xmi" ) ), IAclNodeHelper.DatasourceType.MONDRIAN,
-        acl );
+    verify( dataSourceWizardService.aclAwarePentahoMetadataDomainRepositoryImporter ).setAclFor( eq( domainId ),
+        eq( acl ) );
+    verify( dataSourceWizardService.aclAwareMondrianCatalogService ).setAclFor( eq( domainIdWithoutExt ), eq( acl ) );
   }
 
   @Test
   public void testSetMetadataDatasourceAclNoAcl() throws Exception {
     String domainId = "domainId.xmi";
+    String domainIdWithoutExt = "domainId";
 
-    doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
+    doReturn( true ).when( dataSourceWizardService ).canManageACL();
     doReturn( new HashMap<String, InputStream>() ).when( dataSourceWizardService ).doGetDSWFilesAsDownload( domainId );
 
     dataSourceWizardService.setDSWAcl( domainId, null );
 
-    verify( dataSourceWizardService.aclHelper ).setAclFor( domainId, IAclNodeHelper.DatasourceType.METADATA,
-        null );
-    verify( dataSourceWizardService.aclHelper ).setAclFor( domainId.substring( 0, domainId.indexOf( ".xmi" ) ), IAclNodeHelper.DatasourceType.MONDRIAN,
-        null );
+    verify( dataSourceWizardService.aclAwarePentahoMetadataDomainRepositoryImporter ).setAclFor( eq( domainId ),
+        (RepositoryFileAcl) isNull() );
+    verify( dataSourceWizardService.aclAwareMondrianCatalogService ).setAclFor( eq( domainIdWithoutExt ),
+        (RepositoryFileAcl) isNull() );
   }
 }

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/AnalysisResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/AnalysisResourceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -42,10 +42,15 @@ public class AnalysisResourceTest {
 
   private static AnalysisResource analysisResource;
 
+  private class AnalysisResourceMock extends AnalysisResource {
+    @Override protected AnalysisService createAnalysisService() {
+      return mock( AnalysisService.class );
+    }
+  }
+
   @Before
   public void setUp() {
-    analysisResource = spy( new AnalysisResource() );
-    analysisResource.service = mock( AnalysisService.class );
+    analysisResource = spy( new AnalysisResourceMock() );
   }
 
   @After

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/DataSourceWizardResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/DataSourceWizardResourceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -41,10 +41,15 @@ public class DataSourceWizardResourceTest {
 
   private static DataSourceWizardResource dataSourceWizardResource;
 
+  private class DataSourceWizardResourceMock extends DataSourceWizardResource {
+    @Override protected DataSourceWizardService createDataSourceWizardService() {
+      return mock( DataSourceWizardService.class );
+    }
+  }
+
   @Before
   public void setUp() {
-    dataSourceWizardResource = spy( new DataSourceWizardResource() );
-    dataSourceWizardResource.service = mock( DataSourceWizardService.class );
+    dataSourceWizardResource = spy( new DataSourceWizardResourceMock() );
   }
 
   @After

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/JdbcDatasourceResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/JdbcDatasourceResourceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResourceTest.java
@@ -12,21 +12,16 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
 
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -54,10 +49,15 @@ public class MetadataResourceTest {
 
   private static MetadataResource metadataResource;
 
+  private class MetadataResourceMock extends MetadataResource {
+    @Override protected MetadataService createMetadataService() {
+      return mock( MetadataService.class );
+    }
+  }
+
   @Before
   public void setUp() {
-    metadataResource = spy( new MetadataResource() );
-    metadataResource.service = mock( MetadataService.class );
+    metadataResource = spy( new MetadataResourceMock() );
   }
 
   @After
@@ -272,7 +272,7 @@ public class MetadataResourceTest {
     }
 
     //
-    doReturn( null ).when( metadataResource ).getDomainFilesData( domainId );
+    doThrow( new FileNotFoundException() ).when( metadataResource.service ).getMetadataAcl( domainId );
 
     try {
       metadataResource.doGetMetadataAcl( domainId );
@@ -301,7 +301,7 @@ public class MetadataResourceTest {
     assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus() );
 
     //
-    doReturn( null ).when( metadataResource ).getDomainFilesData( domainId );
+    doThrow( new FileNotFoundException() ).when( metadataResource.service ).setMetadataAcl( domainId, null );
 
     response = metadataResource.doSetMetadataAcl( domainId, null );
     assertEquals( Response.Status.CONFLICT.getStatusCode(), response.getStatus() );

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/ResourceUtilTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/ResourceUtilTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceTest.java
@@ -1,3 +1,20 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import static org.mockito.Matchers.anyString;

--- a/test-src/solutionACL/system/repository-test-override.spring.xml
+++ b/test-src/solutionACL/system/repository-test-override.spring.xml
@@ -2,8 +2,10 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:sec="http://www.springframework.org/schema/security"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-2.0.1.xsd">
+                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-2.0.1.xsd
+                      http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd">
 
   <!-- Bean definitions in this file override bean definitions in repository.spring.xml. -->
 
@@ -29,6 +31,21 @@
         <ref bean="defaultBackingRepositoryLifecycleManager"/>
       </list>
     </constructor-arg>
+  </bean>
+
+  <bean class="org.pentaho.platform.dataaccess.security.policy.rolebased.actions.DatasourceManageAction">
+    <pen:publish as-type="INTERFACES">
+      <pen:attributes>
+        <pen:attr key="priority" value="70"/>
+      </pen:attributes>
+    </pen:publish>
+  </bean>
+
+  <bean id="dataAccessViewPermissionHandler" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessViewPermissionHandler">
+    <pen:publish as-type="INTERFACES" />
+  </bean>
+  <bean id="dataAccessPermissionHandler" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessPermissionHandler">
+    <pen:publish as-type="INTERFACES" />
   </bean>
   <!--
     To enable RMI in a unit test, put jackrabbit-jcr-rmi-1.5.0.jar in dev-lib and add to Eclipse classpath.


### PR DESCRIPTION
adopt the code to new pentaho-platform approach, clean cache for metadata
fix metadata service - return 401 status if user doesn't have permissions and ds does not exist, unit-test for this
fix unit-tests

@pentaho-nbaker please review