### PR TITLE
Revert "SP-1948 - Backport of BISERVER-12579 - Non-admin User Unable …

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
@@ -394,7 +394,8 @@ public class ConnectionService {
   @Consumes( { APPLICATION_JSON } )
   @Facet( name = "Unsupported" )
   public Response addConnection( DatabaseConnection connection ) throws ConnectionServiceException {
-    try {      
+    try {
+      validateAccess();
       boolean success = connectionService.addConnection( connection );
       if ( success ) {
         return Response.ok().build();


### PR DESCRIPTION
@rmansoor 
Please review.

Reverts pentaho/data-access#641

Marc Batchelor's comment on SP-1948:
Changing repository.xml cannot be done on an SP for several reasons:
This is a file we expect many of our customers to change. It is backed up and restored as part of the Upgrade Utility as well, so it cannot be fixed / changed in a point release either.
Changing repository.xml will have no effect unless you blow away the repository folder under jackrabbit. This is because the file gets exploded into several other files in that folder.
AFAIK, this change wouldn't take effect unless they started with a completely clean repository.
So - this SP CANNOT be done. Please back out the change, and close this ticket as "Won't Fix".

Goes with https://github.com/pentaho/pentaho-platform/pull/2368 and https://github.com/pentaho/pentaho-platform-ee/pull/735