### PR TITLE
[BACKLOG-4725] - introducing parameter for import called retainInline…

### DIFF
--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -17,303 +17,270 @@
 
 package org.pentaho.platform.dataaccess.datasource.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.collect.Sets;
+import com.sun.jersey.core.header.FormDataContentDisposition;
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
-import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.IDataAccessPermissionHandler;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IAclAwareMondrianCatalogService;
+import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
+import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCube;
+import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianSchema;
 import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
-import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
+import org.pentaho.platform.plugin.services.importer.RepositoryFileImportBundle;
+import org.pentaho.platform.repository2.unified.fs.FileSystemBackedUnifiedRepository;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclAdapter;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
+import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
+import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
+import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
 
-import com.sun.jersey.core.header.FormDataContentDisposition;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.*;
 
 public class AnalysisServiceTest {
 
-  private static AnalysisService analysisService;
+  private static IMetadataDomainRepository metadataRepository;
+  private static IPlatformImporter importer;
+  private static IAuthorizationPolicy policy;
+  private static IAclAwareMondrianCatalogService catalogService;
+  private static IDataAccessPermissionHandler permissionHandler;
+  private static final RepositoryFileAclDto acl = new RepositoryFileAclDto();
 
-  private class AnalysisServiceMock extends AnalysisService {
-    @Override protected IUnifiedRepository getRepository() {
-      return mock( IUnifiedRepository.class );
-    }
-  }
-
-  @Before
-  public void setUp() {
-    analysisService = spy( new AnalysisServiceMock());
-    analysisService.metadataDomainRepository = mock( IMetadataDomainRepository.class );
-    analysisService.importer = mock( IPlatformImporter.class );
-    analysisService.aclAwareMondrianCatalogService = mock( IAclAwareMondrianCatalogService.class );
-    analysisService.mondrianCatalogService = analysisService.aclAwareMondrianCatalogService;
+  @BeforeClass
+  public static void initPlatform() throws Exception {
+    MicroPlatform platform = new MicroPlatform();
+    metadataRepository = mock( IMetadataDomainRepository.class );
+    platform.defineInstance( IMetadataDomainRepository.class, metadataRepository );
+    importer = mock( IPlatformImporter.class );
+    platform.defineInstance( IPlatformImporter.class, importer );
+    policy = mock( IAuthorizationPolicy.class );
+    platform.defineInstance( IAuthorizationPolicy.class, policy );
+    catalogService = mock( IAclAwareMondrianCatalogService.class );
+    platform.defineInstance( IMondrianCatalogService.class, catalogService );
+    permissionHandler = mock( IDataAccessPermissionHandler.class );
+    platform.defineInstance( IDataAccessPermissionHandler.class, permissionHandler );
+    final IUnifiedRepository unifiedRepository = new FileSystemBackedUnifiedRepository( "test-res/solution1" );
+    platform.defineInstance( IUnifiedRepository.class, unifiedRepository );
+    platform.start();
+    acl.setOwner( "owner" );
+    acl.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
   }
 
   @After
-  public void cleanup() {
-    analysisService = null;
+  public void tearDown() throws Exception {
+    Mockito.reset( metadataRepository, importer, policy, catalogService, permissionHandler );
+
+  }
+
+  private void allAccess() {
+    when( policy.isAllowed( any( String.class ) ) ).thenReturn( true );
+    when( permissionHandler.hasDataAccessPermission( any( IPentahoSession.class ) ) ).thenReturn( true );
+  }
+
+  @Test
+  public void testImportingSchemaRemovesExistingAnnotationsByDefault() throws Exception {
+    when( policy.isAllowed( any( String.class ) ) ).thenReturn( true );
+    FormDataContentDisposition schemaFileInfo = mock( FormDataContentDisposition.class );
+    InputStream schema = getClass().getResourceAsStream( "schema.xml" );
+    MondrianCatalog otherCatalog = new MondrianCatalog( "other", "", "", null );
+    MondrianCatalog salesCatalog = new MondrianCatalog( "sales", "", "", null );
+    when( catalogService.listCatalogs( any( IPentahoSession.class ), eq( false ) ) )
+      .thenReturn( Arrays.asList( otherCatalog, salesCatalog ) );
+    new AnalysisService()
+        .putMondrianSchema(
+          schema, schemaFileInfo, "sample", null, "sample", true, false, "overwrite=true", acl );
+    verify( importer ).importFile( argThat( matchBundle( true, acl ) ) );
+    verify( catalogService ).removeCatalog( eq( "sales" ), any( IPentahoSession.class ) );
+  }
+
+  @Test
+  public void testImportingSkipsRemoveWhenNotPresent() throws Exception {
+    when( policy.isAllowed( any( String.class ) ) ).thenReturn( true );
+    FormDataContentDisposition schemaFileInfo = mock( FormDataContentDisposition.class );
+    InputStream schema = getClass().getResourceAsStream( "schema.xml" );
+    MondrianCatalog otherCatalog = new MondrianCatalog( "other", "", "", null );
+    when( catalogService.listCatalogs( any( IPentahoSession.class ), eq( false ) ) )
+      .thenReturn( Collections.singletonList( otherCatalog ) );
+    new AnalysisService()
+        .putMondrianSchema(
+          schema, schemaFileInfo, "sample", null, "sample", true, false, "overwrite=true", acl );
+    verify( importer ).importFile( argThat( matchBundle( true, acl ) ) );
+    verify( catalogService, never() ).removeCatalog( eq( "sales" ), any( IPentahoSession.class ) );
+  }
+
+  @Test
+  public void testImportingSchemaCanRetainAnnotations() throws Exception {
+    when( policy.isAllowed( any( String.class ) ) ).thenReturn( true );
+    FormDataContentDisposition schemaFileInfo = mock( FormDataContentDisposition.class );
+    InputStream schema = getClass().getResourceAsStream( "schema.xml" );
+    new AnalysisService()
+        .putMondrianSchema(
+          schema, schemaFileInfo, "sample", null, "sample", true, false,
+          "overwrite=true;retainInlineAnnotations=true", acl );
+    verify( importer ).importFile( argThat( matchBundle( true, acl ) ) );
+    verify( catalogService, Mockito.times( 0 ) ).removeCatalog( eq( "sales" ), any( IPentahoSession.class ) );
+  }
+
+  @Test
+  public void testImportingSchemaWillNotOverwrite() throws Exception {
+    when( policy.isAllowed( any( String.class ) ) ).thenReturn( true );
+    FormDataContentDisposition schemaFileInfo = mock( FormDataContentDisposition.class );
+    InputStream schema = getClass().getResourceAsStream( "schema.xml" );
+    new AnalysisService()
+        .putMondrianSchema(
+          schema, schemaFileInfo, "sample", null, "sample", true, false,
+          "overwrite=false;retainInlineAnnotations=true", acl );
+    verify( importer ).importFile( argThat( matchBundle( false, acl ) ) );
+    verify( catalogService, never() ).removeCatalog( eq( "sales" ), any( IPentahoSession.class ) );
+  }
+
+  private BaseMatcher<IPlatformImportBundle> matchBundle( final boolean overwrite, final RepositoryFileAclDto acl ) {
+    return new BaseMatcher<IPlatformImportBundle>() {
+      @Override public void describeTo( final Description description ) {
+      }
+
+      @Override public boolean matches( final Object item ) {
+        RepositoryFileImportBundle bundle = (RepositoryFileImportBundle) item;
+        return bundle.getName().equals( "sales" )
+          && bundle.isOverwriteInRepository() == overwrite
+          && bundle.getAcl().equals( new RepositoryFileAclAdapter().unmarshal( acl ) );
+      }
+    };
   }
 
   @Test
   public void testDoGetAnalysisFilesAsDownload() throws Exception {
-    final String analysisId = "analysisId";
-    Map<String, InputStream> mockMap = mock( Map.class );
-    MondrianCatalogRepositoryHelper
-        mockMondrianCatalogRepositoryHelpere =
-        mock( MondrianCatalogRepositoryHelper.class );
-
-    doReturn( true ).when( analysisService ).canManageACL();
-    final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
-    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( analysisId ), any( IPentahoSession.class ) ) ).thenReturn(
-        mondrianCatalog );
-    doReturn( mockMondrianCatalogRepositoryHelpere ).when( analysisService ).createNewMondrianCatalogRepositoryHelper();
-    doReturn( mockMap ).when( mockMondrianCatalogRepositoryHelpere ).getModrianSchemaFiles( analysisId );
-
-    Map<String, InputStream> response = analysisService.doGetAnalysisFilesAsDownload( analysisId );
-
-    verify( analysisService, times( 1 ) ).doGetAnalysisFilesAsDownload( analysisId );
-    assertEquals( mockMap, response );
+    allAccess();
+    final Map<String, InputStream> sampleData = new AnalysisService().doGetAnalysisFilesAsDownload( "SampleData" );
+    assertEquals( 1, sampleData.size() );
+    final FileInputStream inputStream = new FileInputStream( "test-res/solution1/etc/mondrian/SampleData/schema.xml" );
+    assertEquals( IOUtils.toString( inputStream ), IOUtils.toString( sampleData.get( "schema.xml" ) ) );
   }
 
-  @Test
+  @Test( expected = PentahoAccessControlException.class )
   public void testDoGetAnalysisFilesAsDownloadError() throws Exception {
-    final String analysisId = "analysisId";
-    doReturn( false ).when( analysisService ).canManageACL();
-    final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
-    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( analysisId ), any( IPentahoSession.class ) ) ).thenReturn(
-        mondrianCatalog );
-    try {
-      analysisService.doGetAnalysisFilesAsDownload( analysisId );
-      fail();
-    } catch ( PentahoAccessControlException e ) {
-      //expected
-    }
-
-    verify( analysisService, times( 1 ) ).doGetAnalysisFilesAsDownload( analysisId );
+    when( policy.isAllowed( any( String.class ) ) ).thenReturn( true );
+    when( permissionHandler.hasDataAccessPermission( any( IPentahoSession.class ) ) ).thenReturn( false );
+    new AnalysisService().doGetAnalysisFilesAsDownload( "SampleData" );
   }
 
   @Test
-  public void testRemoveAnalysis() throws Exception {
-    IPentahoSession mockIPentahoSession = mock( IPentahoSession.class );
-
-    doReturn( true ).when( analysisService ).canAdministerCheck();
-    doReturn( "param" ).when( analysisService ).fixEncodedSlashParam( "analysisId" );
-    doReturn( mockIPentahoSession ).when( analysisService ).getSession();
-    doNothing().when( analysisService.mondrianCatalogService ).removeCatalog( "param", mockIPentahoSession );
-
-    analysisService.removeAnalysis( "analysisId" );
-
-    verify( analysisService, times( 1 ) ).removeAnalysis( "analysisId" );
+  public void testRemoveAnalysisRequiresMultiplePermissions() throws Exception {
+    testRemove( true, true, true );
+    testRemove( false, false, false );
+    testRemove( true, true, false );
+    testRemove( true, false, true );
+    testRemove( false, true, true );
+    testRemove( false, false, true );
+    testRemove( true, false, false );
   }
 
-  @Test
-  public void testRemoveAnalysisError() throws Exception {
-    doReturn( false ).when( analysisService ).canAdministerCheck();
+  private void testRemove( final boolean hasRead, final boolean hasCreate, final boolean hasAdmin ) throws PentahoAccessControlException {
+    when( policy.isAllowed( RepositoryReadAction.NAME ) ).thenReturn( hasRead );
+    when( policy.isAllowed( RepositoryCreateAction.NAME ) ).thenReturn( hasCreate );
+    when( policy.isAllowed( AdministerSecurityAction.NAME ) ).thenReturn( hasAdmin );
     try {
-      analysisService.removeAnalysis( "analysisId" );
-      fail();
+      new AnalysisService().removeAnalysis( "analysisId" );
+      if ( hasRead && hasCreate && hasAdmin ) {
+        verify( catalogService ).removeCatalog( eq( "analysisId" ), any( IPentahoSession.class ) );
+      } else {
+        fail( "should have got exception" );
+      }
     } catch ( PentahoAccessControlException e ) {
-      //expected
+      if ( hasRead && hasCreate && hasAdmin ) {
+        fail( "should not have got exception" );
+      } else {
+        verify( catalogService, never() ).removeCatalog( any( String.class ), any( IPentahoSession.class ) );
+      }
     }
-    verify( analysisService, times( 1 ) ).removeAnalysis( "analysisId" );
+    Mockito.reset( policy, catalogService );
   }
 
   @Test
   public void testGetAnalysisDatasourceIds() throws Exception {
-    Set<String> mockSet = mock( Set.class );
-    MondrianCatalog mockMondrianCatalog = mock( MondrianCatalog.class );
-    List<MondrianCatalog> mondrianCatalogList = new ArrayList<MondrianCatalog>();
-    mondrianCatalogList.add( mockMondrianCatalog );
-    List<String> mockList = new ArrayList<String>();
-    mockList.add( mockMondrianCatalog.getName() );
-    IPentahoSession mockIPentahoSession = mock( IPentahoSession.class );
-
-    doReturn( mockIPentahoSession ).when( analysisService ).getSession();
-    doReturn( mondrianCatalogList ).when( analysisService.mondrianCatalogService )
-        .listCatalogs( mockIPentahoSession, false );
-    doReturn( mockSet ).when( analysisService.metadataDomainRepository ).getDomainIds();
-
-    List<String> response = analysisService.getAnalysisDatasourceIds();
-
-    verify( analysisService, times( 1 ) ).getAnalysisDatasourceIds();
-    assertEquals( mockList, response );
-  }
-
-  @Test
-  public void testPutMondrianSchema() throws Exception {
-    InputStream dataInputStream = mock( InputStream.class );
-    FormDataContentDisposition schemaFileInfo = mock( FormDataContentDisposition.class );
-    String catalogName = "catalogName";
-    String origCatalogName = "origCatalogName";
-    String dataSourceName = "dataSourceName";
-    boolean xmlaEnabledFlag = true;
-    String parameters = "parameters";
-
-    doNothing().when( analysisService ).accessValidation();
-    doNothing().when( analysisService )
-        .processMondrianImport( dataInputStream, catalogName, origCatalogName, true, xmlaEnabledFlag, parameters, null,
-            null );
-
-    analysisService
-        .putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true,
-            xmlaEnabledFlag, parameters, null );
-
-    verify( analysisService, times( 1 ) )
-        .putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true,
-            xmlaEnabledFlag, parameters, null );
-  }
-
-  @Test
-  public void testPutMondrianSchemaWithACL() throws Exception {
-    InputStream dataInputStream = mock( InputStream.class );
-    when( dataInputStream.read( any( byte[].class ) ) ).thenReturn( 10, -1 );
-
-    FormDataContentDisposition schemaFileInfo = mock( FormDataContentDisposition.class );
-    String catalogName = "catalogName";
-    String origCatalogName = "";
-    String dataSourceName = "dataSourceName";
-    boolean xmlaEnabledFlag = true;
-    String parameters = "parameters";
-
-    final RepositoryFileAclDto aclDto = new RepositoryFileAclDto();
-    aclDto.setOwner( "owner" );
-    aclDto.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
-
-    doNothing().when( analysisService ).accessValidation();
-
-    analysisService
-        .putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true,
-            xmlaEnabledFlag, parameters, aclDto );
-
-    verify( analysisService, times( 1 ) )
-        .putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, dataSourceName, true,
-            xmlaEnabledFlag, parameters, aclDto );
-
-    verify( analysisService.importer ).importFile( argThat( new ArgumentMatcher<IPlatformImportBundle>() {
-      @Override public boolean matches( Object argument ) {
-        IPlatformImportBundle bundle = (IPlatformImportBundle) argument;
-        return new RepositoryFileAclAdapter().unmarshal( aclDto ).equals( bundle.getAcl() );
-      }
-    } ) );
+    final MondrianCatalog foodmartCatalog = new MondrianCatalog( "foodmart", "info", "file:///place",
+        new MondrianSchema( "foodmart", Collections.<MondrianCube>emptyList() ) );
+    final MondrianCatalog foodmartCatalog2 = new MondrianCatalog( "foodmart2", "info", "file:///place",
+        new MondrianSchema( "foodmart2", Collections.<MondrianCube>emptyList() ) );
+    final List<MondrianCatalog> catalogs = Arrays.asList( foodmartCatalog, foodmartCatalog2 );
+    doReturn( catalogs ).when( catalogService ).listCatalogs( any( IPentahoSession.class ), eq( false ) );
+    final HashSet<String> domainIds = Sets.newHashSet( "foodmart.xmi", "sample.xmi" );
+    doReturn( domainIds ).when( metadataRepository ).getDomainIds();
+    final List<String> response = new AnalysisService().getAnalysisDatasourceIds();
+    assertEquals( Collections.singletonList( "foodmart2" ), response );
   }
 
   @Test
   public void testGetAnalysisDatasourceAcl() throws Exception {
-    String catalogName = "catalogName";
-
-    final RepositoryFileAcl acl = new RepositoryFileAcl.Builder( "owner" ).build();
-
-    doReturn( true ).when( analysisService ).canManageACL();
-    when( analysisService.aclAwareMondrianCatalogService.getAclFor( catalogName ) ).thenReturn( acl );
+    allAccess();
+    final String catalogName = "SampleData";
+    final RepositoryFileAcl expectedAcl = new RepositoryFileAcl.Builder( "owner" ).build();
+    when( catalogService.getAclFor( catalogName ) ).thenReturn( expectedAcl );
     final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
-    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn(
-        mondrianCatalog );
-    final IUnifiedRepository repository = mock( IUnifiedRepository.class );
-    final RepositoryFile repositoryFile = mock( RepositoryFile.class );
-    when( repository.getFileById( anyString() ) ).thenReturn( repositoryFile );
-    doReturn( new HashMap<String, InputStream>() { {
-        put( "test", null );
-      } } ).when( analysisService )
-        .doGetAnalysisFilesAsDownload( catalogName );
-
-    final RepositoryFileAclDto aclDto = analysisService.getAnalysisDatasourceAcl( catalogName );
-
-    verify( analysisService.aclAwareMondrianCatalogService ).getAclFor( eq( catalogName ) );
-
-    assertEquals( acl, new RepositoryFileAclAdapter().unmarshal( aclDto ) );
+    when( catalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn( mondrianCatalog );
+    final RepositoryFileAclDto actualAcl = new AnalysisService().getAnalysisDatasourceAcl( catalogName );
+    assertEquals( expectedAcl, new RepositoryFileAclAdapter().unmarshal( actualAcl ) );
   }
 
   @Test
   public void testGetAnalysisDatasourceAclNoAcl() throws Exception {
-    String catalogName = "catalogName";
-
-    doReturn( true ).when( analysisService ).canManageACL();
+    allAccess();
+    final String catalogName = "catalogName";
     final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
-    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn(
-        mondrianCatalog );
-    when( analysisService.aclAwareMondrianCatalogService.getAclFor( catalogName ) ).thenReturn( null );
-    doReturn( new HashMap<String, InputStream>() { {
-        put( "test", null );
-      } } ).when( analysisService )
-        .doGetAnalysisFilesAsDownload( catalogName );
-
-    final RepositoryFileAclDto aclDto = analysisService.getAnalysisDatasourceAcl( catalogName );
-
-    verify( analysisService.aclAwareMondrianCatalogService ).getAclFor( eq( catalogName ) );
-
+    when( catalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn( mondrianCatalog );
+    when( catalogService.getAclFor( catalogName ) ).thenReturn( null );
+    final RepositoryFileAclDto aclDto = new AnalysisService().getAnalysisDatasourceAcl( catalogName );
     assertNull( aclDto );
   }
 
   @Test
   public void testSetAnalysisDatasourceAcl() throws Exception {
-    String catalogName = "catalogName";
-
+    allAccess();
+    final String catalogName = "catalogName";
     final RepositoryFileAclDto aclDto = new RepositoryFileAclDto();
     aclDto.setOwner( "owner" );
     aclDto.setOwnerType( RepositoryFileSid.Type.USER.ordinal() );
-
-    doReturn( true ).when( analysisService ).canManageACL();
     final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
-    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn(
-        mondrianCatalog );
-    doReturn( new HashMap<String, InputStream>() { {
-        put( "test", null );
-      } } ).when( analysisService )
-        .doGetAnalysisFilesAsDownload( catalogName );
-
-    analysisService.setAnalysisDatasourceAcl( catalogName, aclDto );
-
-    verify( analysisService.aclAwareMondrianCatalogService ).setAclFor( eq( catalogName ),
-        eq( new RepositoryFileAclAdapter().unmarshal( aclDto ) ) );
+    when( catalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn( mondrianCatalog );
+    new AnalysisService().setAnalysisDatasourceAcl( catalogName, aclDto );
+    verify( catalogService ).setAclFor( eq( catalogName ), eq( new RepositoryFileAclAdapter().unmarshal( aclDto ) ) );
   }
 
   @Test
   public void testSetAnalysisDatasourceAclNoAcl() throws Exception {
+    allAccess();
     String catalogName = "catalogName";
-
-    doReturn( true ).when( analysisService ).canManageACL();
     final MondrianCatalog mondrianCatalog = mock( MondrianCatalog.class );
-    when( analysisService.aclAwareMondrianCatalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn(
-        mondrianCatalog );
-    doReturn( new HashMap<String, InputStream>() { {
-        put( "test", null );
-      } } ).when( analysisService )
-        .doGetAnalysisFilesAsDownload( catalogName );
-
-    analysisService.setAnalysisDatasourceAcl( catalogName, null );
-
-    verify( analysisService.aclAwareMondrianCatalogService ).setAclFor( eq( catalogName ),
-        (RepositoryFileAcl) isNull() );
+    when( catalogService.getCatalog( eq( catalogName ), any( IPentahoSession.class ) ) ).thenReturn( mondrianCatalog );
+    new AnalysisService().setAnalysisDatasourceAcl( catalogName, null );
+    verify( catalogService ).setAclFor( eq( catalogName ), (RepositoryFileAcl) isNull() );
   }
 }

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/schema.xml
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/schema.xml
@@ -1,0 +1,17 @@
+<Schema name="sales">
+  <Dimension name="Product">
+    <Hierarchy hasAll="true" primaryKey="product_id">
+      <Table name="products" schema="public"/>
+      <Level name="Product Line" uniqueMembers="false" column="productline" type="String">
+      </Level>
+      <Level name="Product Code" uniqueMembers="false" column="productcode" type="String">
+      </Level>
+    </Hierarchy>
+  </Dimension>
+  <Cube name="sales">
+    <Table name="sales" schema="public"/>
+    <DimensionUsage name="Product" source="Product" foreignKey="product_id"/>
+    <Measure name="PRICEEACH" column="priceeach" aggregator="min" formatString="&#x23;"/>
+    <Measure name="Quantity ordered" column="quantityordered" aggregator="min" formatString="&#x23;"/>
+  </Cube>
+</Schema>


### PR DESCRIPTION
…Annotations.  by default import with overwrite will remove the existing catalog first, which removes the annotations.  Use the new parameter to prevent removal of catalog which retains the inline annotations.  Also refactoring tests in AnalysisServiceTest because they weren't testing anything.