### PR TITLE
[BISERVER-13026] Imported CSV Data Source with Hyphen Character Does Not Display Correctly

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImpl.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
@@ -163,8 +163,7 @@ public class CsvDatasourceServiceImpl extends PentahoBase implements ICsvDatasou
           Thread.sleep( 200 );
         }
 
-        modelerWorkspace.setDomain(
-          modelerService.generateCSVDomain( modelInfo.getStageTableName(), modelInfo.getDatasourceName() ) );
+        modelerWorkspace.setDomain( modelerService.generateCSVDomain( modelInfo ) );
         modelerWorkspace.getWorkspaceHelper().autoModelFlat( modelerWorkspace );
         modelerWorkspace.getWorkspaceHelper().autoModelRelationalFlat( modelerWorkspace );
         modelerWorkspace.setModelName( modelInfo.getDatasourceName() );

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ModelerServiceIT.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ModelerServiceIT.java
@@ -12,15 +12,22 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import org.junit.Test;
+import org.pentaho.agilebi.modeler.util.TableModelerSource;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.metadata.automodel.importing.strategy.CsvDatasourceImportStrategy;
+import org.pentaho.metadata.model.thin.Column;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.dataaccess.datasource.wizard.models.ColumnInfo;
+import org.pentaho.platform.dataaccess.datasource.wizard.models.ModelInfo;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 
+import static junit.framework.Assert.assertEquals;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
@@ -40,5 +47,51 @@ public class ModelerServiceIT extends DataAccessServiceTestBase {
 
     // verify removeCatalog is called
     verify( mondrianCatalogService, times( 1 ) ).removeCatalog( anyString(), (IPentahoSession) anyObject() );
+  }
+
+  @Test
+  public void domainForCsvDatasource_GeneratedWithCsvDatasourceImportStrategy() throws Exception {
+    ModelInfo modelInfo = new ModelInfo();
+    ColumnInfo[] columnInfos = new ColumnInfo[] { createColumnInfo( "id", "title" ) };
+    modelInfo.setColumns( columnInfos );
+
+    modelerService = spy( modelerService );
+    DatabaseMeta dbMeta = mock( DatabaseMeta.class );
+    doReturn( dbMeta ).when( modelerService ).getDatabaseMeta();
+
+    TableModelerSource source = mock( TableModelerSource.class );
+    doReturn( source ).when( modelerService )
+      .createTableModelerSource( any( DatabaseMeta.class ), anyString(), anyString(), anyString() );
+
+    modelerService.generateCSVDomain( modelInfo );
+
+    verify( modelerService ).toColumns( columnInfos );
+    // most important thing here, is that domain is generated with CsvDatasourceImportStrategy
+    verify( source ).generateDomain( any( CsvDatasourceImportStrategy.class ) );
+  }
+
+  @Test
+  public void columnsConvertedCorrectly_FromColumnInfos() throws Exception {
+    final String columnId = "id";
+    final String columnTitle = "title";
+
+    ColumnInfo[] columnInfos = new ColumnInfo[] { createColumnInfo( columnId, columnTitle ) };
+    Column[] columns = modelerService.toColumns( columnInfos );
+
+    assertEquals( 1, columns.length );
+    Column column = columns[ 0 ];
+
+    assertEquals( columnId, column.getId() );
+    assertEquals( columnTitle, column.getName() );
+  }
+
+
+  private ColumnInfo createColumnInfo( String id, String title ) {
+    ColumnInfo columnInfo = new ColumnInfo();
+
+    columnInfo.setId( id );
+    columnInfo.setTitle( title );
+
+    return columnInfo;
   }
 }


### PR DESCRIPTION
- Generating domain of csv datasource using CsvDatasourceImportStrategy, that binds column id's (column names on database level, that have some restrictions on chars in their name) with friendly column names (user-provided names, containing any chars)
- Tests written
- Checkstyle applied