### PR TITLE
[BISERVER-12153]: DSW defaults for zero length for numeric fields in CSV datasource

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvUtils.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvUtils.java
@@ -364,7 +364,7 @@ public class CsvUtils extends PentahoBase {
       // pad the string lengths
       size = meta.getLength() + ( meta.getLength() / 2 );
     } else {
-      size = 0;
+      size = precision > 0 ? meta.getLength() : 0;
     }
 
     profile.setLength( size );

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvModelServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvModelServiceTest.java
@@ -117,4 +117,17 @@ public class CsvModelServiceTest extends BaseTest {
     assertEquals("MM/dd/yyyy", ci.getFormat());
 
   }
+  
+  @Test
+  public void testAssumeColumnDetails_NumericWithPrecisionAndLength() {
+    service = new CsvUtils();
+    String[] samples = new String[] {"11.1", "11.111", "11.1111"};
+    ColumnInfo ci = new ColumnInfo();
+
+    service.assumeColumnDetails(ci, Arrays.asList(samples));
+    assertEquals(DataType.NUMERIC, ci.getDataType());
+    assertEquals(4, ci.getPrecision());
+    assertEquals(7, ci.getLength());
+
+  }
 }


### PR DESCRIPTION
Problem:
By default for numeric fields we set length=0. So we can have ColumnInfo with precision>0 but length=0.
Such combination leads to problem at definition of suitable database type in MSSQLServerDatabaseMeta.getFieldDefinition.
Fix:
Set up default length for numeric fields with precision>0 as length of meta of adviced result.