### PR TITLE
[BISERVER-12335] - Regression: PUC Datasource Wizard - After New datasource creation Source Type is not returned to default

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/EmbeddedWizard.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/EmbeddedWizard.java
@@ -240,6 +240,7 @@ public class EmbeddedWizard extends AbstractXulDialogController<Domain> implemen
     wizardModel.setEditing( false );
     wizardController.setActiveStep( 0 );
     wizardModel.reset();
+    wizardController.resetSelectedDatasource();
     wizardModel.setReportingOnlyValid( this.reportingOnlyValid );
 
     /*


### PR DESCRIPTION
[BISERVER-12335] - Regression: PUC Datasource Wizard - After New datasource creation Source Type is not returned to default