### PR TITLE
[PRD-5459] Upgraded poi to version 3.12

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -48,7 +48,7 @@
     <dependency org="org.apache.axis2" name="axis2-adb" rev="1.4.1" transitive="false"/>
     <dependency org="org.apache.axis2" name="axis2-kernel" rev="1.4.1" transitive="false"/>
     <dependency org="ognl" name="ognl" rev="2.6.9" transitive="false"/>
-    <dependency org="log4j" name="log4j" rev="1.2.16"/>
+    <dependency org="log4j" name="log4j" rev="1.2.17"/>
     <dependency org="jfree" name="jcommon" rev="1.0.14"/>
     <dependency org="com.ibm.icu" name="icu4j" rev="4_4_1_1"/>
     <dependency org="com.ibm.icu" name="icu4j-charsets" rev="4_4_1_1"/>
@@ -121,7 +121,7 @@
     <dependency org="org.springframework" name="spring-test" rev="${dependency.spring.framework.revision}" conf="test->default"/>
     <dependency org="net.sf.saxon" name="saxon" rev="9.1.0.8" transitive="false" conf="test->default"/>
     <dependency org="net.sf.saxon" name="saxon-dom" rev="9.1.0.8" transitive="false" conf="test->default"/>
-    <dependency org="junit" name="junit" rev="4.4" conf="test->default"/>
+    <dependency org="junit" name="junit" rev="4.12" conf="test->default"/>
     <dependency org="org.jmock" name="jmock-junit4" rev="2.5.1" conf="test->default"/>
     <dependency org="pentaho" name="pentaho-platform-repository" rev="${dependency.pentaho-platform.revision}"
                 changing="true" conf="test->default"/>
@@ -147,8 +147,6 @@
     <dependency org="org.apache.lucene"        name="lucene-core"                  rev="2.4.1"      transitive="false" conf="test->default"/>
     <dependency org="net.sourceforge.nekohtml" name="nekohtml"                     rev="1.9.7"      transitive="false" conf="test->default"/>
     <dependency org="pdfbox"                   name="pdfbox"                       rev="0.7.3"      transitive="false" conf="test->default"/>
-    <dependency org="org.apache.poi"           name="poi"                          rev="3.2-FINAL"  transitive="false" conf="test->default"/>
-    <dependency org="org.apache.poi"           name="poi-scratchpad"               rev="3.2-FINAL"  transitive="false" conf="test->default"/>
     <dependency org="xerces"                   name="xercesImpl"                   rev="2.8.1"      transitive="false" conf="test->default"/>
     <dependency org="org.mockito" 						 name="mockito-all" 								 rev="1.8.0" 			transitive="false" conf="test->default"/>
     <dependency org="com.google.collections" name="google-collections" rev="1.0-rc5" transitive="false" conf="test->default"/>
@@ -157,7 +155,7 @@
     <dependency org="com.sun.jersey.jersey-test-framework"  name="jersey-test-framework-grizzly"  rev="1.5" conf="test->default"/>
     <dependency org="com.sun.jersey.contribs"               name="jersey-multipart"               rev="1.5" conf="test->default"/>
 
-    <dependency org="commons-codec" name="commons-codec" rev="1.3" transitive="false" conf="test->default"/>
+    <dependency org="commons-codec" name="commons-codec" rev="1.9" transitive="false" conf="test->default"/>
     <dependency org="org.springframework" name="spring-mock" rev="${dependency.spring.mock.revision}" transitive="false"/>
     <dependency org="org.springframework" name="se-jcr" rev="${dependency.spring.extensions.jcr.revision}" transitive="false" />
     
@@ -177,6 +175,9 @@
       <artifact name="pentaho-xul-gwt" type="source" ext="jar" m:classifier="sources"/>
     </dependency>
     <dependency org="com.google.gwt" name="gwt-servlet" rev="${dependency.gwt.revision}" conf="default->default"/>
+
+    <!-- All the codegen pentaho-xul* items above bring in commons-logging 1.1.1 ... needs to be 1.1.3 -->
+    <dependency org="commons-logging" name="commons-logging" rev="1.1.3" conf="codegen->default" transitive="false"/>
 
     <!-- To support Enunciate Annotations in Resource classes 1.21.1 -->
 	<dependency org="org.codehaus.enunciate" name="enunciate-jersey-rt" rev="1.27" />


### PR DESCRIPTION
Updated the poi dependency and required 3rd party dependencies.
@pentaho-nbaker @mbatchelor Let's discuss this before including ...
NOTE: there are other pull requests that all must go together
NOTE2: data-access doesn't actually depent on poi so the dependency was removed (it is still coming in transitively)