### PR TITLE
Additional pr on BISERVER-12815 - Manage Data Sources: User can impor…

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -383,7 +383,7 @@ public class AnalysisService extends DatasourceService {
   }
 
   protected void fileNameValidation( final String fileName ) throws PlatformImportException {
-    if ( fileName != null && !fileName.endsWith( ".xml" ) ) {
+    if ( StringUtils.isNotEmpty( fileName ) && !fileName.endsWith( ".xml" ) ) {
       throw new PlatformImportException( Messages.getString( "AnalysisService.ERROR_001_ANALYSIS_DATASOURCE_ERROR" ), PlatformImportException.PUBLISH_GENERAL_ERROR );
     }
   }


### PR DESCRIPTION
…t an .xmi using 'Import Analysis'

Additional pull-request on https://github.com/pentaho/data-access/pull/689
In case of editing analysis data source fileName equals empty string, it is valid value, no exception should be thrown. My bad.
@rmansoor @pamval 
Please review.