### PR TITLE
[ANALYZER-3243] - Error to Edit JDBC connection

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/GwtDatasourceEditorEntryPoint.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/GwtDatasourceEditorEntryPoint.java
@@ -1029,7 +1029,7 @@ public class GwtDatasourceEditorEntryPoint implements EntryPoint {
           // This is important for edit mode of datasource model
           datasourceModel.setEditing(true);
           connectionController.setDatasourceModel(datasourceModel);
-          connectionController.showEditConnectionDialog(dialogListener);
+          connectionController.showEditConnectionDialog( dialogListener, conn );
         }
       });
     } catch (Exception e) {

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/controllers/ConnectionController.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/controllers/ConnectionController.java
@@ -616,18 +616,23 @@ public class ConnectionController extends AbstractXulEventHandler {
 
   @SuppressWarnings( "deprecation" )
   public void showEditConnectionDialog( DialogListener dialogListener ) {
+    IDatabaseConnection connection = datasourceModel.getSelectedRelationalConnection();
+    showEditConnectionDialog( dialogListener, connection );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  public void showEditConnectionDialog( DialogListener dialogListener, IDatabaseConnection connection ) {
     connectionSetter = new DatabaseConnectionSetter( dialogListener );
     datasourceModel.setEditing( true );
     if ( databaseDialog != null ) {
-      IDatabaseConnection connection = datasourceModel.getSelectedRelationalConnection();
-      if (connection != null) {
+      if ( connection != null ) {
         databaseDialog.setDatabaseConnection( connection );
         previousConnectionName = connection.getName();
         existingConnectionName = previousConnectionName;
         databaseDialog.show();
       } else {
         openErrorDialog( MessageHandler.getString( "DatasourceEditor.USER_ERROR_TITLE" ), MessageHandler
-            .getString( "DatasourceEditor.ERROR_0001_UNKNOWN_ERROR_HAS_OCCURED" ) );
+          .getString( "DatasourceEditor.ERROR_0001_UNKNOWN_ERROR_HAS_OCCURED" ) );
       }
     } else {
       createNewDatabaseDialog();


### PR DESCRIPTION
Added a way to override the behavior of relying on a selected connection in the DSW dialog and all of it's binding (because you never see it in this repro path and was causing the bug).  So I allow the setting of the connection to use in the edit connection dialog.