### PR TITLE
[SP-2394] - Backport of BISERVER-12815 - Manage Data Sources: User can import an .xmi using "Import Analysis" (6.0 Suite)

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -28,7 +28,6 @@ import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
-import org.pentaho.platform.dataaccess.datasource.wizard.service.messages.Messages;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IAclAwareMondrianCatalogService;
@@ -127,7 +126,6 @@ public class AnalysisService extends DatasourceService {
 
     accessValidation();
     String fileName = schemaFileInfo.getFileName();
-    fileNameValidation( fileName );
     processMondrianImport(
         dataInputStream, catalogName, origCatalogName, overwrite, xmlaEnabledFlag, parameters, fileName, acl );
   }
@@ -380,12 +378,6 @@ public class AnalysisService extends DatasourceService {
 
   protected void accessValidation() throws PentahoAccessControlException {
     super.validateAccess();
-  }
-
-  protected void fileNameValidation( final String fileName ) throws PlatformImportException {
-    if ( StringUtils.isNotEmpty( fileName ) && !fileName.endsWith( ".xml" ) ) {
-      throw new PlatformImportException( Messages.getString( "AnalysisService.ERROR_001_ANALYSIS_DATASOURCE_ERROR" ), PlatformImportException.PUBLISH_GENERAL_ERROR );
-    }
   }
 
   protected IPentahoSession getSession() {

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages.properties
@@ -118,8 +118,6 @@ InMemoryDatasourceServiceImpl.ERROR_0020_UNABLE_TO_GET_DATASOURCE=Unable to cons
 
 ConnectionServiceHelper.ERROR_0001_UNABLE_TO_GET_CONNECTION_PASSWORD=Unable to get the connection password: {0}
 
-AnalysisService.ERROR_001_ANALYSIS_DATASOURCE_ERROR=Error creating Analysis datasource. Check the provided XML file.
-
 MetadataDatasourceService.ERROR_001_METADATA_DATASOURCE_ERROR=Error creating Metadata datasource. Check the provided XMI file.
 MetadataDatasourceService.ERROR_002_PROPERTY_FILES_ERROR=The following property files do not appear to be in text format:
 MetadataDatasourceService.ERROR_003_PROHIBITED_SYMBOLS_ERROR=Invalid characters entered: "{0}". The following characters cannot be used: {1}

--- a/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -41,7 +41,6 @@ import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCube;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianSchema;
 import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
-import org.pentaho.platform.plugin.services.importer.PlatformImportException;
 import org.pentaho.platform.plugin.services.importer.RepositoryFileImportBundle;
 import org.pentaho.platform.repository2.unified.fs.FileSystemBackedUnifiedRepository;
 import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAclAdapter;
@@ -161,18 +160,6 @@ public class AnalysisServiceTest {
           "overwrite=false;retainInlineAnnotations=true", acl );
     verify( importer ).importFile( argThat( matchBundle( false, acl ) ) );
     verify( catalogService, never() ).removeCatalog( eq( "sales" ), any( IPentahoSession.class ) );
-  }
-
-  @Test( expected = PlatformImportException.class )
-  public void testPutInvalidMondrianSchemaError() throws Exception {
-    when( policy.isAllowed( any( String.class ) ) ).thenReturn( true );
-    FormDataContentDisposition schemaFileInfo = mock( FormDataContentDisposition.class );
-    when( schemaFileInfo.getFileName() ).thenReturn( "sample.xmi" );
-    InputStream schema = getClass().getResourceAsStream( "schema.xml" );
-    new AnalysisService()
-        .putMondrianSchema(
-          schema, schemaFileInfo, "sample", null, "sample", true, false,
-          "overwrite=false;retainInlineAnnotations=true", acl );
   }
 
   private BaseMatcher<IPlatformImportBundle> matchBundle( final boolean overwrite, final RepositoryFileAclDto acl ) {


### PR DESCRIPTION
reverting commits dd72b841c10965efa5c2923c6ca851aeb6bd4052 and dd72b841c10965efa5c2923c6ca851aeb6bd4052 which were done for BISERVER-12815.  That is not the correct fix for the issue

@pamval, @kurtwalker, review it please  