### PR TITLE
[SP-2046] - Backport of BISERVER-12702 - Security Vulnerability - Abi…

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImpl.java
@@ -18,6 +18,7 @@
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -97,10 +98,14 @@ public class CsvDatasourceServiceImpl extends PentahoBase implements ICsvDatasou
                               String encoding )
     throws Exception {
     ModelInfo modelInfo;
+    fileName = FilenameUtils.getName( fileName );
     try {
       int headerRows = isFirstRowHeader ? 1 : 0;
-      modelInfo = new CsvUtils().generateFields( "", FilenameUtils.getName( fileName ),
-        AgileHelper.getCsvSampleRowSize(), delimiter, enclosure, headerRows, true, true, encoding ); //$NON-NLS-1$
+      modelInfo = new CsvUtils().generateFields( "", fileName, AgileHelper.getCsvSampleRowSize(),
+        delimiter, enclosure, headerRows, true, true, encoding ); //$NON-NLS-1$
+    } catch ( FileNotFoundException e ) {
+      logger.error( e );
+      throw new Exception( "File was not found: " + fileName );
     } catch ( Exception e ) {
       logger.error( e );
       throw e;

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImplTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImplTest.java
@@ -26,7 +26,6 @@ import org.pentaho.platform.dataaccess.datasource.wizard.models.ModelInfo;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 
 import static org.junit.Assert.*;
@@ -67,24 +66,36 @@ public class CsvDatasourceServiceImplTest {
   }
 
 
-  @Test( expected = FileNotFoundException.class )
+  @Test( expected = Exception.class )
   public void stageFile_InvalidPath_Csv_ThrowsException() throws Exception {
     service.stageFile( "../../../secret-file.csv", ",", "\n", false, "utf-8" );
   }
 
-  @Test( expected = FileNotFoundException.class )
+  @Test( expected = Exception.class )
   public void stageFile_InvalidPath_Tmp_ThrowsException() throws Exception {
     service.stageFile( "../../../secret-file.tmp", ",", "\n", false, "utf-8" );
   }
 
-  @Test( expected = FileNotFoundException.class )
+  @Test( expected = Exception.class )
   public void stageFile_InvalidPath_WindowsStyle_ThrowsException() throws Exception {
     service.stageFile( "..\\..\\..\\secret-file.csv", ",", "\n", false, "utf-8" );
   }
 
-  @Test( expected = FileNotFoundException.class )
+  @Test( expected = Exception.class )
   public void stageFile_InvalidPath_SlashAtEnd_ThrowsException() throws Exception {
     service.stageFile( "../../../secret-file/", ",", "\n", false, "utf-8" );
+  }
+
+
+  @Test
+  public void stageFile_InvalidPath_DoesNotRevealInternalDetails() throws Exception {
+    try {
+      service.stageFile( "../../../secret-file.tmp", ",", "\n", false, "utf-8" );
+      fail( "Should throw exception" );
+    } catch ( Exception e ) {
+      String message = e.getMessage();
+      assertFalse( message, message.contains( TMP_DIR ) );
+    }
   }
 
 


### PR DESCRIPTION
…lity to traverse folders using ICsvDatasourceService (5.4 Suite)

- conceal any details about file system

@mbatchelor, @rmansoor, @pentaho-nbaker, @mdamour1976, @pamval, review it please.

I found out the error message shows up the (temp / upload) folder's path (depending on the file's extension). This fix removes such details from the output. I deliberately didn't respect i18n for exception's message as in normal scenario user will never face such problem.