### PR TITLE
SP-2441 - Backport of BISERVER-12233 - Exported Mondrian schemas when exported from DAW are exported as schema.xml (6.0 Suite)

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -88,6 +88,7 @@ public class AnalysisService extends DatasourceService {
     MondrianCatalogRepositoryHelper helper = createNewMondrianCatalogRepositoryHelper();
 
     Map<String, InputStream> fileData = helper.getModrianSchemaFiles( analysisId );
+    super.parseMondrianSchemaName( analysisId, fileData );
 
     return fileData;
   }

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -195,7 +195,7 @@ public class AnalysisServiceTest {
     final Map<String, InputStream> sampleData = new AnalysisService().doGetAnalysisFilesAsDownload( "SampleData" );
     assertEquals( 1, sampleData.size() );
     final FileInputStream inputStream = new FileInputStream( "test-res/solution1/etc/mondrian/SampleData/schema.xml" );
-    assertEquals( IOUtils.toString( inputStream ), IOUtils.toString( sampleData.get( "schema.xml" ) ) );
+    assertEquals( IOUtils.toString( inputStream ), IOUtils.toString( sampleData.get( "SampleData.mondrian.xml" ) ) );
   }
 
   @Test( expected = PentahoAccessControlException.class )


### PR DESCRIPTION
Cherry-pick of https://github.com/pentaho/data-access/pull/691
@rmansoor @pamval 
Please review.