### PR TITLE
[BACKLOG-3535]: The last dialog (data source wizard summary) unable to access the option to "customize" the model.

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/main_wizard_panel.xul
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/main_wizard_panel.xul
@@ -603,7 +603,7 @@
       </vbox>
       <spacer height="10"/>
       <vbox id="showModelerCheckboxHider" height="140">
-        <groupbox flex="1" height="132">
+        <groupbox flex="1" height="155">
           <caption label="${summaryDialog.note}"/>
           <label id="summaryDialogDescription" value="${summaryDialog.description}" multiline="true"/>
           <radiogroup id="modelerDecision" flex="1" height="53">


### PR DESCRIPTION
Fix verified for IE, FF, Chrome and Safari on Mac.