### PR TITLE
[BACKLOG-7483] Add the field "webapp name" for Pentaho Data Service database type (DSW)

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/kettlethin_native.xul
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/kettlethin_native.xul
@@ -8,6 +8,8 @@
 		<textbox pen:customclass="variabletextbox" id="server-host-name-text" />
 		<label id="port-number-label" value="${DatabaseDialog.label.PortNumber}" />
 		<textbox pen:customclass="variabletextbox" id="port-number-text" />
+		<label id="web-app-name-label" value="${DatabaseDialog.label.WebAppName}" />
+		<textbox pen:customclass="variabletextbox" id="web-application-name-text" />
 		<label id="username-label" value="${DatabaseDialog.label.Username}" />
 		<textbox pen:customclass="variabletextbox" id="username-text" />
 		<label id="password-label" value="${DatabaseDialog.label.Password}" />


### PR DESCRIPTION
Same xul changes as in kettle's dbdialog.
pentaho-data-refinery: https://github.com/pentaho/pentaho-data-refinery/pull/26
pentaho-commons-database: https://github.com/pentaho/pentaho-commons-database/pull/93
@mkambol 