### PR TITLE
[BACKLOG-1493] - Add the ability to create a data source for a specific ...

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -78,13 +78,13 @@
     <dependency org="hsqldb" name="hsqldb" rev="1.8.0.7" conf="test->default"/>
     <dependency org="com.h2database" name="h2" rev="1.0.78" transitive="false" conf="test->default"/>
     <dependency org="org.slf4j" name="slf4j-api" rev="1.6.4" conf="default->default"/>
-    <dependency org="org.slf4j" name="slf4j-jcl" rev="1.6.4" conf="default->default"/>
 
     <!--  internal dependencies -->
     <dependency org="pentaho" name="pentaho-modeler" rev="${dependency.pentaho-modeler.revision}" changing="true"
                 transitive="true">
       <artifact name="pentaho-modeler"/>
       <artifact name="pentaho-modeler" type="source" ext="jar" m:classifier="sources"/>
+      <exclude org="org.slf4j" name="slf4j-jcl"/>
     </dependency>
 
     <dependency org="pentaho" name="pentaho-connections" rev="${dependency.pentaho-connections.revision}"
@@ -113,7 +113,10 @@
     <dependency org="net.sf.saxon" name="saxon-dom" rev="9.1.0.8" transitive="false" conf="test->default"/>
     <dependency org="junit" name="junit" rev="4.4" conf="test->default"/>
     <dependency org="org.jmock" name="jmock-junit4" rev="2.5.1" conf="test->default"/>
-    <dependency org="org.apache.jackrabbit"    name="jackrabbit-core"            rev="2.4.5" conf="test->default" transitive="false"/>
+    <dependency org="pentaho" name="pentaho-platform-repository" rev="${dependency.pentaho-platform.revision}"
+                changing="true" conf="test->default"/>
+    <dependency org="pentaho" name="pentaho-platform-scheduler" rev="${dependency.pentaho-platform.revision}"
+                changing="true" transitive="false" conf="test->default"/>
     <dependency org="org.springframework"          name="spring"                 rev="2.5.6"         transitive="false" conf="test->default"/>
     <dependency org="org.springframework"          name="se-jcr"                 rev="0.9"           transitive="false" conf="test->default"/>
     <dependency org="org.springframework"          name="spring-beans"           rev="2.5.6"         transitive="false" conf="test->default"/>
@@ -141,6 +144,9 @@
     <dependency org="org.mockito" 						 name="mockito-all" 								 rev="1.8.0" 			transitive="false" conf="test->default"/>
     <dependency org="com.google.collections" name="google-collections" rev="1.0-rc5" transitive="false" conf="test->default"/>
     <dependency org="org.aspectj"            name="aspectjrt"          rev="1.6.6"   transitive="false" conf="test->default"/>
+    <dependency org="com.sun.jersey.jersey-test-framework"  name="jersey-test-framework-core"     rev="1.5" conf="test->default"/>
+    <dependency org="com.sun.jersey.jersey-test-framework"  name="jersey-test-framework-grizzly"  rev="1.5" conf="test->default"/>
+    <dependency org="com.sun.jersey.contribs"               name="jersey-multipart"               rev="1.5" conf="test->default"/>
 
     <dependency org="commons-codec" name="commons-codec" rev="1.3" transitive="false" conf="test->default"/>
     <dependency org="org.springframework" name="spring" rev="2.5.6" transitive="false"/>
@@ -206,5 +212,6 @@
     <dependency org="com.sun.jersey" name="jersey-server" rev="1.5" transitive="false"/>
     <dependency org="javax.ws.rs" name="jsr311-api" rev="1.1.1" transitive="false"/>
 
+    <conflict org="commons-dbcp" rev="1.4"/>
   </dependencies>
 </ivy-module>

--- a/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -12,12 +12,13 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -38,8 +39,10 @@ import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.action.mondrian.catalog.IAclAwareMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import org.pentaho.platform.plugin.services.importer.IPlatformImportBundle;
@@ -47,6 +50,7 @@ import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
 import org.pentaho.platform.plugin.services.importer.PlatformImportException;
 import org.pentaho.platform.plugin.services.importer.RepositoryFileImportBundle;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -68,15 +72,19 @@ public class AnalysisService extends DatasourceService {
   /*
    * register the handler in the PentahoSpringObjects.xml for MondrianImportHandler
    */
-  private static IPlatformImporter importer;
+  protected IPlatformImporter importer;
+  protected IAclAwareMondrianCatalogService aclAwareMondrianCatalogService;
 
   public AnalysisService() {
     importer = PentahoSystem.get( IPlatformImporter.class );
+    if ( mondrianCatalogService instanceof IAclAwareMondrianCatalogService ) {
+      aclAwareMondrianCatalogService = (IAclAwareMondrianCatalogService) mondrianCatalogService;
+    }
   }
 
   public Map<String, InputStream> doGetAnalysisFilesAsDownload( String analysisId )
     throws PentahoAccessControlException {
-    if ( !canAdministerCheck() ) {
+    if ( !canManageACL() ) {
       throw new PentahoAccessControlException();
     }
 
@@ -112,14 +120,46 @@ public class AnalysisService extends DatasourceService {
                                  String catalogName, // Optional
                                  String origCatalogName, // Optional
                                  String datasourceName, // Optional
-                                 boolean overwrite, boolean xmlaEnabledFlag, String parameters )
+                                 boolean overwrite, boolean xmlaEnabledFlag, String parameters,
+                                 RepositoryFileAclDto acl )
     throws PentahoAccessControlException,
     PlatformImportException, Exception {
 
     accessValidation();
     String fileName = schemaFileInfo.getFileName();
     processMondrianImport( dataInputStream, catalogName, origCatalogName, overwrite, xmlaEnabledFlag, parameters,
-      fileName );
+        fileName, acl );
+  }
+
+  public RepositoryFileAclDto getAnalysisDatasourceAcl( String analysisId )
+      throws PentahoAccessControlException, FileNotFoundException {
+    checkAnalysisExists( analysisId );
+
+    if ( aclAwareMondrianCatalogService != null ) {
+      final RepositoryFileAcl acl = aclAwareMondrianCatalogService.getAclFor( analysisId );
+      return acl == null ? null : repositoryFileAclAdapter.marshal( acl );
+    }
+    return null;
+  }
+
+  public void setAnalysisDatasourceAcl( String analysisId, RepositoryFileAclDto aclDto )
+      throws PentahoAccessControlException, FileNotFoundException {
+    checkAnalysisExists( analysisId );
+
+    final RepositoryFileAcl acl = aclDto == null ? null : repositoryFileAclAdapter.unmarshal( aclDto );
+    if ( aclAwareMondrianCatalogService != null ) {
+      aclAwareMondrianCatalogService.setAclFor( analysisId, acl );
+    }
+    flushDataSources();
+  }
+
+  private void checkAnalysisExists( String analysisId ) throws FileNotFoundException, PentahoAccessControlException {
+    if ( !canManageACL() ) {
+      throw new PentahoAccessControlException();
+    }
+    if ( mondrianCatalogService.getCatalog( analysisId, PentahoSessionHolder.getSession() ) == null ) {
+      throw new FileNotFoundException( analysisId + " doesn't exist" );
+    }
   }
 
   /**
@@ -131,22 +171,24 @@ public class AnalysisService extends DatasourceService {
    * @param xmlaEnabledFlag
    * @param parameters
    * @param fileName
+   * @param acl acl information for the data source. This parameter is optional.
    * @throws PlatformImportException
    */
   protected void processMondrianImport( InputStream dataInputStream, String catalogName, String origCatalogName,
-                                      boolean overwrite, boolean xmlaEnabledFlag, String parameters, String fileName )
+                                      boolean overwrite, boolean xmlaEnabledFlag, String parameters, String fileName,
+                                      RepositoryFileAclDto acl )
     throws PlatformImportException {
     boolean overWriteInRepository = determineOverwriteFlag( parameters, overwrite );
     IPlatformImportBundle bundle =
-      createPlatformBundle( parameters, dataInputStream, catalogName, overWriteInRepository, fileName,
-        xmlaEnabledFlag );
+        createPlatformBundle( parameters, dataInputStream, catalogName, overWriteInRepository, fileName,
+        xmlaEnabledFlag, acl );
     if ( !StringUtils.isEmpty( origCatalogName ) && !bundle.getName().equals( origCatalogName ) ) {
       // MONDRIAN-1731
       // we are importing a mondrian catalog with a new schema (during edit), remove the old catalog first
       // processing the bundle without doing this will result in a new catalog, giving the effect of adding
       // a catalog rather than editing
       IMondrianCatalogService catalogService =
-        PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
+          PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
       catalogService.removeCatalog( origCatalogName, PentahoSessionHolder.getSession() );
     }
 
@@ -157,7 +199,7 @@ public class AnalysisService extends DatasourceService {
    * helper method to calculate the overwrite in repos flag from parameters or passed value
    *
    * @param parameters
-   * @param overwrite
+   * @param overWriteInRepository
    * @return boolean if overwrite is allowed
    */
   private boolean determineOverwriteFlag( String parameters, boolean overWriteInRepository ) {
@@ -177,18 +219,19 @@ public class AnalysisService extends DatasourceService {
    * @param overWriteInRepository
    * @param fileName
    * @param xmlaEnabled
+   * @param acl acl information for the data source. This parameter is optional.
    * @return IPlatformImportBundle
    */
   private IPlatformImportBundle createPlatformBundle( String parameters, InputStream dataInputStream,
                                                       String catalogName, boolean overWriteInRepository,
-                                                      String fileName, boolean xmlaEnabled ) {
+                                                      String fileName, boolean xmlaEnabled, RepositoryFileAclDto acl ) {
 
     byte[] bytes = null;
     try {
       bytes = IOUtils.toByteArray( dataInputStream );
       if ( bytes.length == 0 && catalogName != null ) {
         MondrianCatalogRepositoryHelper helper =
-          new MondrianCatalogRepositoryHelper( PentahoSystem.get( IUnifiedRepository.class ) );
+            new MondrianCatalogRepositoryHelper( PentahoSystem.get( IUnifiedRepository.class ) );
         Map<String, InputStream> fileData = helper.getModrianSchemaFiles( catalogName );
         dataInputStream = fileData.get( "schema.xml" );
         bytes = IOUtils.toByteArray( dataInputStream );
@@ -199,7 +242,7 @@ public class AnalysisService extends DatasourceService {
 
     String datasource = getValue( parameters, "Datasource" );
     String domainId =
-      this.determineDomainCatalogName( parameters, catalogName, fileName, new ByteArrayInputStream( bytes ) );
+        this.determineDomainCatalogName( parameters, catalogName, fileName, new ByteArrayInputStream( bytes ) );
     String sep = ";";
     if ( StringUtils.isEmpty( parameters ) ) {
       parameters = "Provider=mondrian";
@@ -208,9 +251,12 @@ public class AnalysisService extends DatasourceService {
     }
 
     RepositoryFileImportBundle.Builder bundleBuilder =
-      new RepositoryFileImportBundle.Builder().input( new ByteArrayInputStream( bytes ) ).charSet( UTF_8 ).hidden(
+        new RepositoryFileImportBundle.Builder().input( new ByteArrayInputStream( bytes ) ).charSet( UTF_8 ).hidden(
         false ).name( domainId ).overwriteFile( overWriteInRepository ).mime( MONDRIAN_MIME_TYPE ).withParam(
         PARAMETERS, parameters ).withParam( DOMAIN_ID, domainId );
+    if ( acl != null ) {
+      bundleBuilder.acl( repositoryFileAclAdapter.unmarshal( acl ) ).applyAclSettings( true );
+    }
     bundleBuilder.withParam( ENABLE_XMLA, Boolean.toString( xmlaEnabled ) );
 
     IPlatformImportBundle bundle = bundleBuilder.build();

--- a/src/org/pentaho/platform/dataaccess/datasource/api/DatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/DatasourceService.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api;
@@ -26,22 +26,31 @@ import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.dataaccess.datasource.utils.DataAccessPermissionUtil;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
+import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclAdapter;
 import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
 import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
 
 public class DatasourceService {
-
   protected IMetadataDomainRepository metadataDomainRepository;
   protected IMondrianCatalogService mondrianCatalogService;
+  protected RepositoryFileAclAdapter repositoryFileAclAdapter;
 
   public DatasourceService() {
     metadataDomainRepository = PentahoSystem.get( IMetadataDomainRepository.class, PentahoSessionHolder.getSession() );
     mondrianCatalogService = PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
+    repositoryFileAclAdapter = new RepositoryFileAclAdapter();
+  }
+
+  protected IUnifiedRepository getRepository() {
+    return PentahoSystem.get( IUnifiedRepository.class );
   }
 
   public static boolean canAdminister() {
@@ -53,11 +62,17 @@ public class DatasourceService {
   public static void validateAccess() throws PentahoAccessControlException {
     IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
     boolean isAdmin =
-      policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
+        policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
         && ( policy.isAllowed( AdministerSecurityAction.NAME ) || policy.isAllowed( PublishAction.NAME ) );
     if ( !isAdmin ) {
       throw new PentahoAccessControlException( "Access Denied" );
     }
+  }
+
+  protected boolean canManageACL() {
+    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
+    return policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
+      && DataAccessPermissionUtil.hasManageAccess();
   }
 
   /**
@@ -108,8 +123,13 @@ public class DatasourceService {
     if ( fileData.containsKey( keySchema ) ) {
       final int xmiIndex = dswId.lastIndexOf( ".xmi" ); //$NON-NLS-1$
       fileData.put( ( xmiIndex > 0 ? dswId.substring( 0, xmiIndex ) : dswId ) + ".mondrian.xml",
-        fileData.get( keySchema ) ); //$NON-NLS-1$
+          fileData.get( keySchema ) ); //$NON-NLS-1$
       fileData.remove( keySchema );
     }
+  }
+
+  protected void flushDataSources() {
+    metadataDomainRepository.flushDomains();
+    mondrianCatalogService.reInit( PentahoSessionHolder.getSession() );
   }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -20,9 +20,9 @@ package org.pentaho.platform.dataaccess.datasource.api.resources;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static javax.ws.rs.core.MediaType.WILDCARD;
-import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static javax.ws.rs.core.Response.Status.*;
 
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +53,7 @@ import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.services.importer.PlatformImportException;
 import org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 import org.pentaho.platform.web.http.api.resources.FileResource;
 import org.pentaho.platform.web.http.api.resources.JaxbList;
 
@@ -69,15 +70,20 @@ public class MetadataResource {
   private static final Log logger = LogFactory.getLog( MetadataResource.class );
   protected static final String OVERWRITE_IN_REPOS = "overwrite";
   private static final String SUCCESS = "3";
+  private static final String DATASOURCE_ACL = "acl";
 
   protected MetadataService service;
   protected IMetadataDomainRepository metadataDomainRepository;
   protected ResourceUtil resourceUtil;
 
   public MetadataResource() {
-    service = new MetadataService();
+    service = createMetadataService();
     resourceUtil = new ResourceUtil();
     metadataDomainRepository = PentahoSystem.get( IMetadataDomainRepository.class, PentahoSessionHolder.getSession() );
+  }
+
+  protected MetadataService createMetadataService() {
+    return new MetadataService();
   }
 
   /**
@@ -178,11 +184,13 @@ public class MetadataResource {
                                                   @FormDataParam(OVERWRITE_IN_REPOS) String overwrite,
                                                   @FormDataParam("localeFiles") List<FormDataBodyPart> localeFiles,
                                                   @FormDataParam("localeFiles")
-                                                  List<FormDataContentDisposition> localeFilesInfo ) {
+                                                  List<FormDataContentDisposition> localeFilesInfo,
+                                                  @FormDataParam( DATASOURCE_ACL )
+                                                  RepositoryFileAclDto acl ) {
     try {
       boolean overWriteInRepository = "True".equalsIgnoreCase( overwrite ) ? true : false;      
       service.importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overWriteInRepository, localeFiles,
-        localeFilesInfo );
+        localeFilesInfo, acl );
       return Response.ok().status( new Integer( SUCCESS ) ).type( MediaType.TEXT_PLAIN ).build();
     } catch ( PentahoAccessControlException e ) {
       return buildServerErrorResponse( e );
@@ -237,6 +245,7 @@ public class MetadataResource {
    * @param localeFiles List of local files
    * @param localeFilesInfo List of information for each local file
    * @param overwrite Flag for overwriting existing version of the file
+   * @param acl acl information for the data source. This parameter is optional.
    *
    * @return Text response containing the status of the call.
    *
@@ -263,10 +272,11 @@ public class MetadataResource {
       @FormDataParam( "metadataFile" ) FormDataContentDisposition metadataFileInfo,
       @FormDataParam( OVERWRITE_IN_REPOS ) Boolean overwrite,
       @FormDataParam( "localeFiles" ) List<FormDataBodyPart> localeFiles,
-      @FormDataParam( "localeFiles" ) List<FormDataContentDisposition> localeFilesInfo ) {
+      @FormDataParam( "localeFiles" ) List<FormDataContentDisposition> localeFilesInfo,
+      @FormDataParam( DATASOURCE_ACL ) RepositoryFileAclDto acl ) {
     try {
       service.importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles,
-          localeFilesInfo );
+          localeFilesInfo, acl );
       return Response.status( CREATED ).build();
     } catch ( PentahoAccessControlException e ) {
       throw new WebApplicationException( Response.Status.UNAUTHORIZED );
@@ -302,6 +312,7 @@ public class MetadataResource {
    * @param overwrite
    * @param localeFiles
    * @param localeFilesInfo
+   * @param acl acl information for the data source. This parameter is optional.
    * @return
    */
   protected Response importMetadataDatasource( @FormDataParam( "domainId" ) String domainId,
@@ -310,11 +321,13 @@ public class MetadataResource {
                                             @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
                                             @FormDataParam( "localeFiles" ) List<FormDataBodyPart> localeFiles,
                                             @FormDataParam( "localeFiles" )
-                                            List<FormDataContentDisposition> localeFilesInfo ) {
+                                            List<FormDataContentDisposition> localeFilesInfo,
+                                            @FormDataParam( DATASOURCE_ACL )
+                                            RepositoryFileAclDto acl) {
     try {
       boolean overWriteInRepository = "True".equalsIgnoreCase( overwrite ) ? true : false;
       service.importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overWriteInRepository, localeFiles,
-          localeFilesInfo );
+          localeFilesInfo, acl );
       return Response.ok().status( new Integer( SUCCESS ) ).type( MediaType.TEXT_PLAIN ).build();
     } catch ( PentahoAccessControlException e ) {
       return buildServerErrorResponse( e );
@@ -448,7 +461,72 @@ public class MetadataResource {
                                             @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
                                             @FormDataParam( "localeFiles" ) List<FormDataBodyPart> localeFiles,
                                             @FormDataParam( "localeFiles" )
-                                            List<FormDataContentDisposition> localeFilesInfo ) {
-    return importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo );
+                                            List<FormDataContentDisposition> localeFilesInfo,
+                                            @FormDataParam( DATASOURCE_ACL )
+                                            RepositoryFileAclDto acl) {
+    return importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo, acl );
+  }
+
+  /**
+   * Get ACL for the metadata data source by name
+   *
+   * @param   domainId metadata data source name
+   * @return  ACL or null if the data source doesn't have it
+   */
+  @GET
+  @Path( "/{domainId : .+}/acl" )
+  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @StatusCodes( {
+      @ResponseCode( code = 200, condition = "Successfully got the ACL" ),
+      @ResponseCode( code = 401, condition = "Unauthorized" ),
+      @ResponseCode( code = 404, condition = "ACL doesn't exist" ),
+      @ResponseCode( code = 409, condition = "Metadata DS doesn't exist" ),
+      @ResponseCode(
+          code = 500,
+          condition = "ACL failed to be retrieved. This could be caused by an invalid path, or the file does not exist."
+      )
+      } )
+      public RepositoryFileAclDto doGetMetadataAcl( @PathParam( "domainId" ) String domainId ) {
+    try {
+      final RepositoryFileAclDto acl = service.getMetadataAcl( domainId );
+      if ( acl == null ) {
+        throw new WebApplicationException( NOT_FOUND );
+      }
+      return acl;
+    } catch ( PentahoAccessControlException e ) {
+      throw new WebApplicationException( UNAUTHORIZED );
+    } catch ( FileNotFoundException e) {
+      throw new WebApplicationException( CONFLICT );
+    }
+  }
+
+  /**
+   * Set ACL for the metadata data source
+   *
+   * @param domainId  metadata data source name
+   * @param acl       ACL to set
+   * @return          response
+   * @throws          PentahoAccessControlException if the user doesn't have access
+   */
+  @PUT
+  @Path( "/{domainId : .+}/acl" )
+  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @StatusCodes( {
+      @ResponseCode( code = 200, condition = "Successfully updated the ACL" ),
+      @ResponseCode( code = 401, condition = "Unauthorized" ),
+      @ResponseCode( code = 409, condition = "Metadata DS doesn't exist" ),
+      @ResponseCode( code = 500, condition = "Failed to save acls due to another error." )
+      } )
+      public Response doSetMetadataAcl( @PathParam( "domainId" ) String domainId, RepositoryFileAclDto acl ) {
+    try {
+      service.setMetadataAcl( domainId, acl );
+      return buildOkResponse();
+    } catch ( PentahoAccessControlException e ) {
+      return buildUnauthorizedResponse();
+    } catch ( FileNotFoundException e) {
+      return Response.status( CONFLICT ).build();
+    } catch ( Exception e ) {
+      return buildServerErrorResponse();
+    }
   }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
@@ -20,6 +20,7 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 import java.io.InputStream;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -37,12 +38,13 @@ import org.pentaho.platform.plugin.services.importer.PlatformImportException;
 
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataParam;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 
 @Path( "/data-access/api/mondrian" )
 public class AnalysisDatasourceService {
-  
+
   private static final Log logger = LogFactory.getLog( AnalysisDatasourceService.class );
-  
+
   private static final String XMLA_ENABLED_FLAG = "xmlaEnabledFlag";
   private static final String CATALOG_NAME = "catalogName";
   private static final String ORIG_CATALOG_NAME = "origCatalogName";
@@ -50,6 +52,7 @@ public class AnalysisDatasourceService {
   private static final String UPLOAD_ANALYSIS = "uploadAnalysis";
   private static final String PARAMETERS = "parameters";
   private static final String OVERWRITE_IN_REPOS = "overwrite";
+  private static final String DATASOURCE_ACL = "acl";
   private static final int SUCCESS = 3;
 
   /**
@@ -62,6 +65,7 @@ public class AnalysisDatasourceService {
    * @param overwrite
    * @param xmlaEnabledFlag
    * @param parameters
+   * @param acl acl information for the data source. This parameter is optional.
    * @return this method returns a response of "3" for success, 8 if exists, etc.
    * @throws PentahoAccessControlException
    */
@@ -77,7 +81,8 @@ public class AnalysisDatasourceService {
       @FormDataParam( ORIG_CATALOG_NAME ) String origCatalogName, // Optional
       @FormDataParam( DATASOURCE_NAME ) String datasourceName, // Optional
       @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
-      @FormDataParam( XMLA_ENABLED_FLAG ) String xmlaEnabledFlag, @FormDataParam( PARAMETERS ) String parameters )
+      @FormDataParam( XMLA_ENABLED_FLAG ) String xmlaEnabledFlag, @FormDataParam( PARAMETERS ) String parameters,
+      @FormDataParam( DATASOURCE_ACL ) RepositoryFileAclDto acl )
     throws PentahoAccessControlException {
     Response response = null;
     int statusCode = PlatformImportException.PUBLISH_GENERAL_ERROR;
@@ -86,7 +91,7 @@ public class AnalysisDatasourceService {
       boolean overWriteInRepository = "True".equalsIgnoreCase( overwrite ) ? true : false;
       boolean xmlaEnabled = "True".equalsIgnoreCase( xmlaEnabledFlag ) ? true : false;
       service.putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-          overWriteInRepository, xmlaEnabled, parameters );
+          overWriteInRepository, xmlaEnabled, parameters, acl );
       statusCode = SUCCESS;
     } catch ( PentahoAccessControlException pac ) {
       logger.error( pac.getMessage() );
@@ -114,6 +119,7 @@ public class AnalysisDatasourceService {
    * @param overwrite
    * @param xmlaEnabledFlag
    * @param parameters
+   * @param acl acl information for the data source. This parameter is optional.
    * @return this method returns a response of "SUCCESS" for success, 8 if exists, 2 for general error,etc.
    * @throws PentahoAccessControlException
    */
@@ -129,13 +135,14 @@ public class AnalysisDatasourceService {
       @FormDataParam( ORIG_CATALOG_NAME ) String origCatalogName, // Optional
       @FormDataParam( DATASOURCE_NAME ) String datasourceName, // Optional
       @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
-      @FormDataParam( XMLA_ENABLED_FLAG ) String xmlaEnabledFlag, @FormDataParam( PARAMETERS ) String parameters )
+      @FormDataParam( XMLA_ENABLED_FLAG ) String xmlaEnabledFlag, @FormDataParam( PARAMETERS ) String parameters,
+      @FormDataParam( DATASOURCE_ACL ) RepositoryFileAclDto acl )
     throws PentahoAccessControlException {
     // use existing Jersey post method - but translate into text/html for PUC Client
     ResponseBuilder responseBuilder;
     Response response =
         this.putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-            overwrite, xmlaEnabledFlag, parameters );
+            overwrite, xmlaEnabledFlag, parameters, acl );
     responseBuilder = Response.ok();
     responseBuilder.entity( String.valueOf( response.getStatus() ) );
     responseBuilder.status( 200 );

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MetadataDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/MetadataDatasourceService.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
@@ -28,12 +28,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -53,11 +48,13 @@ import org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainReposi
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataBodyPart;
 import com.sun.jersey.multipart.FormDataParam;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 
 @Path( "/data-access/api/metadata" )
 public class MetadataDatasourceService {
   
   private static final String OVERWRITE_IN_REPOS = "overwrite";
+  private static final String DATASOURCE_ACL = "acl";
   private static final String LANG = "[a-z]{2}";
   private static final String LANG_CC = LANG + "_[A-Z]{2}";
   private static final String LANG_CC_EXT = LANG_CC + "_[^/]+";
@@ -234,6 +231,8 @@ public class MetadataDatasourceService {
    *          List of local files
    * @param localeFilesInfo
    *          List of information for each local file
+   * @param acl
+   *          acl information for the data source. This parameter is optional.
    * 
    * @return Response containing the success of the method
    * 
@@ -253,10 +252,11 @@ public class MetadataDatasourceService {
       @FormDataParam( "metadataFile" ) FormDataContentDisposition metadataFileInfo,
       @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
       @FormDataParam( "localeFiles" ) List<FormDataBodyPart> localeFiles,
-      @FormDataParam( "localeFiles" ) List<FormDataContentDisposition> localeFilesInfo )
+      @FormDataParam( "localeFiles" ) List<FormDataContentDisposition> localeFilesInfo,
+      @FormDataParam( DATASOURCE_ACL ) RepositoryFileAclDto acl )
     throws PentahoAccessControlException {
     Response response =
-        importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo );
+        importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo, acl );
     ResponseBuilder responseBuilder;
     responseBuilder = Response.ok();
     responseBuilder.entity( String.valueOf( response.getStatus() ) );
@@ -277,6 +277,8 @@ public class MetadataDatasourceService {
    *          List of information for each local file
    * @param overwrite
    *          Flag for overwriting existing version of the file
+   * @param acl
+   *          acl information for the data source. This parameter is optional.
    * 
    * @return Response containing the success of the method
    * 
@@ -292,8 +294,9 @@ public class MetadataDatasourceService {
       @FormDataParam( "metadataFile" ) FormDataContentDisposition metadataFileInfo,
       @FormDataParam( OVERWRITE_IN_REPOS ) String overwrite,
       @FormDataParam( "localeFiles" ) List<FormDataBodyPart> localeFiles,
-      @FormDataParam( "localeFiles" ) List<FormDataContentDisposition> localeFilesInfo ) {
+      @FormDataParam( "localeFiles" ) List<FormDataContentDisposition> localeFilesInfo,
+      @FormDataParam( DATASOURCE_ACL ) RepositoryFileAclDto acl ) {
     return new MetadataResource().importMetadataDatasourceLegacy( domainId, metadataFile, metadataFileInfo, overwrite,
-        localeFiles, localeFilesInfo );
+        localeFiles, localeFilesInfo, acl );
   }
 }

--- a/test-res/schema.xml
+++ b/test-res/schema.xml
@@ -1,0 +1,6 @@
+<Schema name="FoodMart">  <Cube name="Sales" defaultMeasure="Unit Sales">    <Table name="sales_fact_1997"/>  <Dimension name="customer">
+    <Hierarchy hasAll="true" primaryKey="customer_id">
+      <Table name="sales_fact_1997"/>
+      <Level name="customer id" type="Integer" column="customer_id" uniqueMembers="true"/>
+    </Hierarchy>
+  </Dimension>    <Measure name="Unit Sales" column="unit_sales" aggregator="sum" formatString="Standard"/>  </Cube></Schema>

--- a/test-src/org/pentaho/platform/dataaccess/datasource/DataSourcePublishACLTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/DataSourcePublishACLTest.java
@@ -1,0 +1,635 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+*/
+
+package org.pentaho.platform.dataaccess.datasource;
+
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.core.header.FormDataContentDisposition;
+import com.sun.jersey.multipart.FormDataBodyPart;
+import com.sun.jersey.multipart.FormDataMultiPart;
+import com.sun.jersey.multipart.MultiPart;
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.WebAppDescriptor;
+import com.sun.jersey.test.framework.spi.container.TestContainerException;
+import com.sun.jersey.test.framework.spi.container.TestContainerFactory;
+import com.sun.jersey.test.framework.spi.container.grizzly.web.GrizzlyWebTestContainerFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.metadata.repository.IMetadataDomainRepository;
+import org.pentaho.platform.api.engine.IAclVoter;
+import org.pentaho.platform.api.engine.ICacheManager;
+import org.pentaho.platform.api.engine.IPluginResourceLoader;
+import org.pentaho.platform.api.engine.ISystemConfig;
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.config.SystemConfig;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.IDataAccessPermissionHandler;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.IDataAccessViewPermissionHandler;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessPermissionHandler;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessViewPermissionHandler;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.core.system.TenantUtils;
+import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
+import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogHelper;
+import org.pentaho.platform.plugin.services.importer.IPlatformImportMimeResolver;
+import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
+import org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepositoryInfo;
+import org.pentaho.platform.plugin.services.pluginmgr.PluginResourceLoader;
+import org.pentaho.platform.repository2.ClientRepositoryPaths;
+import org.pentaho.platform.repository2.unified.DefaultUnifiedRepositoryBase;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclAceDto;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
+import org.pentaho.platform.web.http.api.resources.JaxbList;
+import org.pentaho.platform.web.http.filters.PentahoRequestContextFilter;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.security.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Aliaksei_Haidukou on 12/12/2014.
+ */
+@RunWith( SpringJUnit4ClassRunner.class )
+@ContextConfiguration( locations = { "classpath:/repository.spring.xml",
+    "classpath:/solutionACL/system/repository-test-override.spring.xml",
+    "classpath:/solutionACL/system/importExport.xml", "classpath:/solutionACL/system/pentahoObjects.spring.xml" } )
+public class DataSourcePublishACLTest extends JerseyTest implements ApplicationContextAware {
+  private static final String USERNAME_SUZY = "suzy";
+  private static final String USERNAME_TIFFANY = "tiffany";
+  private static final String PASSWORD = "password";
+  private static final String AUTHENTICATED_ROLE_NAME = "Authenticated";
+
+  private static final String DATA_ACCESS_API_DATASOURCE_METADATA = "data-access/api/datasource/metadata/";
+  private static final String DATA_ACCESS_API_DATASOURCE_DSW = "data-access/api/datasource/dsw/";
+
+  private static WebAppDescriptor webAppDescriptor = new WebAppDescriptor.Builder(
+      new String[] {
+          "org.pentaho.platform.dataaccess.datasource.api.resources",
+          "org.pentaho.platform.dataaccess.datasource.wizard.service.impl"
+      } ).contextPath( "plugin" ).addFilter(
+      PentahoRequestContextFilter.class, "pentahoRequestContextFilter" ).build();
+
+  private ApplicationContext applicationContext;
+  private ITenant defaultTenant;
+  private DefaultUnifiedRepositoryBase repositoryBase;
+  private String singleTenantAdminUserName;
+  public static final String DATA_ACCESS_API_DATASOURCE_ANALYSIS = "data-access/api/datasource/analysis/";
+
+  public DataSourcePublishACLTest() throws TestContainerException {
+    repositoryBase = new DefaultUnifiedRepositoryBase() {
+      @Override
+      protected String getSolutionPath() {
+        return "test-src/solutionACL";
+      }
+
+      @Override public void login( String username, ITenant tenant, String[] roles ) {
+        super.login( username, tenant, roles );
+        try {
+          PentahoSystem.get( IMetadataDomainRepository.class ).flushDomains();
+          PentahoSystem.get( IMondrianCatalogService.class ).reInit( PentahoSessionHolder.getSession() );
+        } catch ( Exception e ) {
+          // do nothing
+        }
+      }
+    };
+  }
+
+  @Override
+  protected AppDescriptor configure() {
+    return webAppDescriptor;
+  }
+
+  @Override
+  protected TestContainerFactory getTestContainerFactory() {
+    return new GrizzlyWebTestContainerFactory();
+  }
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    DefaultUnifiedRepositoryBase.setUpClass();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    repositoryBase.setUp();
+
+    repositoryBase.loginAsRepositoryAdmin();
+
+    defaultTenant = repositoryBase.createTenant( repositoryBase.getSystemTenant(), TenantUtils.getDefaultTenant() );
+
+    singleTenantAdminUserName = (String) applicationContext.getBean( "singleTenantAdminUserName" );
+    repositoryBase.createUser( defaultTenant, singleTenantAdminUserName, PASSWORD, repositoryBase.getTenantAdminRoleName() );
+    final String singleTenantAuthenticatedAuthorityName =
+        (String) applicationContext.getBean( "singleTenantAuthenticatedAuthorityName" );
+    repositoryBase.createUser( defaultTenant, USERNAME_SUZY, PASSWORD, singleTenantAuthenticatedAuthorityName );
+    repositoryBase.createUser( defaultTenant, USERNAME_TIFFANY, PASSWORD, singleTenantAuthenticatedAuthorityName );
+
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant, new String[] { repositoryBase.getTenantAdminRoleName() } );
+
+    final IUnifiedRepository repo = PentahoSystem.get( IUnifiedRepository.class );
+
+    String etcID = String.valueOf( repo.getFile( ClientRepositoryPaths.getEtcFolderPath() ).getId() );
+    repo.createFolder( etcID, new RepositoryFile.Builder( MondrianCatalogHelper.MONDRIAN_DATASOURCE_FOLDER ).folder( true ).build(), "initialization" );
+    repo.createFolder( etcID, new RepositoryFile.Builder( PentahoMetadataDomainRepositoryInfo.getMetadataFolderName() ).folder( true ).build(), "initialization" );
+
+    final MicroPlatform mp = repositoryBase.getMp();
+    mp.define( IMondrianCatalogService.class, MondrianCatalogHelper.class );
+    mp.define( ISystemConfig.class, SystemConfig.class );
+    mp.defineInstance( IPlatformImportMimeResolver.class, applicationContext.getBean( "IPlatformImportMimeResolver" ) );
+    mp.defineInstance( IPlatformImporter.class, applicationContext.getBean( "IPlatformImporter" ) );
+
+    mp.defineInstance( ICacheManager.class, applicationContext.getBean( "ICacheManager" ) );
+    mp.defineInstance( IMetadataDomainRepository.class, applicationContext.getBean( "IMetadataDomainRepository" ) );
+
+    final PluginResourceLoader pluginResourceLoader = (PluginResourceLoader) applicationContext.getBean( "IPluginResourceLoader" );
+    pluginResourceLoader.setRootDir( new File( "test-src/solutionACL/system/data-access" ) );
+    mp.defineInstance( IPluginResourceLoader.class, pluginResourceLoader );
+    mp.define( IDataAccessPermissionHandler.class, SimpleDataAccessPermissionHandler.class );
+    mp.define( IDataAccessViewPermissionHandler.class, SimpleDataAccessViewPermissionHandler.class );
+    mp.defineInstance( IAclVoter.class, applicationContext.getBean( "IAclVoter" ) );
+
+    SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
+    super.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    repositoryBase.loginAsRepositoryAdmin();
+    PentahoSystem.get( IMetadataDomainRepository.class ).flushDomains();
+
+    repositoryBase.cleanupUserAndRoles( defaultTenant );
+    applicationContext = null;
+    defaultTenant = null;
+
+    repositoryBase.tearDown();
+
+    super.tearDown();
+  }
+
+  @Test
+  public void testPublishAnalysis() throws Exception {
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+
+    final String catalogID = "FoodMart";
+    final InputStream uploadAnalysis = new FileInputStream( "test-res/schema.xml" );
+    final boolean overwrite = true;
+    final boolean xmlaEnabledFlag = false;
+    final String parameters = "DataSource=" + catalogID + ";EnableXmla=" + xmlaEnabledFlag + ";overwrite=" + overwrite;
+
+    final RepositoryFileAclDto acl = generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER );
+
+    MultiPart part = new FormDataMultiPart()
+        .field( "catalogName", catalogID )
+        .field( "datasourceName", catalogID )
+        .field( "overwrite", String.valueOf( overwrite ) )
+        .field( "xmlaEnabledFlag", String.valueOf( xmlaEnabledFlag ) )
+        .field( "acl", marshalACL( acl ) )
+        .field( "parameters", parameters )
+        .bodyPart(
+            new FormDataBodyPart(
+                FormDataContentDisposition.name( "uploadAnalysis" )
+                    .fileName( "schema.xml" )
+                    .size( uploadAnalysis.available() )
+                    .build()
+                , uploadAnalysis, MediaType.TEXT_XML_TYPE )
+        );
+
+    WebResource webResource = resource();
+
+    ClientResponse postAnalysis = webResource.path( "data-access/api/mondrian/postAnalysis" )
+        .type( MediaType.MULTIPART_FORM_DATA_TYPE )
+        .post( ClientResponse.class, part );
+    assertEquals( Response.Status.OK.getStatusCode(), postAnalysis.getStatus() );
+
+    final RepositoryFileAclDto savedACL = webResource
+        .path( "data-access/api/datasource/analysis/" + catalogID + "/acl" )
+        .get( ClientResponse.class ).getEntity( RepositoryFileAclDto.class );
+    assertNotNull( savedACL );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkAnalysis( webResource, catalogID, true );
+
+    repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkAnalysis( webResource, catalogID, false );
+
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+    final ClientResponse changeACL = webResource
+        .path( "data-access/api/datasource/analysis/" + catalogID + "/acl" )
+        .put( ClientResponse.class, generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ) );
+    assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
+
+    repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkAnalysis( webResource, catalogID, true );
+  }
+
+  @Test
+  public void testAnalysis_ACL() throws Exception {
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+
+    final String catalogID = "FoodMart";
+    final InputStream uploadAnalysis = new FileInputStream( "test-res/schema.xml" );
+    final boolean overwrite = true;
+    final boolean xmlaEnabledFlag = false;
+    final String parameters = "DataSource=" + catalogID + ";EnableXmla=" + xmlaEnabledFlag + ";overwrite=" + overwrite;
+
+    MultiPart part = new FormDataMultiPart()
+        .field( "catalogName", catalogID )
+        .field( "datasourceName", catalogID )
+        .field( "overwrite", String.valueOf( overwrite ) )
+        .field( "xmlaEnabledFlag", String.valueOf( xmlaEnabledFlag ) )
+        .field( "parameters", parameters )
+        .bodyPart(
+            new FormDataBodyPart(
+                FormDataContentDisposition.name( "uploadAnalysis" )
+                    .fileName( "schema.xml" )
+                    .size( uploadAnalysis.available() )
+                    .build()
+                , uploadAnalysis, MediaType.TEXT_XML_TYPE )
+        );
+
+    WebResource webResource = resource();
+
+    final ClientResponse noAnalysis = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.CONFLICT.getStatusCode(), noAnalysis.getStatus() );
+
+    ClientResponse postAnalysis = webResource.path( "data-access/api/mondrian/postAnalysis" )
+        .type( MediaType.MULTIPART_FORM_DATA_TYPE )
+        .post( ClientResponse.class, part );
+    assertEquals( Response.Status.OK.getStatusCode(), postAnalysis.getStatus() );
+
+    final ClientResponse noACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.NOT_FOUND.getStatusCode(), noACL.getStatus() );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkAnalysis( webResource, catalogID, true );
+
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+    final ClientResponse changeACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" )
+        .put( ClientResponse.class, generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ) );
+    assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkAnalysis( webResource, catalogID, true );
+
+    final ClientResponse noAccessACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
+
+    final ClientResponse noAccessACLNoDS = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "_not_exist/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
+  }
+
+  private void checkAnalysis( WebResource webResource, String catalogID, boolean hasAccess ) {
+    final JaxbList analysisDatasourceIds = webResource
+          .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + "ids" )
+          .get( JaxbList.class );
+
+    final List list = analysisDatasourceIds.getList();
+    if ( hasAccess ) {
+      assertTrue( list != null && list.contains( catalogID ) );
+    } else if ( list != null ) {
+      assertFalse( list.contains( catalogID ) );
+    }
+  }
+
+  @Test
+  public void testPublishMetadata() throws Exception {
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+
+    final String domainID = "domainID";
+    final FileInputStream metadataFile = new FileInputStream( "test-res/Sample_SQL_Query.xmi" );
+    final String overwrite = "true";
+    final RepositoryFileAclDto acl = generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER );
+
+    MultiPart part = new FormDataMultiPart()
+        .field( "domainId", domainID )
+        .field( "overwrite", String.valueOf( overwrite ) )
+        .field( "acl", marshalACL( acl ) )
+        .bodyPart(
+            new FormDataBodyPart(
+                FormDataContentDisposition.name( "metadataFile" )
+                    .fileName( "Sample_SQL_Query.xmi" )
+                    .size( metadataFile.available() )
+                    .build()
+                , metadataFile, MediaType.TEXT_XML_TYPE )
+        );
+
+    WebResource webResource = resource();
+
+    ClientResponse postAnalysis = webResource.path( "data-access/api/metadata/import" )
+        .type( MediaType.MULTIPART_FORM_DATA_TYPE )
+        .put( ClientResponse.class, part );
+    assertEquals( 3, postAnalysis.getStatus() );
+
+    final RepositoryFileAclDto savedACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
+        .get( ClientResponse.class ).getEntity( RepositoryFileAclDto.class );
+    assertNotNull( savedACL );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkMetadata( webResource, domainID, true );
+
+    repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkMetadata( webResource, domainID, false );
+
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+    final ClientResponse changeACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
+        .put( ClientResponse.class, generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ) );
+    assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
+
+    repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkMetadata( webResource, domainID, true );
+  }
+
+  @Test
+  public void testMetadata_ACL() throws Exception {
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+
+    final String domainID = "domainID";
+    final FileInputStream metadataFile = new FileInputStream( "test-res/Sample_SQL_Query.xmi" );
+    final String overwrite = "true";
+
+    MultiPart part = new FormDataMultiPart()
+        .field( "domainId", domainID )
+        .field( "overwrite", String.valueOf( overwrite ) )
+        .bodyPart(
+            new FormDataBodyPart(
+                FormDataContentDisposition.name( "metadataFile" )
+                    .fileName( "Sample_SQL_Query.xmi" )
+                    .size( metadataFile.available() )
+                    .build()
+                , metadataFile, MediaType.TEXT_XML_TYPE )
+        );
+
+    WebResource webResource = resource();
+
+    final ClientResponse noMetadata = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.CONFLICT.getStatusCode(), noMetadata.getStatus() );
+
+    ClientResponse postAnalysis = webResource.path( "data-access/api/metadata/import" )
+        .type( MediaType.MULTIPART_FORM_DATA_TYPE )
+        .put( ClientResponse.class, part );
+    assertEquals( 3, postAnalysis.getStatus() );
+
+    final ClientResponse noACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.NOT_FOUND.getStatusCode(), noACL.getStatus() );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkMetadata( webResource, domainID, true );
+
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+    final ClientResponse changeACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
+        .put( ClientResponse.class, generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ) );
+    assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkMetadata( webResource, domainID, true );
+
+    final ClientResponse noAccessACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
+
+    final ClientResponse noAccessACLNoDS = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "_not_exist/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
+  }
+
+  private void checkMetadata( WebResource webResource, String domainID, boolean hasAccess ) {
+    final JaxbList metadataDatasourceIds = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_METADATA + "ids" )
+        .get( JaxbList.class );
+
+    final List list = metadataDatasourceIds.getList();
+    if ( hasAccess ) {
+      assertTrue( list != null && list.contains( domainID ) );
+    } else if ( list != null ) {
+      assertFalse( list.contains( domainID ) );
+    }
+  }
+
+  @Test
+  public void testPublishDSW() throws Exception {
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+
+    final String domainID = "test.xmi";
+    final FileInputStream metadataFile = new FileInputStream( "test-res/test.xmi" );
+    final boolean overwrite = true;
+    final RepositoryFileAclDto acl = generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER );
+
+    MultiPart part = new FormDataMultiPart()
+        .field( "domainId", domainID )
+        .field( "overwrite", String.valueOf( overwrite ) )
+        .field( "acl", marshalACL( acl ) )
+        .bodyPart(
+            new FormDataBodyPart(
+                FormDataContentDisposition.name( "metadataFile" )
+                    .fileName( "test.xmi" )
+                    .size( metadataFile.available() )
+                    .build()
+                , metadataFile, MediaType.TEXT_XML_TYPE )
+        );
+
+    WebResource webResource = resource();
+
+    ClientResponse postAnalysis = webResource.path( DATA_ACCESS_API_DATASOURCE_DSW + "import" )
+        .type( MediaType.MULTIPART_FORM_DATA_TYPE )
+        .put( ClientResponse.class, part );
+    assertEquals( Response.Status.OK.getStatusCode(), postAnalysis.getStatus() );
+
+    final RepositoryFileAclDto savedACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
+        .get( ClientResponse.class ).getEntity( RepositoryFileAclDto.class );
+    assertNotNull( savedACL );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkDSW( webResource, domainID, true );
+
+    repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkDSW( webResource, domainID, false );
+
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+    final ClientResponse changeACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
+        .put( ClientResponse.class, generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ) );
+    assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
+
+    repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkDSW( webResource, domainID, true );
+  }
+
+  @Test
+  public void testDSW_ACL() throws Exception {
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+
+    final String domainID = "test.xmi";
+    final FileInputStream metadataFile = new FileInputStream( "test-res/test.xmi" );
+    final boolean overwrite = true;
+
+    MultiPart part = new FormDataMultiPart()
+        .field( "domainId", domainID )
+        .field( "overwrite", String.valueOf( overwrite ) )
+        .bodyPart(
+            new FormDataBodyPart(
+                FormDataContentDisposition.name( "metadataFile" )
+                    .fileName( "test.xmi" )
+                    .size( metadataFile.available() )
+                    .build()
+                , metadataFile, MediaType.TEXT_XML_TYPE )
+        );
+
+    WebResource webResource = resource();
+
+    final ClientResponse noDSW = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.CONFLICT.getStatusCode(), noDSW.getStatus() );
+
+    ClientResponse postAnalysis = webResource.path( DATA_ACCESS_API_DATASOURCE_DSW + "import" )
+        .type( MediaType.MULTIPART_FORM_DATA_TYPE )
+        .put( ClientResponse.class, part );
+    assertEquals( Response.Status.OK.getStatusCode(), postAnalysis.getStatus() );
+
+    final ClientResponse noACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.NOT_FOUND.getStatusCode(), noACL.getStatus() );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkDSW( webResource, domainID, true );
+
+    repositoryBase.login( singleTenantAdminUserName, defaultTenant,
+        new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
+    final ClientResponse setSuzyACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
+        .put( ClientResponse.class, generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ) );
+    assertEquals( Response.Status.OK.getStatusCode(), setSuzyACL.getStatus() );
+
+    repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
+    checkDSW( webResource, domainID, true );
+
+    final ClientResponse noAccessACL = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
+
+    final ClientResponse noAccessACLNoDS = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "_not_exist/acl" )
+        .get( ClientResponse.class );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
+  }
+
+  private void checkDSW( WebResource webResource, String domainID, boolean hasAccess ) {
+    final JaxbList dswIds = webResource
+        .path( DATA_ACCESS_API_DATASOURCE_DSW + "ids" )
+        .get( JaxbList.class );
+
+    final List list = dswIds.getList();
+    if ( hasAccess ) {
+      assertTrue( list != null && list.contains( domainID ) );
+    } else if ( list != null ) {
+      assertFalse( list.contains( domainID ) );
+    }
+  }
+
+  private RepositoryFileAclDto generateACL( String userOrRole, RepositoryFileSid.Type type ) {
+    final RepositoryFileAclDto aclDto = new RepositoryFileAclDto();
+    aclDto.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
+    aclDto.setOwner( singleTenantAdminUserName );
+    aclDto.setEntriesInheriting( false );
+
+    final ArrayList<RepositoryFileAclAceDto> aces = new ArrayList<RepositoryFileAclAceDto>();
+    final RepositoryFileAclAceDto aceDto = new RepositoryFileAclAceDto();
+    aceDto.setRecipient( userOrRole );
+    aceDto.setRecipientType( type.ordinal() );
+
+    final ArrayList<Integer> permissions = new ArrayList<Integer>();
+    permissions.add( RepositoryFilePermission.ALL.ordinal() );
+    aceDto.setPermissions( permissions );
+    aces.add( aceDto );
+
+    aclDto.setAces( aces );
+    return aclDto;
+  }
+
+  private static String marshalACL( RepositoryFileAclDto acl ) throws JAXBException {
+    JAXBContext context = JAXBContext.newInstance( RepositoryFileAclDto.class );
+    Marshaller marshaller = context.createMarshaller();
+    StringWriter sw = new StringWriter();
+    marshaller.marshal( acl, sw );
+
+    return sw.toString();
+  }
+
+  @Override
+  public void setApplicationContext( ApplicationContext applicationContext ) throws BeansException {
+    this.applicationContext = applicationContext;
+    repositoryBase.setApplicationContext( applicationContext );
+  }
+}

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -12,22 +12,20 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,24 +33,42 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.plugin.action.mondrian.catalog.IAclAwareMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
+import org.pentaho.platform.plugin.services.importer.IPlatformImportBundle;
+import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
 
 import com.sun.jersey.core.header.FormDataContentDisposition;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclAdapter;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 
 public class AnalysisServiceTest {
-  
+
   private static AnalysisService analysisService;
+
+  private class AnalysisServiceMock extends AnalysisService {
+    @Override protected IUnifiedRepository getRepository() {
+      return mock( IUnifiedRepository.class );
+    }
+  }
 
   @Before
   public void setUp() {
-    analysisService = spy( new AnalysisService() );
+    analysisService = spy( new AnalysisServiceMock());
     analysisService.metadataDomainRepository = mock( IMetadataDomainRepository.class );
-    analysisService.mondrianCatalogService = mock( IMondrianCatalogService.class );
+    analysisService.importer = mock( IPlatformImporter.class );
+    analysisService.aclAwareMondrianCatalogService = mock( IAclAwareMondrianCatalogService.class );
+    analysisService.mondrianCatalogService = analysisService.aclAwareMondrianCatalogService;
   }
 
   @After
@@ -62,30 +78,40 @@ public class AnalysisServiceTest {
 
   @Test
   public void testDoGetAnalysisFilesAsDownload() throws Exception {
+    final String analysisId = "analysisId";
     Map<String, InputStream> mockMap = mock( Map.class );
-    MondrianCatalogRepositoryHelper mockMondrianCatalogRepositoryHelpere = mock( MondrianCatalogRepositoryHelper.class );
+    MondrianCatalogRepositoryHelper
+        mockMondrianCatalogRepositoryHelpere =
+        mock( MondrianCatalogRepositoryHelper.class );
 
-    doReturn( true ).when( analysisService ).canAdministerCheck();
+    doReturn( true ).when( analysisService ).canManageACL();
+    final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
+    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( analysisId ), any( IPentahoSession.class ) ) ).thenReturn(
+        mondrianCatalog );
     doReturn( mockMondrianCatalogRepositoryHelpere ).when( analysisService ).createNewMondrianCatalogRepositoryHelper();
-    doReturn( mockMap ).when( mockMondrianCatalogRepositoryHelpere ).getModrianSchemaFiles( "analysisId" );
+    doReturn( mockMap ).when( mockMondrianCatalogRepositoryHelpere ).getModrianSchemaFiles( analysisId );
 
-    Map<String, InputStream> response = analysisService.doGetAnalysisFilesAsDownload( "analysisId" );
+    Map<String, InputStream> response = analysisService.doGetAnalysisFilesAsDownload( analysisId );
 
-    verify( analysisService, times( 1 ) ).doGetAnalysisFilesAsDownload(  "analysisId" );
+    verify( analysisService, times( 1 ) ).doGetAnalysisFilesAsDownload( analysisId );
     assertEquals( mockMap, response );
   }
 
   @Test
   public void testDoGetAnalysisFilesAsDownloadError() throws Exception {
-    doReturn( false ).when( analysisService ).canAdministerCheck();
+    final String analysisId = "analysisId";
+    doReturn( false ).when( analysisService ).canManageACL();
+    final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
+    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( analysisId ), any( IPentahoSession.class ) ) ).thenReturn(
+        mondrianCatalog );
     try {
-      analysisService.doGetAnalysisFilesAsDownload( "analysisId" );
+      analysisService.doGetAnalysisFilesAsDownload( analysisId );
       fail();
     } catch ( PentahoAccessControlException e ) {
       //expected
     }
 
-    verify( analysisService, times( 1 ) ).doGetAnalysisFilesAsDownload( "analysisId" );
+    verify( analysisService, times( 1 ) ).doGetAnalysisFilesAsDownload( analysisId );
   }
 
   @Test
@@ -95,7 +121,7 @@ public class AnalysisServiceTest {
     doReturn( true ).when( analysisService ).canAdministerCheck();
     doReturn( "param" ).when( analysisService ).fixEncodedSlashParam( "analysisId" );
     doReturn( mockIPentahoSession ).when( analysisService ).getSession();
-    doNothing().when( analysisService.mondrianCatalogService ).removeCatalog( "param", mockIPentahoSession);
+    doNothing().when( analysisService.mondrianCatalogService ).removeCatalog( "param", mockIPentahoSession );
 
     analysisService.removeAnalysis( "analysisId" );
 
@@ -111,7 +137,7 @@ public class AnalysisServiceTest {
     } catch ( PentahoAccessControlException e ) {
       //expected
     }
-    verify( analysisService, times( 1 ) ).removeAnalysis(  "analysisId" );
+    verify( analysisService, times( 1 ) ).removeAnalysis( "analysisId" );
   }
 
   @Test
@@ -125,7 +151,8 @@ public class AnalysisServiceTest {
     IPentahoSession mockIPentahoSession = mock( IPentahoSession.class );
 
     doReturn( mockIPentahoSession ).when( analysisService ).getSession();
-    doReturn( mondrianCatalogList ).when( analysisService.mondrianCatalogService ).listCatalogs( mockIPentahoSession, false );
+    doReturn( mondrianCatalogList ).when( analysisService.mondrianCatalogService )
+        .listCatalogs( mockIPentahoSession, false );
     doReturn( mockSet ).when( analysisService.metadataDomainRepository ).getDomainIds();
 
     List<String> response = analysisService.getAnalysisDatasourceIds();
@@ -145,10 +172,139 @@ public class AnalysisServiceTest {
     String parameters = "parameters";
 
     doNothing().when( analysisService ).accessValidation();
-    doNothing().when( analysisService ).processMondrianImport( dataInputStream, catalogName, origCatalogName, true, xmlaEnabledFlag, parameters, null);
+    doNothing().when( analysisService )
+        .processMondrianImport( dataInputStream, catalogName, origCatalogName, true, xmlaEnabledFlag, parameters, null,
+            null );
 
-    analysisService.putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true, xmlaEnabledFlag, parameters);
+    analysisService
+        .putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true,
+            xmlaEnabledFlag, parameters, null );
 
-    verify( analysisService, times( 1 ) ).putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true, xmlaEnabledFlag, parameters);
+    verify( analysisService, times( 1 ) )
+        .putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true,
+            xmlaEnabledFlag, parameters, null );
+  }
+
+  @Test
+  public void testPutMondrianSchemaWithACL() throws Exception {
+    InputStream dataInputStream = mock( InputStream.class );
+    when( dataInputStream.read( any( byte[].class ) ) ).thenReturn( 10, -1 );
+
+    FormDataContentDisposition schemaFileInfo = mock( FormDataContentDisposition.class );
+    String catalogName = "catalogName";
+    String origCatalogName = "";
+    String dataSourceName = "dataSourceName";
+    boolean xmlaEnabledFlag = true;
+    String parameters = "parameters";
+
+    final RepositoryFileAclDto aclDto = new RepositoryFileAclDto();
+    aclDto.setOwner( "owner" );
+    aclDto.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
+
+    doNothing().when( analysisService ).accessValidation();
+
+    analysisService
+        .putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true,
+            xmlaEnabledFlag, parameters, aclDto );
+
+    verify( analysisService, times( 1 ) )
+        .putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true,
+            xmlaEnabledFlag, parameters, aclDto );
+
+    verify( analysisService.importer ).importFile( argThat( new ArgumentMatcher<IPlatformImportBundle>() {
+      @Override public boolean matches( Object argument ) {
+        IPlatformImportBundle bundle = (IPlatformImportBundle) argument;
+        return new RepositoryFileAclAdapter().unmarshal( aclDto ).equals( bundle.getAcl() );
+      }
+    } ) );
+  }
+
+  @Test
+  public void testGetAnalysisDatasourceAcl() throws Exception {
+    String catalogName = "catalogName";
+
+    final RepositoryFileAcl acl = new RepositoryFileAcl.Builder( "owner" ).build();
+
+    doReturn( true ).when( analysisService ).canManageACL();
+    when( analysisService.aclAwareMondrianCatalogService.getAclFor( catalogName ) ).thenReturn( acl );
+    final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
+    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn(
+        mondrianCatalog );
+    final IUnifiedRepository repository = mock( IUnifiedRepository.class );
+    final RepositoryFile repositoryFile = mock( RepositoryFile.class );
+    when( repository.getFileById( anyString() ) ).thenReturn( repositoryFile );
+    doReturn( new HashMap<String, InputStream>() { {
+        put( "test", null );
+      } } ).when( analysisService )
+        .doGetAnalysisFilesAsDownload( catalogName );
+
+    final RepositoryFileAclDto aclDto = analysisService.getAnalysisDatasourceAcl( catalogName );
+
+    verify( analysisService.aclAwareMondrianCatalogService ).getAclFor( eq( catalogName ) );
+
+    assertEquals( acl, new RepositoryFileAclAdapter().unmarshal( aclDto ) );
+  }
+
+  @Test
+  public void testGetAnalysisDatasourceAclNoAcl() throws Exception {
+    String catalogName = "catalogName";
+
+    doReturn( true ).when( analysisService ).canManageACL();
+    final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
+    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn(
+        mondrianCatalog );
+    when( analysisService.aclAwareMondrianCatalogService.getAclFor( catalogName ) ).thenReturn( null );
+    doReturn( new HashMap<String, InputStream>() { {
+        put( "test", null );
+      } } ).when( analysisService )
+        .doGetAnalysisFilesAsDownload( catalogName );
+
+    final RepositoryFileAclDto aclDto = analysisService.getAnalysisDatasourceAcl( catalogName );
+
+    verify( analysisService.aclAwareMondrianCatalogService ).getAclFor( eq( catalogName ) );
+
+    assertNull( aclDto );
+  }
+
+  @Test
+  public void testSetAnalysisDatasourceAcl() throws Exception {
+    String catalogName = "catalogName";
+
+    final RepositoryFileAclDto aclDto = new RepositoryFileAclDto();
+    aclDto.setOwner( "owner" );
+    aclDto.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
+
+    doReturn( true ).when( analysisService ).canManageACL();
+    final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
+    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn(
+        mondrianCatalog );
+    doReturn( new HashMap<String, InputStream>() { {
+        put( "test", null );
+      } } ).when( analysisService )
+        .doGetAnalysisFilesAsDownload( catalogName );
+
+    analysisService.setAnalysisDatasourceAcl( catalogName, aclDto );
+
+    verify( analysisService.aclAwareMondrianCatalogService ).setAclFor( eq( catalogName ),
+        eq( new RepositoryFileAclAdapter().unmarshal( aclDto ) ) );
+  }
+
+  @Test
+  public void testSetAnalysisDatasourceAclNoAcl() throws Exception {
+    String catalogName = "catalogName";
+
+    doReturn( true ).when( analysisService ).canManageACL();
+    final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
+    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn(
+        mondrianCatalog );
+    doReturn( new HashMap<String, InputStream>() { {
+        put( "test", null );
+      } } ).when( analysisService )
+        .doGetAnalysisFilesAsDownload( catalogName );
+
+    analysisService.setAnalysisDatasourceAcl( catalogName, null );
+
+    verify( analysisService.aclAwareMondrianCatalogService ).setAclFor( eq( catalogName ),
+        (RepositoryFileAcl) isNull() );
   }
 }

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/MetadataServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/MetadataServiceTest.java
@@ -12,54 +12,65 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import javax.ws.rs.core.Response;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.pentaho.metadata.repository.IMetadataDomainRepository;
+import org.mockito.ArgumentMatcher;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.services.importer.IPlatformImportBundle;
 import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
 import org.pentaho.platform.plugin.services.importer.PlatformImportException;
 import org.pentaho.platform.plugin.services.importer.RepositoryFileImportBundle;
+import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
+import org.pentaho.platform.plugin.services.metadata.IAclAwarePentahoMetadataDomainRepositoryImporter;
+import org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclAdapter;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 import org.pentaho.platform.web.http.api.resources.FileResource;
 
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataBodyPart;
 
-public class MetadataServiceTest {
+ public class MetadataServiceTest {
 
   private static MetadataService metadataService;
 
+  private class MetadataServiceMock extends MetadataService {
+    @Override protected IUnifiedRepository getRepository() {
+      return mock( IUnifiedRepository.class );
+    }
+  }
+
   @Before
   public void setUp() {
-    metadataService = spy( new MetadataService() );
-    metadataService.metadataDomainRepository = mock( IMetadataDomainRepository.class );
+    metadataService = spy( new MetadataServiceMock() );
+    metadataService.metadataDomainRepository = mock( PentahoMetadataDomainRepository.class );
+    metadataService.aclAwarePentahoMetadataDomainRepositoryImporter = mock( IAclAwarePentahoMetadataDomainRepositoryImporter.class );
+    metadataService.mondrianCatalogService = mock( IMondrianCatalogService.class );
   }
 
   @After
@@ -145,21 +156,21 @@ public class MetadataServiceTest {
     doReturn( null ).when( mockResponse ).getEntity();
     doReturn( "\t\n/" ).when( metadataService ).objectToString( null );
     doReturn( mockRepositoryFileImportBundleBuilder ).when( metadataService ).createNewRepositoryFileImportBundleBuilder(
-      metadataFile, false, domainId );
+        metadataFile, false, domainId, null );
     doReturn( "fileName" ).when( mockFormDataContentDisposition ).getFileName();
-    doReturn( mockByteArrayInputStream ).when( metadataService ).createNewByteArrayInputStream( any(byte[].class) );
+    doReturn( mockByteArrayInputStream ).when( metadataService ).createNewByteArrayInputStream( any( byte[].class ) );
     doReturn( mockRepositoryFileImportBundle ).when( metadataService ).createNewRepositoryFileImportBundle(
-      mockByteArrayInputStream, "fileName", domainId );
+        mockByteArrayInputStream, "fileName", domainId );
     doReturn( mockRepositoryFileImportBundle ).when( mockRepositoryFileImportBundleBuilder ).build();
     doReturn( mockIPlatformImporter ).when( metadataService ).getImporter();
     doNothing().when( mockIPlatformImporter ).importFile( mockIPlatformImportBundle );
     doReturn( mockIPentahoSession ).when( metadataService ).getSession();
     doNothing().when( metadataService ).publish( mockIPentahoSession );
 
-    metadataService.importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo );
+    metadataService.importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo, null );
 
     verify( metadataService, times( 1 ) ).importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite,
-      localeFiles, localeFilesInfo );
+        localeFiles, localeFilesInfo, null );
   }
 
   @Test
@@ -186,14 +197,166 @@ public class MetadataServiceTest {
 
     try {
       metadataService
-        .importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo );
+        .importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo, null );
       fail();
     } catch ( PlatformImportException e ) {
       //expected
     }
 
     verify( metadataService, times( 1 ) ).importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite,
-      localeFiles, localeFilesInfo );
+        localeFiles, localeFilesInfo, null );
+  }
+
+  @Test
+  public void testImportMetadataDatasourceWithACL() throws Exception {
+    String domainId = "home\\admin/resource/";
+    InputStream metadataFile = mock( InputStream.class );
+    FormDataContentDisposition metadataFileInfo = mock( FormDataContentDisposition.class );
+    boolean overwrite = true;
+    FormDataBodyPart mockFormDataBodyPart = mock( FormDataBodyPart.class );
+    List<FormDataBodyPart> localeFiles = new ArrayList<FormDataBodyPart>();
+    localeFiles.add( mockFormDataBodyPart );
+    List<FormDataContentDisposition> localeFilesInfo = new ArrayList<FormDataContentDisposition>();
+    FormDataContentDisposition mockFormDataContentDisposition = mock( FormDataContentDisposition.class );
+    localeFilesInfo.add( mockFormDataContentDisposition );
+    FileResource mockFileResource = mock( FileResource.class );
+    Response mockResponse = mock( Response.class );
+    IPentahoSession mockIPentahoSession = mock( IPentahoSession.class );
+    IPlatformImporter mockIPlatformImporter = mock( IPlatformImporter.class );
+    IPlatformImportBundle mockIPlatformImportBundle = mock( IPlatformImportBundle.class );
+    RepositoryFileImportBundle.Builder mockRepositoryFileImportBundleBuilder = mock( RepositoryFileImportBundle.Builder.class );
+    RepositoryFileImportBundle mockRepositoryFileImportBundle = mock( RepositoryFileImportBundle.class );
+    ByteArrayInputStream mockByteArrayInputStream = mock( ByteArrayInputStream.class );
+
+    doNothing().when( metadataService ).accessValidation();
+    doReturn( mockFileResource ).when( metadataService ).createNewFileResource();
+    doReturn( mockResponse ).when( mockFileResource ).doGetReservedChars();
+    doReturn( null ).when( mockResponse ).getEntity();
+    doReturn( "\t\n/" ).when( metadataService ).objectToString( null );
+    doReturn( mockRepositoryFileImportBundleBuilder ).when( metadataService ).createNewRepositoryFileImportBundleBuilder(
+        metadataFile, false, domainId, null );
+    doReturn( "fileName" ).when( mockFormDataContentDisposition ).getFileName();
+    doReturn( mockByteArrayInputStream ).when( metadataService ).createNewByteArrayInputStream( any( byte[].class ) );
+    doReturn( mockRepositoryFileImportBundle ).when( metadataService ).createNewRepositoryFileImportBundle(
+        mockByteArrayInputStream, "fileName", domainId );
+    doReturn( mockRepositoryFileImportBundle ).when( mockRepositoryFileImportBundleBuilder ).build();
+    doReturn( mockIPlatformImporter ).when( metadataService ).getImporter();
+    doNothing().when( mockIPlatformImporter ).importFile( mockIPlatformImportBundle );
+    doReturn( mockIPentahoSession ).when( metadataService ).getSession();
+    doNothing().when( metadataService ).publish( mockIPentahoSession );
+
+    final RepositoryFileAclDto acl = new RepositoryFileAclDto();
+    acl.setOwner( "owner" );
+    acl.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
+
+    metadataService.importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite, localeFiles, localeFilesInfo, acl );
+
+    verify( metadataService, times( 1 ) ).importMetadataDatasource( domainId, metadataFile, metadataFileInfo, overwrite,
+        localeFiles, localeFilesInfo, acl );
+
+    verify( metadataService.getImporter() ).importFile( argThat( new ArgumentMatcher<IPlatformImportBundle>() {
+      @Override public boolean matches( Object argument ) {
+        IPlatformImportBundle bundle = (IPlatformImportBundle) argument;
+        return new RepositoryFileAclAdapter().unmarshal( acl ).equals( bundle.getAcl() );
+      }
+    } ) );
+  }
+
+  @Test
+  public void testGetMetadataDatasourceAcl() throws Exception {
+    String domainId = "home\\admin/resource/";
+
+    final RepositoryFileAcl acl = new RepositoryFileAcl.Builder( "owner" ).build();
+
+    doReturn( true ).when( metadataService ).canManageACL();
+    when( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter.getAclFor( domainId ) ).thenReturn( acl );
+    final Map<String, InputStream> domainFilesData = mock( Map.class );
+    when( domainFilesData.isEmpty() ).thenReturn( false );
+    when( ( (PentahoMetadataDomainRepository) metadataService.metadataDomainRepository ).getDomainFilesData( domainId ) )
+        .thenReturn( domainFilesData );
+    final RepositoryFileAclDto aclDto = metadataService.getMetadataAcl( domainId );
+
+    verify( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter ).getAclFor( eq( domainId ) );
+
+    assertEquals( acl, new RepositoryFileAclAdapter().unmarshal( aclDto ) );
+  }
+
+  @Test( expected = FileNotFoundException.class )
+  public void testGetMetadataDatasourceAclNoDS() throws Exception {
+    String domainId = "home\\admin/resource/";
+
+    doReturn( true ).when( metadataService ).canManageACL();
+    when( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter.getAclFor( domainId ) ).thenReturn( null );
+    final RepositoryFileAclDto aclDto = metadataService.getMetadataAcl( domainId );
+
+    verify( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter ).getAclFor( eq( domainId ) );
+
+    assertNull( aclDto );
+  }
+
+  @Test
+  public void testGetMetadataDatasourceAclNoAcl() throws Exception {
+    String domainId = "home\\admin/resource/";
+
+    doReturn( true ).when( metadataService ).canManageACL();
+    when( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter.getAclFor( domainId ) ).thenReturn( null );
+    final Map<String, InputStream> domainFilesData = mock( Map.class );
+    when( domainFilesData.isEmpty() ).thenReturn( false );
+    when( ( (PentahoMetadataDomainRepository) metadataService.metadataDomainRepository ).getDomainFilesData( domainId ) )
+        .thenReturn( domainFilesData );
+    final RepositoryFileAclDto aclDto = metadataService.getMetadataAcl( domainId );
+
+    verify( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter ).getAclFor( eq( domainId ) );
+
+    assertNull( aclDto );
+  }
+
+  @Test
+  public void testSetMetadataDatasourceAcl() throws Exception {
+    String domainId = "home\\admin/resource/";
+
+    final RepositoryFileAclDto aclDto = new RepositoryFileAclDto();
+    aclDto.setOwner( "owner" );
+    aclDto.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
+
+    doReturn( true ).when( metadataService ).canManageACL();
+    final Map<String, InputStream> domainFilesData = mock( Map.class );
+    when( domainFilesData.isEmpty() ).thenReturn( false );
+    when( ( (PentahoMetadataDomainRepository) metadataService.metadataDomainRepository ).getDomainFilesData( domainId ) )
+        .thenReturn( domainFilesData );
+
+    metadataService.setMetadataAcl( domainId, aclDto );
+
+    verify( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter ).setAclFor( eq( domainId ),
+        eq( new RepositoryFileAclAdapter().unmarshal( aclDto ) ) );
+  }
+
+  @Test( expected = FileNotFoundException.class )
+  public void testSetMetadataDatasourceAclNoDS() throws Exception {
+    String domainId = "home\\admin/resource/";
+
+    doReturn( true ).when( metadataService ).canManageACL();
+
+    metadataService.setMetadataAcl( domainId, null );
+
+    verify( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter ).setAclFor( eq( domainId ),
+        (RepositoryFileAcl) isNull() );
+  }
+
+  @Test
+  public void testSetMetadataDatasourceAclNoAcl() throws Exception {
+    String domainId = "home\\admin/resource/";
+
+    doReturn( true ).when( metadataService ).canManageACL();
+    final Map<String, InputStream> domainFilesData = mock( Map.class );
+    when( domainFilesData.isEmpty() ).thenReturn( false );
+    when( ( (PentahoMetadataDomainRepository) metadataService.metadataDomainRepository ).getDomainFilesData( domainId ) )
+        .thenReturn( domainFilesData );
+
+    metadataService.setMetadataAcl( domainId, null );
+
+    verify( metadataService.aclAwarePentahoMetadataDomainRepositoryImporter ).setAclFor( eq( domainId ),
+        (RepositoryFileAcl) isNull() );
   }
 }
 

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/AnalysisResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/AnalysisResourceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -42,10 +42,15 @@ public class AnalysisResourceTest {
 
   private static AnalysisResource analysisResource;
 
+  private class AnalysisResourceMock extends AnalysisResource {
+    @Override protected AnalysisService createAnalysisService() {
+      return mock( AnalysisService.class );
+    }
+  }
+
   @Before
   public void setUp() {
-    analysisResource = spy( new AnalysisResource() );
-    analysisResource.service = mock( AnalysisService.class );
+    analysisResource = spy( new AnalysisResourceMock() );
   }
 
   @After
@@ -79,7 +84,7 @@ public class AnalysisResourceTest {
     try {
       Response response = analysisResource.downloadSchema( "analysisId" );
       fail( "Should have gotten a WebApplicationException" );
-    } catch( WebApplicationException e ) {
+    } catch ( WebApplicationException e ) {
       // Good
     }
 
@@ -110,7 +115,7 @@ public class AnalysisResourceTest {
     try {
       Response response = analysisResource.deleteSchema( "analysisId" );
       fail( "should have gotten a WebApplicationException" );
-    } catch ( WebApplicationException e ){
+    } catch ( WebApplicationException e ) {
       // Good
     }
 
@@ -131,7 +136,7 @@ public class AnalysisResourceTest {
   }
 
   @Test
-  public void testImportMetadataDatasource() throws Exception {
+  public void testImportAnalysisDatasource() throws Exception {
     Response mockResponse = mock( Response.class );
 
     InputStream uploadAnalysis = mock( InputStream.class );
@@ -145,20 +150,20 @@ public class AnalysisResourceTest {
 
     doNothing().when( analysisResource.service ).putMondrianSchema( uploadAnalysis, schemaFileInfo, catalogName,
         origCatalogName, datasourceName,
-        true, true, parameters );
+        true, true, parameters, null );
 
     Response response = analysisResource.putSchema( catalogName, uploadAnalysis, schemaFileInfo, catalogName,
-      origCatalogName,
-      Boolean.valueOf( overwrite ), Boolean.valueOf( xmlaEnabledFlag ), parameters );
+        origCatalogName,
+        Boolean.valueOf( overwrite ), Boolean.valueOf( xmlaEnabledFlag ), parameters, null );
 
     verify( analysisResource, times( 1 ) ).putSchema( catalogName, uploadAnalysis, schemaFileInfo, catalogName,
         origCatalogName,
-        Boolean.valueOf( overwrite ), Boolean.valueOf( xmlaEnabledFlag ), parameters );
+        Boolean.valueOf( overwrite ), Boolean.valueOf( xmlaEnabledFlag ), parameters, null );
     assertEquals( 201, response.getStatus() );
   }
 
   @Test
-  public void testImportMetadataDatasourceError() throws Exception {
+  public void testImportAnalysisDatasourceError() throws Exception {
     Response mockResponse = mock( Response.class );
 
     InputStream uploadAnalysis = mock( InputStream.class );
@@ -173,34 +178,35 @@ public class AnalysisResourceTest {
     //Test 1
     PentahoAccessControlException mockPentahoAccessControlException = mock( PentahoAccessControlException.class );
     doThrow( mockPentahoAccessControlException ).when( analysisResource.service ).putMondrianSchema( uploadAnalysis, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-      false, false, parameters );
+        false, false, parameters, null );
     doReturn( mockResponse ).when( analysisResource ).buildOkResponse( "5" );
 
     Response response = analysisResource.importMondrianSchema( uploadAnalysis, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-      overwrite, xmlaEnabledFlag, parameters );
+        overwrite, xmlaEnabledFlag, parameters, null );
     assertEquals( mockResponse, response );
 
     //Test 2
     PlatformImportException mockPlatformImportException = mock( PlatformImportException.class );
     doThrow( mockPlatformImportException ).when( analysisResource.service ).putMondrianSchema( uploadAnalysis, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-        true, true, parameters );
+        true, true, parameters, null );
     doReturn( mockResponse ).when( analysisResource ).buildOkResponse( "0" );
 
     response = analysisResource.importMondrianSchema( uploadAnalysis, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-      overwrite, xmlaEnabledFlag, parameters );
+      overwrite, xmlaEnabledFlag, parameters, null );
     assertEquals( mockResponse, response );
 
     //Test 3
     RuntimeException mockException = mock( RuntimeException.class );
     doThrow( mockException ).when( analysisResource.service ).putMondrianSchema( uploadAnalysis, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-        true, true, parameters );
+        true, true, parameters, null );
     doReturn( mockResponse ).when( analysisResource ).buildOkResponse( "2" );
 
     response = analysisResource.importMondrianSchema( uploadAnalysis, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-      overwrite, xmlaEnabledFlag, parameters );
+      overwrite, xmlaEnabledFlag, parameters, null );
     assertEquals( mockResponse, response );
 
     verify( analysisResource, times( 3 ) ).importMondrianSchema( uploadAnalysis, schemaFileInfo, catalogName, origCatalogName, datasourceName,
-      overwrite, xmlaEnabledFlag, parameters );
+        overwrite, xmlaEnabledFlag, parameters, null );
   }
+
 }

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/DataSourceWizardResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/DataSourceWizardResourceTest.java
@@ -12,22 +12,22 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
-import com.sun.jersey.multipart.FormDataParam;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.dataaccess.datasource.api.DataSourceWizardService;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 import org.pentaho.platform.web.http.api.resources.JaxbList;
 
-import javax.ws.rs.DefaultValue;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -41,10 +41,15 @@ public class DataSourceWizardResourceTest {
 
   private static DataSourceWizardResource dataSourceWizardResource;
 
+  private class DataSourceWizardResourceMock extends DataSourceWizardResource {
+    @Override protected DataSourceWizardService createDataSourceWizardService() {
+      return mock( DataSourceWizardService.class );
+    }
+  }
+
   @Before
   public void setUp() {
-    dataSourceWizardResource = spy( new DataSourceWizardResource() );
-    dataSourceWizardResource.service = mock( DataSourceWizardService.class );
+    dataSourceWizardResource = spy( new DataSourceWizardResourceMock() );
   }
 
   @After
@@ -73,7 +78,7 @@ public class DataSourceWizardResourceTest {
     //Test 1
     PentahoAccessControlException mockPentahoAccessControlException = mock( PentahoAccessControlException.class );
     doThrow( mockPentahoAccessControlException ).when( dataSourceWizardResource.service ).doGetDSWFilesAsDownload(
-      "dswId" );
+        "dswId" );
     doReturn( mockResponse ).when( dataSourceWizardResource ).buildUnauthorizedResponse();
 
     Response response = dataSourceWizardResource.downloadDsw( "dswId" );
@@ -105,7 +110,7 @@ public class DataSourceWizardResourceTest {
     try {
       Response response = dataSourceWizardResource.remove( "dswId" );
       fail( "should have thrown an exception" );
-    } catch ( Exception e ){
+    } catch ( Exception e ) {
       //good
     }
     verify( dataSourceWizardResource, times( 1 ) ).remove( "dswId" );
@@ -131,12 +136,12 @@ public class DataSourceWizardResourceTest {
     boolean overwrite = false;
     boolean checkConnection = false;
     Response mockResponse = mock( Response.class );
-    doReturn( "dswId" ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    doReturn( "dswId" ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     doReturn( mockResponse ).when( dataSourceWizardResource ).buildOkResponse( "dswId" );
 
-    Response response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    Response response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
 
-    verify( dataSourceWizardResource, times( 1 ) ).publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    verify( dataSourceWizardResource, times( 1 ) ).publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     assertEquals( mockResponse, response );
   }
 
@@ -150,36 +155,85 @@ public class DataSourceWizardResourceTest {
 
     //Test 1
     PentahoAccessControlException mockPentahoAccessControlException = mock( PentahoAccessControlException.class );
-    doThrow( mockPentahoAccessControlException ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    doThrow( mockPentahoAccessControlException ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     doReturn( mockResponse ).when( dataSourceWizardResource ).buildUnauthorizedResponse();
 
-    Response response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    Response response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     assertEquals( mockResponse, response );
 
     //Test 2
     IllegalArgumentException mockIllegalArgumentException = mock( IllegalArgumentException.class );
-    doThrow( mockIllegalArgumentException ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    doThrow( mockIllegalArgumentException ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     doReturn( mockResponse ).when( dataSourceWizardResource ).buildBadRequestResponse( anyString() );
 
-    response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     assertEquals( mockResponse, response );
 
     //Test 3
     DataSourceWizardService.DswPublishValidationException mockDataSourceWizardServiceDswPublishValidationException = mock( DataSourceWizardService.DswPublishValidationException.class );
-    doThrow( mockDataSourceWizardServiceDswPublishValidationException ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    doThrow( mockDataSourceWizardServiceDswPublishValidationException ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     doReturn( mockResponse ).when( dataSourceWizardResource ).buildConfilictResponse( anyString() );
 
-    response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     assertEquals( mockResponse, response );
 
     //Test 4
     RuntimeException mockException = mock( RuntimeException.class );
-    doThrow( mockException ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    doThrow( mockException ).when( dataSourceWizardResource.service ).publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     doReturn( mockResponse ).when( dataSourceWizardResource ).buildServerErrorResponse();
 
-    response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    response = dataSourceWizardResource.publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
     assertEquals( mockResponse, response );
 
-    verify( dataSourceWizardResource, times( 4 ) ).publishDsw( domainId, metadataFile, overwrite, checkConnection );
+    verify( dataSourceWizardResource, times( 4 ) ).publishDsw( domainId, metadataFile, overwrite, checkConnection, null );
+  }
+
+  @Test
+  public void doGetAnalysisAcl() throws Exception {
+    String domainId = "domainId";
+
+    doReturn( new RepositoryFileAclDto() ).when( dataSourceWizardResource.service ).getDSWAcl( domainId );
+
+    dataSourceWizardResource.doGetDSWAcl( domainId ); // no exception thrown
+
+    //
+    doThrow( new PentahoAccessControlException() ).when( dataSourceWizardResource.service ).getDSWAcl( domainId );
+
+    try {
+      dataSourceWizardResource.doGetDSWAcl( domainId );
+      fail();
+    } catch ( WebApplicationException e ) {
+      assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), e.getResponse().getStatus() );
+    }
+
+    //
+    doThrow( new FileNotFoundException() ).when( dataSourceWizardResource.service ).getDSWAcl( domainId );
+
+    try {
+      dataSourceWizardResource.doGetDSWAcl( domainId );
+      fail();
+    } catch ( WebApplicationException e ) {
+      assertEquals( Response.Status.CONFLICT.getStatusCode(), e.getResponse().getStatus() );
+    }
+  }
+
+  @Test
+  public void doSetMetadataAcl() throws Exception {
+    String domainId = "domainId";
+
+    Response response = dataSourceWizardResource.doSetDSWAcl( domainId, null );
+    assertEquals( Response.Status.OK.getStatusCode(), response.getStatus() );
+
+    //
+    doThrow( new PentahoAccessControlException() ).when( dataSourceWizardResource.service ).setDSWAcl( domainId, null );
+
+    response = dataSourceWizardResource.doSetDSWAcl( domainId, null );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus() );
+
+    //
+    doThrow( new FileNotFoundException() ).when( dataSourceWizardResource.service ).setDSWAcl( domainId, null );
+
+    response = dataSourceWizardResource.doSetDSWAcl( domainId, null );
+    assertEquals( Response.Status.CONFLICT.getStatusCode(), response.getStatus() );
   }
 }

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/JdbcDatasourceResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/JdbcDatasourceResourceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -22,10 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
-import org.pentaho.platform.dataaccess.datasource.api.DatasourceService;
-import org.pentaho.platform.dataaccess.datasource.api.resources.JDBCDatasourceResource;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
-import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.ConnectionService;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.ConnectionServiceImpl;
 import org.pentaho.platform.web.http.api.resources.JaxbList;
 
@@ -113,7 +110,7 @@ public class JdbcDatasourceResourceTest {
     try {
       JaxbList<String> connections = jdbcDatasourceResource.getConnectionIDs();
       fail( "Should get WebApplicationException" );
-    } catch( WebApplicationException e ){
+    } catch ( WebApplicationException e ) {
       // good
     }
   }

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResourceTest.java
@@ -12,22 +12,18 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
 
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
+import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,6 +38,7 @@ import org.junit.Test;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.dataaccess.datasource.api.MetadataService;
 import org.pentaho.platform.plugin.services.importer.PlatformImportException;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 import org.pentaho.platform.web.http.api.resources.FileResource;
 import org.pentaho.platform.web.http.api.resources.JaxbList;
 
@@ -52,10 +49,15 @@ public class MetadataResourceTest {
 
   private static MetadataResource metadataResource;
 
+  private class MetadataResourceMock extends MetadataResource {
+    @Override protected MetadataService createMetadataService() {
+      return mock( MetadataService.class );
+    }
+  }
+
   @Before
   public void setUp() {
-    metadataResource = spy( new MetadataResource() );
-    metadataResource.service = mock( MetadataService.class );
+    metadataResource = spy( new MetadataResourceMock() );
   }
 
   @After
@@ -69,13 +71,14 @@ public class MetadataResourceTest {
     Map<String, InputStream> mockFileData = mock( Map.class );
 
     doReturn( true ).when( metadataResource ).canAdminister();
-    doReturn( true ).when( metadataResource).isInstanceOfIPentahoMetadataDomainRepositoryExporter( metadataResource.metadataDomainRepository );
+    doReturn( true ).when( metadataResource )
+        .isInstanceOfIPentahoMetadataDomainRepositoryExporter( metadataResource.metadataDomainRepository );
     doReturn( mockFileData ).when( metadataResource ).getDomainFilesData( "metadataId" );
     doReturn( mockResponse ).when( metadataResource ).createAttachment( mockFileData, "metadataId" );
 
     Response response = metadataResource.downloadMetadata( "metadataId" );
 
-    verify( metadataResource, times( 1 ) ).downloadMetadata(  "metadataId" );
+    verify( metadataResource, times( 1 ) ).downloadMetadata( "metadataId" );
     assertEquals( mockResponse, response );
   }
 
@@ -90,7 +93,7 @@ public class MetadataResourceTest {
     try {
       Response response = metadataResource.downloadMetadata( "metadataId" );
       fail( "Should have gotten a WebApplicationException" );
-    } catch ( WebApplicationException e ){
+    } catch ( WebApplicationException e ) {
       Assert.assertEquals( 401, e.getResponse().getStatus() );
     }
 
@@ -101,7 +104,7 @@ public class MetadataResourceTest {
     try {
       Response response = metadataResource.downloadMetadata( "metadataId" );
       fail( "Should have gotten a WebApplicationException" );
-    } catch ( WebApplicationException e ){
+    } catch ( WebApplicationException e ) {
       Assert.assertEquals( 500, e.getResponse().getStatus() );
     }
 
@@ -126,12 +129,12 @@ public class MetadataResourceTest {
     doThrow( mockPentahoAccessControlException ).when( metadataResource.service ).removeMetadata( "metadataId" );
     doReturn( mockResponse ).when( metadataResource ).buildUnauthorizedResponse();
 
-    try{
+    try {
       Response response = metadataResource.deleteMetadata( "metadataId" );
       fail( "Should have had a WebApplicationException" );
-    } catch( WebApplicationException e ){
+    } catch ( WebApplicationException e ) {
       // Good
-      assertEquals(401, e.getResponse().getStatus());
+      assertEquals( 401, e.getResponse().getStatus() );
     }
 
     verify( metadataResource, times( 1 ) ).deleteMetadata( "metadataId" );
@@ -162,18 +165,18 @@ public class MetadataResourceTest {
     List<FormDataBodyPart> localeFiles = mock( List.class );
     List<FormDataContentDisposition> localeFilesInfo = mock( List.class );
 
-
-    doNothing().when( metadataResource.service ).importMetadataDatasource( domainId, metadataFile, metadataFileInfo, true, localeFiles,
-      localeFilesInfo );
+    doNothing().when( metadataResource.service )
+        .importMetadataDatasource( domainId, metadataFile, metadataFileInfo, true, localeFiles,
+            localeFilesInfo, null );
     doReturn( mockResponse ).when( metadataResource ).buildOkResponse( "3" );
-    
+
     Response response = metadataResource.importMetadataDatasourceLegacy( domainId, metadataFile, metadataFileInfo,
         overwrite, localeFiles,
-        localeFilesInfo );
+        localeFilesInfo, null );
 
     verify( metadataResource, times( 1 ) ).importMetadataDatasourceLegacy( domainId, metadataFile, metadataFileInfo,
         overwrite, localeFiles,
-        localeFilesInfo );
+        localeFilesInfo, null );
     assertEquals( mockResponse.getStatus(), response.getStatus() );
   }
 
@@ -191,54 +194,117 @@ public class MetadataResourceTest {
 
     //Test 1
     PentahoAccessControlException mockPentahoAccessControlException = mock( PentahoAccessControlException.class );
-    doThrow( mockPentahoAccessControlException ).when( metadataResource.service ).importMetadataDatasource( domainId, metadataFile, metadataFileInfo, false, localeFiles,
-      localeFilesInfo );
+    doThrow( mockPentahoAccessControlException ).when( metadataResource.service )
+        .importMetadataDatasource( domainId, metadataFile, metadataFileInfo, false, localeFiles,
+            localeFilesInfo, null );
     doReturn( mockResponse ).when( metadataResource ).buildServerErrorResponse( mockPentahoAccessControlException );
 
     Response response = metadataResource.importMetadataDatasourceLegacy( domainId, metadataFile, metadataFileInfo,
         overwrite, localeFiles,
-        localeFilesInfo );
+        localeFilesInfo, null );
     assertEquals( mockResponse, response );
 
     //Test 2
     PlatformImportException mockPlatformImportException = mock( PlatformImportException.class );
-    doThrow( mockPlatformImportException ).when( metadataResource.service ).importMetadataDatasource( domainId, metadataFile, metadataFileInfo, true, localeFiles,
-      localeFilesInfo );
+    doThrow( mockPlatformImportException ).when( metadataResource.service )
+        .importMetadataDatasource( domainId, metadataFile, metadataFileInfo, true, localeFiles,
+            localeFilesInfo, null );
     doReturn( 10 ).when( mockPlatformImportException ).getErrorStatus();
     doReturn( mockFileResource ).when( metadataResource ).createFileResource();
     doReturn( mockResponse ).when( metadataResource ).buildServerError003Response( domainId, mockFileResource );
 
     response = metadataResource.importMetadataDatasourceLegacy( domainId, metadataFile, metadataFileInfo, overwrite,
         localeFiles,
-        localeFilesInfo );
+        localeFilesInfo, null );
     assertEquals( mockResponse, response );
 
     //Test 3
     RuntimeException mockException = mock( RuntimeException.class );
-    doThrow( mockPlatformImportException ).when( metadataResource.service ).importMetadataDatasource( domainId, metadataFile, metadataFileInfo, true, localeFiles,
-      localeFilesInfo );
+    doThrow( mockPlatformImportException ).when( metadataResource.service )
+        .importMetadataDatasource( domainId, metadataFile, metadataFileInfo, true, localeFiles,
+            localeFilesInfo, null );
     doReturn( 1 ).when( mockPlatformImportException ).getErrorStatus();
     doReturn( mockResponse ).when( metadataResource ).buildOkResponse( "1" );
     doReturn( mockException ).when( mockPlatformImportException ).getCause();
 
     response = metadataResource.importMetadataDatasourceLegacy( domainId, metadataFile, metadataFileInfo, overwrite,
         localeFiles,
-        localeFilesInfo );
+        localeFilesInfo, null );
     assertEquals( mockResponse, response );
 
     //Test
-    doThrow( mockException ).when( metadataResource.service ).importMetadataDatasource( domainId, metadataFile, metadataFileInfo, true, localeFiles,
-      localeFilesInfo );
+    doThrow( mockException ).when( metadataResource.service )
+        .importMetadataDatasource( domainId, metadataFile, metadataFileInfo, true, localeFiles,
+            localeFilesInfo, null );
     doReturn( mockResponse ).when( metadataResource ).buildServerError001Response();
 
     response = metadataResource.importMetadataDatasourceLegacy( domainId, metadataFile, metadataFileInfo, overwrite,
         localeFiles,
-        localeFilesInfo );
+        localeFilesInfo, null );
     assertEquals( mockResponse, response );
 
     verify( metadataResource, times( 4 ) ).importMetadataDatasourceLegacy( domainId, metadataFile, metadataFileInfo,
         overwrite, localeFiles,
-        localeFilesInfo );
+        localeFilesInfo, null );
+  }
+
+  @Test
+  public void doGetMetadataAcl() throws Exception {
+    String domainId = "domainId";
+
+    doReturn( new HashMap<String, InputStream>() { {
+        put( "test", null );
+      } } ).when( metadataResource )
+        .getDomainFilesData( domainId );
+
+    doReturn( new RepositoryFileAclDto() ).when( metadataResource.service ).getMetadataAcl( domainId );
+
+    metadataResource.doGetMetadataAcl( domainId ); // no exception thrown
+
+    //
+    doThrow( new PentahoAccessControlException() ).when( metadataResource.service ).getMetadataAcl( domainId );
+
+    try {
+      metadataResource.doGetMetadataAcl( domainId );
+      fail();
+    } catch ( WebApplicationException e ) {
+      assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), e.getResponse().getStatus() );
+    }
+
+    //
+    doThrow( new FileNotFoundException() ).when( metadataResource.service ).getMetadataAcl( domainId );
+
+    try {
+      metadataResource.doGetMetadataAcl( domainId );
+      fail();
+    } catch ( WebApplicationException e ) {
+      assertEquals( Response.Status.CONFLICT.getStatusCode(), e.getResponse().getStatus() );
+    }
+  }
+
+  @Test
+  public void doSetMetadataAcl() throws Exception {
+    String domainId = "domainId";
+
+    doReturn( new HashMap<String, InputStream>() { {
+        put( "test", null );
+      } } ).when( metadataResource )
+        .getDomainFilesData( domainId );
+
+    Response response = metadataResource.doSetMetadataAcl( domainId, null );
+    assertEquals( Response.Status.OK.getStatusCode(), response.getStatus() );
+
+    //
+    doThrow( new PentahoAccessControlException() ).when( metadataResource.service ).setMetadataAcl( domainId, null );
+
+    response = metadataResource.doSetMetadataAcl( domainId, null );
+    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus() );
+
+    //
+    doThrow( new FileNotFoundException() ).when( metadataResource.service ).setMetadataAcl( domainId, null );
+
+    response = metadataResource.doSetMetadataAcl( domainId, null );
+    assertEquals( Response.Status.CONFLICT.getStatusCode(), response.getStatus() );
   }
 }
 

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/ResourceUtilTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/resources/ResourceUtilTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -132,7 +132,7 @@ public class ResourceUtilTest {
     doReturn( mockFileInputStream ).when( resourceUtil ).createFileInputStream( mockFile );
     doReturn( mockStreamingOutput ).when( resourceUtil ).createStreamingOutput( mockFileInputStream );
     doReturn( mockResponse ).when( resourceUtil ).buildOkResponse( mockStreamingOutput, resourceUtil.APPLICATION_ZIP,
-      "\"domainId.zip\"" );
+        "\"domainId.zip\"" );
 
     response = resourceUtil.createAttachment( fileData, domainId );
     assertEquals( mockResponse, response );

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceTest.java
@@ -1,3 +1,20 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import static org.mockito.Matchers.anyString;
@@ -273,7 +290,7 @@ public class DatasourceResourceTest {
     } );
     FileInputStream in = new FileInputStream( new File( new File( "test-res" ), "SampleDataOlap.xmi" ) );
     try {
-      Response resp = service.publishDsw( "AModel.xmi", in, true, false );
+      Response resp = service.publishDsw( "AModel.xmi", in, true, false, null );
       Assert.assertEquals(
           Response.Status.Family.SUCCESSFUL,
           Response.Status.fromStatusCode( resp.getStatus() ).getFamily() );
@@ -306,7 +323,7 @@ public class DatasourceResourceTest {
     FileInputStream in = new FileInputStream( filePath );
     try {
       service.putMondrianSchema( in, schemaFileInfo, null, null, null, false, false,
-          "Datasource=SampleData;overwrite=false" );
+          "Datasource=SampleData;overwrite=false", null );
 
       mockery.assertIsSatisfied();
     } finally {

--- a/test-src/solutionACL/system/ImportHandlerMimeTypeDefinitions.xml
+++ b/test-src/solutionACL/system/ImportHandlerMimeTypeDefinitions.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--===========================================================================
+PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
+
+Copyright 2002 - 2014 Pentaho Corporation (Pentaho). All rights reserved.
+
+NOTICE: All information including source code contained herein is, and
+remains the sole property of Pentaho and its licensors. The intellectual
+and technical concepts contained herein are proprietary and confidential
+to, and are trade secrets of Pentaho and may be covered by U.S. and foreign
+patents, or patents in process, and are protected by trade secret and
+copyright laws. The receipt or possession of this source code and/or related
+information does not convey or imply any rights to reproduce, disclose or
+distribute its contents, or to manufacture, use, or sell anything that it
+may describe, in whole or in part. Any reproduction, modification, distribution,
+or public display of this information without the express written authorization
+from Pentaho is strictly prohibited and in violation of applicable laws and
+international treaties. Access to the source code contained herein is strictly
+prohibited to anyone except those individuals and entities who have executed
+confidentiality and non-disclosure agreements or other agreements with Pentaho,
+explicitly covering such access.
+============================================================================-->
+<tns:ImportHandlerMimeTypeDefinitions xmlns:tns="http://www.pentaho.com/schema/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pentaho.com/schema/ImportHandlerMimeTypeDefinitions.xsd ">
+  <ImportHandler class="org.pentaho.platform.plugin.services.importer.RepositoryFileImportFileHandler">
+    <MimeTypeDefinitions>
+      <MimeTypeDefinition mimeType="application/internet-shortcut" converter="streamConverter" hidden="false" locale="false">
+        <extension>url</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="application/vnd.ms-excel">
+        <extension>xls</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="application/vnd.pentaho.dashboard">
+        <extension>xdash</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="image/gif" hidden="true">
+        <extension>gif</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="image/jpeg" hidden="true">
+        <extension>jpg</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="image/png" hidden="true">
+        <extension>png</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="image/svg+xml" hidden="true">
+        <extension>svg</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="text/css" hidden="true">
+        <extension>css</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="text/html" hidden="true">
+        <extension>htm</extension>
+        <extension>html</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="text/javascript" hidden="true">
+        <extension>js</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="text/plain" hidden="true">
+        <extension>properties</extension>
+        <extension>sql</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="application/vnd.pentaho.schedule">
+        <extension>qtz</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="text/pdf" hidden="false">
+        <extension>pdf</extension>
+      </MimeTypeDefinition>
+      <MimeTypeDefinition mimeType="text/xml">
+        <extension>cda</extension>
+        <extension>cdfde</extension>
+        <extension>cfg.xml</extension>
+        <extension>jrxml</extension>
+        <extension>kcs</extension>
+        <extension>kdb</extension>
+        <extension>kps</extension>
+        <extension>ksl</extension>
+        <extension>report</extension>
+        <extension>rptdesign</extension>
+        <extension>wcdf</extension>
+        <extension>xanalyzer</extension>
+        <extension>xcdf</extension>
+        <extension>xjpivot</extension>
+        <extension>xml</extension>
+        <extension>xreportspec</extension>
+      </MimeTypeDefinition>      
+    </MimeTypeDefinitions>
+  </ImportHandler>
+  
+  <ImportHandler class="org.pentaho.platform.plugin.services.importer.SolutionImportHandler">
+    <MimeTypeDefinitions>
+      <MimeTypeDefinition mimeType="application/vnd.pentaho.solution-repository">
+        <extension>zip</extension>
+      </MimeTypeDefinition>
+    </MimeTypeDefinitions>
+  </ImportHandler>
+  
+
+  
+  <ImportHandler class="org.pentaho.platform.plugin.services.importer.MondrianImportHandler">
+    <MimeTypeDefinitions>
+      <MimeTypeDefinition mimeType="application/vnd.pentaho.mondrian+xml">
+        <extension>mondrian+xml</extension>
+      </MimeTypeDefinition>
+    </MimeTypeDefinitions>
+  </ImportHandler>
+  
+  <ImportHandler class="org.pentaho.platform.plugin.services.importer.LocaleImportHandler">
+    <MimeTypeDefinitions>
+      <MimeTypeDefinition mimeType="text/locale" hidden="true">
+        <extension>locale</extension>
+      </MimeTypeDefinition>
+    </MimeTypeDefinitions>
+  </ImportHandler>
+  
+  <ImportHandler class="org.pentaho.platform.plugin.services.importer.MetadataImportHandler">
+    <MimeTypeDefinitions>
+      <MimeTypeDefinition mimeType="text/xmi+xml">
+        <extension>xmi</extension>
+      </MimeTypeDefinition>
+    </MimeTypeDefinitions>
+  </ImportHandler>
+</tns:ImportHandlerMimeTypeDefinitions>

--- a/test-src/solutionACL/system/data-access/settings.xml
+++ b/test-src/solutionACL/system/data-access/settings.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+  <!-- set this to true for production, and false for development/localization -->
+  <cache-messages>true</cache-messages>
+  <!-- how far ahead to set the browser's cache -->
+  <max-age>2628001</max-age>
+  <cache>true</cache>
+    
+  <!-- roles with data access permissions -->
+  <data-access-roles>Administrator</data-access-roles>
+  <!-- users with data access permissions -->
+  <!--
+  <data-access-users></data-access-users>
+   -->
+  <!-- roles with datasource view permissions -->
+  <data-access-view-roles>Authenticated,Administrator</data-access-view-roles>
+  <!-- users with datasource view permissions -->
+  <data-access-view-users>suzy</data-access-view-users>
+  <!-- default view acls for user or role -->
+  <data-access-default-view-acls>31</data-access-default-view-acls>
+
+  <!-- settings for Agile Data Access -->
+  <data-access-staging-jndi>Hibernate</data-access-staging-jndi>
+
+  <data-access-datasource-solution-storage>admin</data-access-datasource-solution-storage>
+  <data-access-csv-sample-rows>10000</data-access-csv-sample-rows>
+  <data-access-datasource-illegal-characters><![CDATA[$<>?&#%^*()!~:;[]{}|]]></data-access-datasource-illegal-characters>
+
+  <!-- Agile Mart Datasource  -->
+  <agile-mart-staging-datasource>AgileBI</agile-mart-staging-datasource>
+
+  <!-- Geography settings -->
+  <geo>
+    <roles>territory, continent, country, state, county, city, postal_code</roles>
+    <dimension-name>Geography</dimension-name>
+
+    <territory>
+      <aliases>territory</aliases>
+    </territory>
+
+    <continent>
+      <aliases>continent</aliases>
+    </continent>
+
+    <country>
+      <aliases>country, ctry</aliases>
+    </country>
+
+    <state>
+      <aliases>state, province, st, stateprovince</aliases>
+      <required-parents>country</required-parents>
+    </state>
+
+    <county>
+      <aliases>CountrySecondarySubdivision, county</aliases>
+      <required-parents>country,state</required-parents>
+    </county> 
+
+    <city>
+      <aliases>city, town</aliases>
+      <required-parents>country,state</required-parents>
+    </city>
+
+    <postal_code>
+      <aliases>zip, postal code, zip code</aliases>
+      <required-parents>country</required-parents>
+    </postal_code>
+
+    <latitude>
+      <aliases>lat, latitude</aliases>
+    </latitude>
+
+    <longitude>
+      <aliases>long, lon, lng, longitude</aliases>
+    </longitude>
+  </geo>
+
+    <!-- Settings for the PUC "new" toolbar dropdown: priority, label, tabName, action-url -->  
+    <new-toolbar-button>9,newDataAccess,dataaccess,javascript:window.top.pho.openDatasourceEditor(window.top.datasourceEditorCallback)</new-toolbar-button>
+
+</settings>

--- a/test-src/solutionACL/system/importExport.xml
+++ b/test-src/solutionACL/system/importExport.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--===========================================================================
+PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
+
+Copyright 2002 - 2014 Pentaho Corporation (Pentaho). All rights reserved.
+
+NOTICE: All information including source code contained herein is, and
+remains the sole property of Pentaho and its licensors. The intellectual
+and technical concepts contained herein are proprietary and confidential
+to, and are trade secrets of Pentaho and may be covered by U.S. and foreign
+patents, or patents in process, and are protected by trade secret and
+copyright laws. The receipt or possession of this source code and/or related
+information does not convey or imply any rights to reproduce, disclose or
+distribute its contents, or to manufacture, use, or sell anything that it
+may describe, in whole or in part. Any reproduction, modification, distribution,
+or public display of this information without the express written authorization
+from Pentaho is strictly prohibited and in violation of applicable laws and
+international treaties. Access to the source code contained herein is strictly
+prohibited to anyone except those individuals and entities who have executed
+confidentiality and non-disclosure agreements or other agreements with Pentaho,
+explicitly covering such access.
+============================================================================-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+	xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd 
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd 
+       http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd"
+	default-lazy-init="true">
+
+	<bean id="MimeTypeListFactory" class="org.pentaho.platform.plugin.services.importer.mimeType.MimeTypeListFactory">
+		<constructor-arg value="system/ImportHandlerMimeTypeDefinitions.xml" />
+	</bean>
+	
+  <bean id="streamConverter"
+		class="org.pentaho.platform.plugin.services.importexport.StreamConverter">
+		<constructor-arg ref="unifiedRepository"/>
+		<pen:publish as-type="INTERFACES">
+			<pen:attributes>
+				<pen:attr key="name" value="streamConverter" />
+			</pen:attributes>
+		</pen:publish>
+	</bean>
+
+	<bean id="IRepositoryContentConverterHandler"
+		class="org.pentaho.platform.plugin.services.importer.DefaultRepositoryContentConverterHandler" scope="singleton">
+		<constructor-arg>
+			<util:map id="convertersMap">
+				<entry key="mondrian.xml" value-ref="streamConverter"/>
+				<entry key="jpeg" value-ref="streamConverter"/>
+			</util:map>
+		</constructor-arg>
+	</bean>
+
+	<bean id="ITenant" class="org.pentaho.platform.core.mt.Tenant"
+		scope="prototype" />
+
+	<bean id="IPlatformImportMimeResolver" class="org.pentaho.platform.plugin.services.importer.NameBaseMimeResolver" />
+	<!-- For compatibility with Migrators that still use the actual class name	-->
+	<alias name="IPlatformImportMimeResolver" alias="NameBaseMimeResolver"/>
+
+	<bean id="DefaultExportHandler"
+		class="org.pentaho.platform.plugin.services.importexport.DefaultExportHandler">
+		<property name="repository" ref="unifiedRepository" />
+		<property name="localeExportList">
+			<list>
+				<value>.xanalyzer</value>
+				<value>.prpti</value>
+				<value>.prpt</value>
+				<value>.xaction</value>
+				<value>.xdash</value>
+				<value>.url</value>
+				<value>.xanalyzer</value>
+				<value>.xjpivot</value>
+				<value>.xcdf</value>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="defaultImportHandler"
+		class="org.pentaho.platform.plugin.services.importer.RepositoryFileImportFileHandler">
+		<constructor-arg>
+			<bean factory-bean="MimeTypeListFactory" factory-method="createMimeTypeList" >
+				<constructor-arg value="org.pentaho.platform.plugin.services.importer.RepositoryFileImportFileHandler"/> 
+			</bean>
+		</constructor-arg>
+		<property name="repository" ref="unifiedRepository" />
+		<property name="defaultAclHandler" ref="defaultAclHandler" />
+	</bean>
+
+	<bean id="IPlatformImporter"
+		class="org.pentaho.platform.plugin.services.importer.PentahoPlatformImporter"
+		scope="singleton">
+		<constructor-arg>
+			<ref bean="importHandlers" />
+		</constructor-arg>
+		<constructor-arg>
+			<ref bean="IRepositoryContentConverterHandler" />
+		</constructor-arg>
+		<property name="defaultHandler">
+			<ref bean="defaultImportHandler" />
+		</property>
+		<property name="repositoryImportLogger">
+			<bean
+				class="org.pentaho.platform.plugin.services.importexport.Log4JRepositoryImportLogger" />
+		</property>
+	</bean>
+
+	<bean id="importHandlers" class="java.util.ArrayList">
+		<constructor-arg>
+			<util:list list-class="java.util.ArrayList"
+				value-type="org.pentaho.platform.plugin.services.importer.IPlatformImportHandler">
+				<ref bean="defaultImportHandler" />
+
+				<bean
+					class="org.pentaho.platform.plugin.services.importer.SolutionImportHandler">
+					<constructor-arg>
+						<bean factory-bean="MimeTypeListFactory" factory-method="createMimeTypeList" >
+							<constructor-arg value="org.pentaho.platform.plugin.services.importer.SolutionImportHandler"/> 
+						</bean>
+					</constructor-arg>
+				</bean>
+
+				<bean
+					class="org.pentaho.platform.plugin.services.importer.MetadataImportHandler">
+					<constructor-arg>
+						<bean factory-bean="MimeTypeListFactory" factory-method="createMimeTypeList" >
+							<constructor-arg value="org.pentaho.platform.plugin.services.importer.MetadataImportHandler"/> 
+						</bean>
+					</constructor-arg>
+					<constructor-arg ref="IMetadataDomainRepositoryImpl" />
+				</bean>
+				
+				<bean
+					class="org.pentaho.platform.plugin.services.importer.MondrianImportHandler">
+					<constructor-arg>
+						<bean factory-bean="MimeTypeListFactory" factory-method="createMimeTypeList" >
+							<constructor-arg value="org.pentaho.platform.plugin.services.importer.MondrianImportHandler"/> 
+						</bean>
+					</constructor-arg>
+					<constructor-arg ref="IMondrianCatalogService" />
+				</bean>
+				
+				<bean
+					class="org.pentaho.platform.plugin.services.importer.LocaleImportHandler">
+					<constructor-arg>
+						<bean factory-bean="MimeTypeListFactory" factory-method="createMimeTypeList" >
+							<constructor-arg value="org.pentaho.platform.plugin.services.importer.LocaleImportHandler"/> 
+						</bean>
+					</constructor-arg>
+					<constructor-arg>
+						<list>
+							<value>xaction</value>
+							<value>url</value>
+							<value>xdash</value>
+							<value>prpt</value>
+							<value>prpti</value>
+							<value>xanalyzer</value>
+							<value>wcdf</value>
+							<value>xcdf</value>
+						</list>
+					</constructor-arg>
+					<property name="repository" ref="unifiedRepository" />
+					<property name="defaultAclHandler" ref="defaultAclHandler" />
+				</bean>
+				
+				<bean
+					class="org.pentaho.platform.plugin.services.importer.XActionImportHandler">
+					<constructor-arg>
+						<bean factory-bean="MimeTypeListFactory" factory-method="createMimeTypeList" >
+							<constructor-arg value="org.pentaho.platform.plugin.services.importer.XActionImportHandler"/> 
+						</bean>
+					</constructor-arg>
+				    <property name="repository" ref="unifiedRepository" />
+					<property name="defaultAclHandler" ref="defaultAclHandler" />
+				</bean>
+
+			</util:list>
+		</constructor-arg>
+	</bean>
+</beans>

--- a/test-src/solutionACL/system/pentaho.xml
+++ b/test-src/solutionACL/system/pentaho.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--===========================================================================
+PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
+
+Copyright 2002 - 2014 Pentaho Corporation (Pentaho). All rights reserved.
+
+NOTICE: All information including source code contained herein is, and
+remains the sole property of Pentaho and its licensors. The intellectual
+and technical concepts contained herein are proprietary and confidential
+to, and are trade secrets of Pentaho and may be covered by U.S. and foreign
+patents, or patents in process, and are protected by trade secret and
+copyright laws. The receipt or possession of this source code and/or related
+information does not convey or imply any rights to reproduce, disclose or
+distribute its contents, or to manufacture, use, or sell anything that it
+may describe, in whole or in part. Any reproduction, modification, distribution,
+or public display of this information without the express written authorization
+from Pentaho is strictly prohibited and in violation of applicable laws and
+international treaties. Access to the source code contained herein is strictly
+prohibited to anyone except those individuals and entities who have executed
+confidentiality and non-disclosure agreements or other agreements with Pentaho,
+explicitly covering such access.
+============================================================================-->
+<pentaho-system>
+
+  <!--
+ 	The kiosk-mode setting when set to true, will cause the platform to ignore some aspects of security 
+ 	to allow/enable behavior.  For example,	disable saving in WAQR.
+  -->
+  <kiosk-mode>false</kiosk-mode>
+
+  <!--
+    The login-show-users-list setting when set to true, will show a drop-down list of the default 
+    sample pentaho users (admin,suzy,pat,tiffany) in the login dialog which is shown when a user attemps
+    to login to the Pentaho User Console (PUC).
+  -->
+  <login-show-users-list>false</login-show-users-list> 
+  
+  <!-- 
+    If true, show hint about sample users. Ultimately, should replace login-show-users-list.
+  -->
+  <login-show-sample-users-hint>true</login-show-sample-users-hint>
+
+    <!--
+	This is the URL to the user guide
+    -->
+    <documentation-url>docs/InformationMap.jsp</documentation-url>
+
+	<log-file>server.log</log-file>
+	<log-level>DEBUG</log-level>
+
+	<!--
+		The configuration of publishers, system listeners, and session actions has been moved to
+		the systemListeners.xml, adminPlugins.xml, and sessionStartupActions.xml files which 
+		can be found in the "system" folder within your configured pentaho solution directory.
+	
+		If you're looking for the objects node, this functionality
+		has been moved to the file pentahoObjects.spring.xml in the
+		system solution.
+		
+		When everything is completed, this file will go away, and
+		not be at all required by the bi-platform-engine classes.
+		Rather, the wiring of the components/engines/system will
+		be able to be implemented by many different wiring schemes.
+		As a bare minimum, we'll have examples of system wiring using
+			Spring injection
+			Hand coded wiring
+			properties-file wiring
+		
+		This new system will allow for optimized wiring without requiring
+		the PentahoSystem, SystemSettings, or any components to parse
+		or interpret an XML document.
+	-->
+
+        <cache-provider>
+          <class>net.sf.ehcache.hibernate.SingletonEhCacheProvider</class>
+          <region>pentahoCache</region>
+          <!--
+          Uncomment this block to specify some parameters for your cache provider. EHCache has no parameters 
+          other than what are provided in the ehcache.xml.
+          <properties>
+              <property name="someProperty">someValue</property>
+          </properties>
+          -->
+        </cache-provider>
+        <acl-publisher>
+					<!-- 
+						These acls are used when publishing from the file system. Every folder
+						gets these ACLS. Authenticated is a "default" role that everyone
+						gets when they're authenticated (be sure to setup your bean xml properly
+						for this to work).
+					-->
+					<default-acls>
+						<acl-entry role="Administrator" acl="FULL_CONTROL" />				<!-- Administrator users get all authorities -->
+						<acl-entry role="cto" acl="FULL_CONTROL" />				<!-- CTO gets everything -->
+						<acl-entry role="dev" acl="EXECUTE_SUBSCRIBE" />		<!-- Dev gets execute/subscribe -->
+						<acl-entry role="Authenticated" acl="EXECUTE" />		<!-- Authenticated users get execute only -->
+					</default-acls>
+					
+					<!--
+						These acls are overrides to specific file/folders.  The above default-acls will
+						be applied and then these overrides.  This allows for specific access controls to
+						be loaded when the repository if first populated.  Futher changes to acls can be
+						made in the platform GUI tool.  Uncomment these and change add or delete to your hearts desire -->					
+
+					<overrides>
+						<file path="/pentaho-solutions/admin">
+							<acl-entry role="Administrator" acl="FULL_CONTROL" />
+						</file>
+					</overrides>
+
+					<!--
+					<overrides>
+						<file path="/pentaho-solutions/samples/bursting">
+							<acl-entry role="Administrator" acl="FULL_CONTROL" />
+							<acl-entry role="cto" acl="SUBSCRIBE_ADMINISTRATION" />
+							<acl-entry role="dev" acl="EXECUTE_SUBSCRIBE" />
+							<acl-entry role="Authenticated" acl="NOTHING" />
+						</file>
+						<file path="/pentaho-solutions/samples/datasources/MDX_Datasource.xaction">
+							<acl-entry role="Administrator" acl="FULL_CONTROL" />			
+							<acl-entry role="cto" acl="FULL_CONTROL" />			
+							<acl-entry role="dev" acl="EXECUTE_SUBSCRIBE" />	
+							<acl-entry role="Authenticated" acl="EXECUTE" />	
+						</file>
+					</overrides>
+					-->					
+				</acl-publisher>
+				<acl-voter>
+					<!-- What role must someone be in to be an ADMIN of Pentaho -->
+					<admin-role>Administrator</admin-role>
+				</acl-voter>
+				<!-- 
+				  acl-files tag was added in support of PPP-130 
+				  
+				  * Allow specification of ACLs on .url files
+				  
+				  * Allow specification of files acl-able to be
+					in the configuration
+					
+				  Usage: List the file extensions of files allowed to have
+				  acls. This is a performance tuning exercise since any file
+				  with an extension in this list can have ACLs applied.
+				-->
+                
+				<acl-files>xaction,url,prpt,prpti,xdash,xcdf,xanalyzer</acl-files>
+
+				<anonymous-authentication>
+				  <anonymous-user>anonymousUser</anonymous-user>
+				  <anonymous-role>Anonymous</anonymous-role>
+        </anonymous-authentication>
+                                
+	<!-- Insert additional pentaho-system -->
+	
+    <audit>
+      <auditLogFile>/PentahoAuditLog.log</auditLogFile>
+      <id_separator><![CDATA[\t]]></id_separator>
+      <auditDateFormat>yyyy/MM/dd k:mm:ss</auditDateFormat>
+    </audit>
+
+	<solution-repository>
+		<!-- Insert solution-repository -->
+		<cache-size>0</cache-size>
+	</solution-repository>
+
+</pentaho-system>

--- a/test-src/solutionACL/system/pentahoObjects.spring.xml
+++ b/test-src/solutionACL/system/pentahoObjects.spring.xml
@@ -1,0 +1,363 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--===========================================================================
+PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
+
+Copyright 2002 - 2014 Pentaho Corporation (Pentaho). All rights reserved.
+
+NOTICE: All information including source code contained herein is, and
+remains the sole property of Pentaho and its licensors. The intellectual
+and technical concepts contained herein are proprietary and confidential
+to, and are trade secrets of Pentaho and may be covered by U.S. and foreign
+patents, or patents in process, and are protected by trade secret and
+copyright laws. The receipt or possession of this source code and/or related
+information does not convey or imply any rights to reproduce, disclose or
+distribute its contents, or to manufacture, use, or sell anything that it
+may describe, in whole or in part. Any reproduction, modification, distribution,
+or public display of this information without the express written authorization
+from Pentaho is strictly prohibited and in violation of applicable laws and
+international treaties. Access to the source code contained herein is strictly
+prohibited to anyone except those individuals and entities who have executed
+confidentiality and non-disclosure agreements or other agreements with Pentaho,
+explicitly covering such access.
+============================================================================-->
+<!-- 
+This is a Spring file that defines how Pentaho system objects are created and managed.  
+An implementation of IPentahoObjectFactory, such as WebSpringPentahoObjectFactory, is 
+responsible for serving objects to callers based on this file.
+
+Possible values for scope attribute:
+*singleton* - each request for this object returns the same instance
+*prototype* - each request for this object returns a new instance
+*session* - each request for this object within a session returns the same instance
+
+default-lazy-init is set to true since some of these object make calls into 
+PentahoSystem which is initialized after Spring
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd 
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd 
+       http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd" default-lazy-init="true">
+
+  <bean id="ISolutionEngine" class="org.pentaho.platform.engine.services.solution.SolutionEngine" scope="prototype"/>
+  <!-- runtime repositories are not used in the current implmentation of the BI platform -->
+  <!-- <bean id="IRuntimeRepository" class="org.pentaho.platform.repository.runtime.RuntimeRepository" scope="session" /> -->
+  <bean id="IAuditEntry" class="org.pentaho.platform.engine.services.audit.AuditSQLEntry" scope="singleton"/>
+  <bean id="IUITemplater" class="org.pentaho.platform.web.http.WebTemplateHelper" scope="singleton"/>
+  <!-- Concrete implementation of IMetadataDomainRepository -->
+  <bean id="IMetadataDomainRepositoryImpl"
+        class="org.pentaho.platform.plugin.services.metadata.SecurityAwarePentahoMetadataDomainRepository" scope="singleton">
+    <constructor-arg>
+      <ref bean="unifiedRepository"/>
+    </constructor-arg>
+  </bean>
+  <!-- Wrap the concrete IMetadataDomainRepository implementation with one that caches domains per session -->
+  <bean id="IMetadataDomainRepository"
+        class="org.pentaho.platform.plugin.services.metadata.SessionCachingMetadataDomainRepository" scope="singleton">
+    <constructor-arg>
+      <ref bean="IMetadataDomainRepositoryImpl"/>
+    </constructor-arg>
+  </bean>
+  <!--  Use this schema factory to disable PMD security -->
+  <!--  <bean id="IMetadataDomainRepository" class="org.pentaho.platform.plugin.services.metadata.CachingPentahoMetadataDomainRepository" scope="singleton"/>-->
+  <bean id="IUserSettingService" class="org.pentaho.platform.repository.usersettings.UserSettingService"
+        scope="session">
+      <constructor-arg ref="unifiedRepository"/>
+  </bean>
+  <bean id="IEmailService" class="org.pentaho.platform.plugin.services.email.EmailService" scope="session"/>
+  <bean id="file" class="org.pentaho.platform.plugin.outputs.FileOutputHandler" scope="session"/>
+  <bean id="contentrepo" class="org.pentaho.platform.repository2.unified.fileio.RepositoryContentOutputHandler"
+        scope="session"/>
+  <bean id="vfs-ftp" class="org.pentaho.platform.plugin.outputs.ApacheVFSOutputHandler" scope="session"/>
+  <bean id="IAclPublisher" class="org.pentaho.platform.engine.security.acls.AclPublisher" scope="singleton"/>
+  <bean id="IAclVoter" class="org.pentaho.platform.engine.security.acls.voter.PentahoBasicAclVoter" scope="singleton"/>
+  <bean id="IVersionHelper" class="com.pentaho.util.SubscriptionVersionHelper" scope="singleton"/>
+  <bean id="ICacheManager" class="org.pentaho.platform.plugin.services.cache.CacheManager" scope="singleton"/>
+
+  <bean id="IBlockoutManager" class="org.pentaho.platform.scheduler2.blockout.PentahoBlockoutManager" scope="singleton"/>
+  <bean id="IConditionalExecution" class="org.pentaho.platform.plugin.condition.javascript.ConditionalExecution"
+        scope="prototype"/>
+  <bean id="IMessageFormatter" class="org.pentaho.platform.engine.services.MessageFormatter" scope="singleton"/>
+  <bean id="IVersionCheckDataProvider" class="com.pentaho.core.system.PentahoEEVersionCheckDataProvider"
+        scope="prototype"/>
+  <!--
+    IDBDatasourceService - options are: 
+    org.pentaho.platform.engine.services.connection.datasource.dbcp.JndiDatasourceService
+    org.pentaho.platform.engine.services.connection.datasource.dbcp.NonPooledOrJndiDatasourceService
+    org.pentaho.platform.engine.services.connection.datasource.dbcp.PooledDatasourceService
+    org.pentaho.platform.engine.services.connection.datasource.dbcp.NonPooledDatasourceService
+    org.pentaho.platform.engine.services.connection.datasource.dbcp.PooledOrJndiDatasourceService  
+    org.pentaho.platform.engine.services.connection.datasource.dbcp.DynamicallyPooledOrJndiDatasourceService (Default option)
+  -->
+  <bean id="pooledOrJndiDatasourceService" class="org.pentaho.platform.engine.services.connection.datasource.dbcp.PooledOrJndiDatasourceService" scope="singleton" />
+  <bean id="nonPooledOrJndiDatasourceService" class="org.pentaho.platform.engine.services.connection.datasource.dbcp.NonPooledOrJndiDatasourceService" scope="singleton" />
+  
+  <bean id="IDBDatasourceService" class="org.pentaho.platform.engine.services.connection.datasource.dbcp.DynamicallyPooledOrJndiDatasourceService" scope="singleton">
+    <property name="pooledDatasourceService" ref="pooledOrJndiDatasourceService" />
+    <property name="nonPooledDatasourceService" ref="nonPooledOrJndiDatasourceService" />
+  </bean>
+  <bean id="IPasswordService" class="org.pentaho.platform.util.Base64PasswordService" scope="singleton"/>
+  <bean id="IPluginProvider" class="org.pentaho.platform.plugin.services.pluginmgr.SystemPathXmlPluginProvider"
+        scope="singleton"/>
+
+  <bean id="IPluginManager" class="org.pentaho.platform.plugin.services.pluginmgr.DefaultPluginManager"
+        scope="singleton"/>
+
+  <!-- Enhanced PluginManager -->
+  <!--<bean id="IPluginManager" class="com.pentaho.platform.pluginManager.EEPluginManager"-->
+        <!--scope="singleton"/>-->
+
+  <bean id="IPluginResourceLoader" class="org.pentaho.platform.plugin.services.pluginmgr.PluginResourceLoader"
+        scope="singleton"/>
+  <bean id="IPluginPerspectiveManager"
+        class="org.pentaho.platform.plugin.services.pluginmgr.perspective.DefaultPluginPerspectiveManager"
+        scope="singleton"/>
+  <bean id="IServiceManager" class="org.pentaho.platform.plugin.services.pluginmgr.servicemgr.DefaultServiceManager"
+        scope="singleton">
+    <property name="serviceTypeManagers">
+      <list>
+        <ref bean="gwtServiceManager"/>
+        <ref bean="axisServiceManager"/>
+      </list>
+    </property>
+  </bean>
+  <bean id="ITempFileDeleter" class="org.pentaho.platform.web.http.session.SessionTempFileDeleter" scope="prototype"/>
+  <bean id="gwtServiceManager" class="org.pentaho.platform.plugin.services.pluginmgr.servicemgr.GwtRpcServiceManager"
+        scope="singleton"/>
+  <bean id="axisServiceManager" class="org.pentaho.platform.plugin.services.pluginmgr.servicemgr.AxisWebServiceManager"
+        scope="singleton"/>
+
+  <bean id="IChartBeansGenerator" class="org.pentaho.platform.plugin.action.chartbeans.DefaultChartBeansGenerator"
+        scope="singleton"/>
+
+  <!-- Data connections.  Connections objects should be accessed through PentahoConnectionFactory,
+not directly from the PentahoObjectFactory. -->
+  <bean id="connection-SQL" class="org.pentaho.platform.plugin.services.connections.sql.SQLConnection"
+        scope="prototype">
+    <property name="fallBackToNonscrollableOnError" value="true"/>
+  </bean>
+  <bean id="connection-MDX" class="org.pentaho.platform.plugin.services.connections.mondrian.MDXConnection"
+        scope="prototype">
+    <property name="useExtendedColumnNames" value="true"/>
+  </bean>
+  <bean id="connection-MDXOlap4j" class="org.pentaho.platform.plugin.services.connections.mondrian.MDXOlap4jConnection" scope="prototype" />
+  <bean id="connection-XML" class="org.pentaho.platform.plugin.services.connections.xquery.XQConnection"
+        scope="prototype"/>
+  <bean id="connection-HQL" class="org.pentaho.platform.plugin.services.connections.hql.HQLConnection"
+        scope="prototype"/>
+
+  <!-- actual bean defined in repository.spring.xml; aliased here -->
+  <alias name="unifiedRepository" alias="IUnifiedRepository"/>
+
+  <!-- actual bean defined in repository.spring.xml; aliased here -->
+  <alias name="backingRepositoryLifecycleManager" alias="IBackingRepositoryLifecycleManager"/>
+
+  <!-- actual bean defined in repository.spring.xml; aliased here -->
+  <alias name="authorizationPolicy" alias="IAuthorizationPolicy"/>
+
+  <!-- actual bean defined in repository.spring.xml; aliased here -->
+  <alias name="roleAuthorizationPolicyRoleBindingDaoTxn" alias="IRoleAuthorizationPolicyRoleBindingDao"/>
+
+  <!-- Reference to a bean in one of the applicationContext-pentaho-security-*.xml; selected by configured provider-->
+  <pen:bean id="activeUserRoleListService" class="org.pentaho.platform.api.engine.IUserRoleListService">
+    <pen:attributes>
+      <pen:attr key="providerName" value="${security.provider}"/>
+    </pen:attributes>
+  </pen:bean>
+
+  <!-- The system must have access to the jackrabbit version even if another is configured. -->
+  <pen:bean id="systemUserRoleListService" class="org.pentaho.platform.api.engine.IUserRoleListService">
+    <pen:attributes>
+      <pen:attr key="providerName" value="jackrabbit"/>
+    </pen:attributes>
+  </pen:bean>
+
+  <!-- A composite bean composed of the activeUserRoleListService and systemUserRoleListService -->
+  <bean id="IUserRoleListService" class="org.pentaho.platform.plugin.services.security.userrole.CompositeUserRoleListService">
+    <constructor-arg>
+      <list>
+        <ref bean="activeUserRoleListService"/>
+        <ref bean="systemUserRoleListService"/>
+      </list>
+    </constructor-arg>
+    <pen:publish as-type="INTERFACES">
+      <pen:attributes>
+        <pen:attr key="priority" value="50"/>
+      </pen:attributes>
+    </pen:publish>
+  </bean>
+
+  <!-- Reference to a bean in one of the applicationContext-pentaho-security-*.xml; selected by configured provider-->
+  <pen:bean id="activeUserDetailsService" class="org.springframework.security.userdetails.UserDetailsService">
+    <pen:attributes>
+      <pen:attr key="providerName" value="${security.provider}"/>
+    </pen:attributes>
+  </pen:bean>
+
+  <!-- The system must have access to the jackrabbit version even if another is configured. -->
+  <pen:bean id="systemUserDetailsService" class="org.springframework.security.userdetails.UserDetailsService">
+    <pen:attributes>
+      <pen:attr key="providerName" value="jackrabbit"/>
+    </pen:attributes>
+  </pen:bean>
+
+  <!-- A composite bean composed of the activeUserDetailsService and systemUserDetailsService -->
+  <bean id="UserDetailsService" class="org.pentaho.platform.plugin.services.security.userrole.ChainedUserDetailsService">
+    <constructor-arg>
+      <list>
+        <ref bean="activeUserDetailsService"/>
+        <ref bean="systemUserDetailsService"/>
+      </list>
+    </constructor-arg>
+  </bean>
+
+  <bean id="ehCacheUserCache" class="org.springframework.security.providers.dao.cache.EhCacheBasedUserCache">
+    <property name="cache">
+      <bean class="org.springframework.cache.ehcache.EhCacheFactoryBean">
+        <property name="cacheManager">
+          <bean class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
+      <property name="shared" value="true"/>
+  </bean>
+        </property>
+        <property name="cacheName" value="userCache"/>
+      </bean>
+    </property>
+  </bean>
+
+  <bean id="cachingUserDetailsService" class="org.pentaho.platform.plugin.services.security.userrole.PentahoCachingUserDetailsService">
+    <constructor-arg>
+      <ref bean="UserDetailsService"/>
+    </constructor-arg>
+    <constructor-arg ref="tenantedUserNameUtils"/>
+    <property name="userCache" ref="ehCacheUserCache"/>
+
+    <pen:publish as-type="INTERFACES">
+      <pen:attributes>
+        <pen:attr key="priority" value="50"/>
+      </pen:attributes>
+    </pen:publish>
+
+  </bean>
+
+
+    <pen:bean class="org.springframework.security.providers.AuthenticationProvider">
+        <pen:attributes>
+            <pen:attr key="providerName" value="${security.provider}"/>
+        </pen:attributes>
+        <pen:publish as-type="ALL">
+            <pen:attributes>
+                <pen:attr key="priority" value="50"/>
+            </pen:attributes>
+        </pen:publish>
+    </pen:bean>
+
+
+  <!-- actual bean defined in applicationContext-spring-security.xml; aliased here -->
+  <alias name="authenticationManager" alias="AuthenticationManager"/>
+
+    <bean id="IMondrianCatalogService" class="org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogHelper"
+        scope="singleton"/>
+
+  <bean id="IOlapService" class="org.pentaho.platform.plugin.action.olap.impl.OlapServiceImpl"
+        scope="singleton">
+    <pen:publish as-type="org.pentaho.platform.plugin.action.olap.IOlapService"/>
+    <!-- Allows to override some properties form each connection before they are established. -->
+    <!--property name="connectionFilters">
+      <list>
+        <bean class="org.pentaho.platform.plugin.action.olap.IOlapConnectionFilter"/>
+      </list>
+    </property-->
+    <!-- Allows to specify a custom class to use as a role implementation for hosted mondrian connections. -->
+    <!--property name="mondrianRole">
+      <bean class="mondrian.olap.RoleImpl"/>
+    </property-->
+  </bean>
+
+  <!--  This mondrian user/role mapper assumes that roles from the platform also exist in mondrian -->
+
+  <bean id="IDatabaseDialectService" class="org.pentaho.database.service.DatabaseDialectService" scope="singleton"/>
+
+  <bean id="IDatasourceMgmtService" class="org.pentaho.platform.repository.JcrBackedDatasourceMgmtService"
+        scope="singleton">
+    <constructor-arg ref="unifiedRepository"/>
+    <constructor-arg ref="IDatabaseDialectService"/>
+  </bean>
+
+  <!--
+  Disabled by default in 3.5.2. In trunk, this should be enabled.
+     -->
+  <bean id="Mondrian-UserRoleMapper" 
+        name="Mondrian-One-To-One-UserRoleMapper"  
+        class="org.pentaho.platform.plugin.action.mondrian.mapper.MondrianOneToOneUserRoleListMapper" 
+        scope="singleton" />
+
+
+  <!--  
+
+ This sample mapper assumes that a translator is needed (in the form of a Map) to map a platform role to a mondrian role
+
+ Note- Key = platform role, value = mondrian role
+
+ <bean id="Mondrian-UserRoleMapper"
+       name="Mondrian-SampleLookupMap-UserRoleMapper"
+       class="org.pentaho.platform.plugin.action.mondrian.mapper.MondrianLookupMapUserRoleListMapper"
+       scope="singleton">
+   <property name="lookupMap">
+     <map>
+       <entry key="ceo" value="M_CEO" />
+       <entry key="cto" value="M_CTO" />
+       <entry key="dev" value="M_DEV" />
+     </map>
+   </property>
+ </bean>
+  -->
+
+  <!--  
+  This sample mapper assumes that every user has their mondrian roles in their session under then named session variable
+  <bean id="Mondrian-UserRoleMapper" 
+        name="Mondrian-SampleUserSession-UserRoleMapper" 
+        class="org.pentaho.platform.plugin.action.mondrian.mapper.MondrianUserSessionUserRoleListMapper" 
+        scope="singleton">
+    <property name="sessionProperty" value="MondrianUserRoles" />
+  </bean>
+  -->
+  <bean id="ReportCache" class="org.pentaho.reporting.platform.plugin.cache.NullReportCache" scope="singleton"/>
+  <bean id="PentahoNameGenerator" class="org.pentaho.reporting.platform.plugin.repository.TempDirectoryNameGenerator"
+        scope="prototype"/>
+  <bean id="MondrianConnectionProvider"
+        class="org.pentaho.reporting.platform.plugin.connection.PentahoMondrianConnectionProvider" scope="singleton"/>
+
+  <bean id="metadataqueryexec-SQL"
+        class="org.pentaho.platform.plugin.services.connections.metadata.sql.SqlMetadataQueryExec" scope="prototype"/>
+  <bean id="sqlGenerator" class="org.pentaho.metadata.query.impl.sql.SqlGenerator" scope="prototype"/>
+  <bean id="IThemeManager" class="org.pentaho.platform.web.html.themes.DefaultThemeManager" scope="singleton"/>
+
+  <bean id="ICacheExpirationRegistry" class="org.pentaho.platform.plugin.services.cache.CacheExpirationRegistry"
+        scope="singleton"/>
+
+  <!--
+  Used by Dashboards Printing to authenticate the printing process for a given user.
+  -->
+  <bean id="PreAuthenticatedSessionHolder" class="org.pentaho.platform.web.http.PreAuthenticatedSessionHolder" scope="singleton">
+    <!-- TTL in seconds -->
+    <constructor-arg value="600"/>
+    <!-- eviction schedule in seconds -->
+    <constructor-arg value="60"/>
+  </bean>
+
+  <bean id="jdbcDriverTranslationMap" class="java.util.HashMap">
+    <pen:publish as-type="ALL"/>
+    <constructor-arg index="0" type="java.util.Map">
+      <map key-type="java.lang.String" value-type="java.lang.String">
+        <entry key="mondrian4" value="mondrian"/>
+      </map>
+    </constructor-arg>
+  </bean>
+
+
+    <bean id="dataAccessPermissionHandler" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessPermissionHandler">
+        <pen:publish as-type="INTERFACES" />
+    </bean>
+</beans>

--- a/test-src/solutionACL/system/repository-test-override.spring.xml
+++ b/test-src/solutionACL/system/repository-test-override.spring.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:sec="http://www.springframework.org/schema/security"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-2.0.1.xsd
+                      http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd">
+
+  <!-- Bean definitions in this file override bean definitions in repository.spring.xml. -->
+
+  <sec:authentication-provider>
+    <sec:user-service id="userDetailsService">
+      <sec:user password="password" name="admin" authorities="Authenticated, Administrator"/>
+      <sec:user password="password" name="suzy" authorities="Authenticated"/>
+    </sec:user-service>
+  </sec:authentication-provider>
+
+  <sec:authentication-manager alias="authenticationManager"/>
+
+  <bean id="jcrRepository" class="org.springframework.extensions.jcr.jackrabbit.RepositoryFactoryBean">
+    <property name="configuration" value="classpath:/jackrabbit-test-repo.xml"/>
+    <property name="homeDir" value="file:/tmp/jackrabbit-test-TRUNK"/>
+  </bean>
+
+  <!-- override to keep only the required managers -->
+  <bean id="backingRepositoryLifecycleManager"
+        class="org.pentaho.platform.repository2.unified.lifecycle.DelegatingBackingRepositoryLifecycleManager">
+    <constructor-arg>
+      <list>
+        <ref bean="defaultBackingRepositoryLifecycleManager"/>
+      </list>
+    </constructor-arg>
+  </bean>
+
+  <bean class="org.pentaho.platform.dataaccess.security.policy.rolebased.actions.DatasourceManageAction">
+    <pen:publish as-type="INTERFACES">
+      <pen:attributes>
+        <pen:attr key="priority" value="70"/>
+      </pen:attributes>
+    </pen:publish>
+  </bean>
+
+  <bean id="dataAccessViewPermissionHandler" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessViewPermissionHandler">
+    <pen:publish as-type="INTERFACES" />
+  </bean>
+  <bean id="dataAccessPermissionHandler" class="org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessPermissionHandler">
+    <pen:publish as-type="INTERFACES" />
+  </bean>
+  <!--
+    To enable RMI in a unit test, put jackrabbit-jcr-rmi-1.5.0.jar in dev-lib and add to Eclipse classpath.
+
+
+    You have to acquire your remote repository using the JackrabbitClientAdapterFactory instead of the default
+    ClientAdapterFactory. Otherwise the Jackrabbit API is not available on the client side.
+
+    In short you should do:
+
+      LocalAdapterFactory aFactory = new JackrabbitClientAdapterFactory();
+      ClientRepositoryFactory rFactory = new ClientRepositoryFactory(aFactory);
+      Repository repo = rFactory.getRepository(rmiURL);
+
+    Then you can cast the NodeTypeManager you get from the workspace to a JackrabbitNodeTypeManager and can then register
+    your node types.
+     -->
+  <!--bean id="rmiClientFactory" class="org.apache.jackrabbit.rmi.client.ClientRepositoryFactory">
+    <constructor-arg>
+      <bean class="org.apache.jackrabbit.rmi.jackrabbit.JackrabbitClientAdapterFactory" />
+    </constructor-arg>
+  </bean>
+
+  <bean id="jcrRepository" factory-bean="rmiClientFactory" factory-method="getRepository">
+    <constructor-arg value="rmi://localhost:1099/jackrabbit"/>
+  </bean-->
+
+</beans>


### PR DESCRIPTION
...user/role

[BACKLOG-1561] - Add the ability to get security/ACL information about a datasource
[BACKLOG-1564] - Change current datasource creation endpoints to allow ACL configuration
[BACKLOG-1495] - Add the ability to change the visibility of a data source
add ACL parameters to publish endpoints, move them to the bundle creation
add endpoints for get/put ACL data for Data Sources
integration test, correct response status codes, flush cache on ACL set
unit tests