### PR TITLE
BISERVER-12446 - Unable to delete Data Source Connection: additional pull-request

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -49,6 +49,7 @@ import org.pentaho.platform.plugin.services.importer.PlatformImportException;
 import org.pentaho.platform.plugin.services.importer.RepositoryFileImportBundle;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
 
 import com.sun.jersey.core.header.FormDataContentDisposition;
 
@@ -92,7 +93,9 @@ public class AnalysisService extends DatasourceService {
   }
 
   public void removeAnalysis( String analysisId ) throws PentahoAccessControlException {
-    if ( !canAdministerCheck() ) {
+    try {
+      ensureDataAccessPermissionCheck();
+    } catch ( ConnectionServiceException e ) {
       throw new PentahoAccessControlException();
     }
     mondrianCatalogService.removeCatalog( fixEncodedSlashParam( analysisId ), getSession() );
@@ -367,6 +370,10 @@ public class AnalysisService extends DatasourceService {
 
   protected boolean canAdministerCheck() {
     return super.canAdminister();
+  }
+
+  protected void ensureDataAccessPermissionCheck() throws ConnectionServiceException {
+    super.ensureDataAccessPermission();
   }
 
   protected void accessValidation() throws PentahoAccessControlException {

--- a/src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardService.java
@@ -63,6 +63,7 @@ import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogR
 import org.pentaho.platform.plugin.services.metadata.IAclAwarePentahoMetadataDomainRepositoryImporter;
 import org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
 
 public class DataSourceWizardService extends DatasourceService {
 
@@ -129,7 +130,9 @@ public class DataSourceWizardService extends DatasourceService {
   }
 
   public void removeDSW( String dswId ) throws PentahoAccessControlException {
-    if ( !canAdministerCheck() ) {
+    try {
+      ensureDataAccessPermissionCheck();
+    } catch ( ConnectionServiceException e ){
       throw new PentahoAccessControlException();
     }
     Domain domain = metadataDomainRepository.getDomain( dswId );
@@ -383,6 +386,10 @@ public class DataSourceWizardService extends DatasourceService {
 
   protected boolean canAdministerCheck() {
     return super.canAdminister();
+  }
+
+  protected void ensureDataAccessPermissionCheck() throws ConnectionServiceException {
+    super.ensureDataAccessPermission();
   }
 
   protected boolean hasManageAccessCheck() {

--- a/src/org/pentaho/platform/dataaccess/datasource/api/DatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/DatasourceService.java
@@ -28,6 +28,8 @@ import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.dataaccess.datasource.utils.DataAccessPermissionUtil;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.ConnectionServiceImpl;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
@@ -131,5 +133,10 @@ public class DatasourceService {
   protected void flushDataSources() {
     metadataDomainRepository.flushDomains();
     mondrianCatalogService.reInit( PentahoSessionHolder.getSession() );
+  }
+
+  public void ensureDataAccessPermission() throws ConnectionServiceException {
+    ConnectionServiceImpl connectionService = new ConnectionServiceImpl();
+    connectionService.ensureDataAccessPermission();
   }
 }

--- a/src/org/pentaho/platform/dataaccess/datasource/api/MetadataService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/MetadataService.java
@@ -40,6 +40,7 @@ import org.pentaho.platform.plugin.services.metadata.IAclAwarePentahoMetadataDom
 import org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclDto;
 import org.pentaho.platform.web.http.api.resources.FileResource;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
 
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataBodyPart;
@@ -56,7 +57,9 @@ public class MetadataService extends DatasourceService {
   }
 
   public void removeMetadata( String metadataId ) throws PentahoAccessControlException {
-    if ( !canAdministerCheck() ) {
+    try {
+      ensureDataAccessPermissionCheck();
+    } catch ( ConnectionServiceException e ) {
       throw new PentahoAccessControlException();
     }
     metadataDomainRepository.removeDomain( metadataId );
@@ -180,6 +183,10 @@ public class MetadataService extends DatasourceService {
 
   protected boolean canAdministerCheck() {
     return super.canAdminister();
+  }
+
+  protected void ensureDataAccessPermissionCheck() throws ConnectionServiceException {
+    super.ensureDataAccessPermission();
   }
 
   protected FileResource createNewFileResource() {

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceImpl.java
@@ -100,7 +100,7 @@ public class ConnectionServiceImpl extends PentahoBase implements IConnectionSer
       && dataAccessPermHandler.hasDataAccessPermission( PentahoSessionHolder.getSession() );
   }
 
-  protected void ensureDataAccessPermission() throws ConnectionServiceException {
+  public void ensureDataAccessPermission() throws ConnectionServiceException {
     if ( !hasDataAccessPermission() ) {
       String message = Messages.getErrorString( "ConnectionServiceImpl.ERROR_0001_PERMISSION_DENIED" ); //$NON-NLS-1$
       logger.error( message );

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -207,6 +207,9 @@ public class AnalysisServiceTest {
     when( policy.isAllowed( RepositoryReadAction.NAME ) ).thenReturn( hasRead );
     when( policy.isAllowed( RepositoryCreateAction.NAME ) ).thenReturn( hasCreate );
     when( policy.isAllowed( AdministerSecurityAction.NAME ) ).thenReturn( hasAdmin );
+    if( hasRead && hasCreate && hasAdmin ) {
+      when( policy.isAllowed( any( String.class ) ) ).thenReturn( true );
+    }
     try {
       new AnalysisService().removeAnalysis( "analysisId" );
       if ( hasRead && hasCreate && hasAdmin ) {

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardServiceTest.java
@@ -60,6 +60,7 @@ import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
 import org.pentaho.platform.dataaccess.datasource.beans.LogicalModelSummary;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.DatasourceServiceException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.IDSWDatasourceService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IAclAwareMondrianCatalogService;
@@ -162,7 +163,7 @@ public class DataSourceWizardServiceTest {
     LogicalModel mockLogicalModel = mock( LogicalModel.class );
     String mockObject = "not null";
 
-    doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
+    doNothing().when( dataSourceWizardService ).ensureDataAccessPermissionCheck();
     doReturn( dswId ).when( dataSourceWizardService ).parseMondrianSchemaNameWrapper( dswId );
     doReturn( mockDomain ).when( dataSourceWizardService.metadataDomainRepository ).getDomain( dswId );
     doReturn( mockModelerWorkspace ).when( dataSourceWizardService ).createModelerWorkspace();
@@ -197,7 +198,7 @@ public class DataSourceWizardServiceTest {
     String mockObject = "not null";
     String dswId = "dswId";
 
-    doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
+    doNothing().when( dataSourceWizardService ).ensureDataAccessPermissionCheck();
     doReturn( dswId ).when( dataSourceWizardService ).parseMondrianSchemaNameWrapper( dswId );
     doReturn( mockDomain ).when( dataSourceWizardService.metadataDomainRepository ).getDomain( dswId );
     doReturn( mockModelerWorkspace ).when( dataSourceWizardService ).createModelerWorkspace();
@@ -226,7 +227,8 @@ public class DataSourceWizardServiceTest {
     String dswId = "dswId";
 
     //Test 1
-    doReturn( false ).when( dataSourceWizardService ).canAdministerCheck();
+    ConnectionServiceException cse = new ConnectionServiceException();
+    doThrow( cse ).when( dataSourceWizardService ).ensureDataAccessPermissionCheck();
 
     try {
       dataSourceWizardService.removeDSW( "dswId" );
@@ -237,7 +239,7 @@ public class DataSourceWizardServiceTest {
 
     //Test 2
     DatasourceServiceException mockDatasourceServiceException = mock( DatasourceServiceException.class );
-    doReturn( true ).when( dataSourceWizardService ).canAdministerCheck();
+    doNothing().when( dataSourceWizardService ).ensureDataAccessPermissionCheck();
     doReturn( dswId ).when( dataSourceWizardService ).parseMondrianSchemaNameWrapper( dswId );
     doReturn( mockDomain ).when( dataSourceWizardService.metadataDomainRepository ).getDomain( dswId );
     doReturn( mockModelerWorkspace ).when( dataSourceWizardService ).createModelerWorkspace();

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/MetadataServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/MetadataServiceTest.java
@@ -55,6 +55,7 @@ import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
 import org.pentaho.platform.plugin.services.importer.PlatformImportException;
@@ -93,7 +94,7 @@ import com.sun.jersey.multipart.FormDataBodyPart;
 
   @Test
   public void testRemoveMetadata() throws Exception {
-    doReturn( true ).when( metadataService ).canAdministerCheck();
+    doNothing().when( metadataService ).ensureDataAccessPermissionCheck();
     doReturn( "param" ).when( metadataService ).fixEncodedSlashParam( "metadataId" );
     doNothing().when( metadataService.metadataDomainRepository ).removeDomain( "param" );
 
@@ -106,7 +107,8 @@ import com.sun.jersey.multipart.FormDataBodyPart;
 
   @Test
   public void testRemoveMetadataError() throws Exception {
-    doReturn( false ).when( metadataService ).canAdministerCheck();
+    ConnectionServiceException cse = new ConnectionServiceException();
+    doThrow( cse ).when( metadataService ).ensureDataAccessPermissionCheck();
     try {
       metadataService.removeMetadata( "metadataId" );
       fail();


### PR DESCRIPTION
Comment from QA(Pavel Hrakovich):
During verification of BISERVER-12446 with biserver-ee-6.0-Nightly (138) I encountered the following system behavior:
Case 1
Non-admin user with “Manage data sources” and “Create content” permissions can delete any custom connections (JDBC) but cannot delete Data Sources (Analysis, MetaData, Data Source Wizard).
Case 2
Non-admin user with “Manage data sources” and “Create content” permissions cannot delete default connections (Audit, pentaho_operation_mart, SampleData). Default admin-user also cannot delete such connections.

Fix for Case 1 added. As for Case 2, this will break referential integrity, so as for me right now it's works correctly.
@rmansoor @pminutillo @mdamour1976 
Can you please review it and give your opinion about Case 2?