### PR TITLE
[SP-2046] - Backport of BISERVER-12702 - Security Vulnerability - Abi…

### DIFF
--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImplTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImplTest.java
@@ -52,7 +52,7 @@ public class CsvDatasourceServiceImplTest {
     existingContext = PentahoSystem.getApplicationContext();
 
     mockContext = mock( IApplicationContext.class );
-    when( mockContext.getSolutionPath( anyString() ) ).thenReturn( TMP_DIR );
+    when( mockContext.getSolutionPath( anyString() ) ).thenReturn( TMP_DIR + '/' );
     PentahoSystem.setApplicationContext( mockContext );
 
     service = new CsvDatasourceServiceImpl();


### PR DESCRIPTION
…lity to traverse folders using ICsvDatasourceService (5.4 Suite)

- fixing failed test

@mbatchelor, merge it please. Looks like ```solutionPath``` is expected to strictly be ended with '/' 