### PR TITLE
SP-2442 - Backport of BISERVER-12233 - Exported Mondrian schemas when exported from DAW are exported as schema.xml (5.4 Suite)

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -91,6 +91,7 @@ public class AnalysisService extends DatasourceService {
     MondrianCatalogRepositoryHelper helper = createNewMondrianCatalogRepositoryHelper();
 
     Map<String, InputStream> fileData = helper.getModrianSchemaFiles( analysisId );
+    super.parseMondrianSchemaName( analysisId, fileData );
 
     return fileData;
   }

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -94,6 +94,7 @@ public class AnalysisServiceTest {
     Map<String, InputStream> response = analysisService.doGetAnalysisFilesAsDownload( analysisId );
 
     verify( analysisService, times( 1 ) ).doGetAnalysisFilesAsDownload( analysisId );
+    verify( analysisService, times( 1 ) ).parseMondrianSchemaName( analysisId, mockMap );
     assertEquals( mockMap, response );
   }
 


### PR DESCRIPTION
Backport of https://github.com/pentaho/data-access/pull/691
@rmansoor @pamval 
Please review.