### PR TITLE
[BISERVER-13225] Unable to use 'SQL Query' source type with Data Service in Data Source Wizard

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
@@ -84,12 +84,12 @@ public class AnalysisDatasourceService {
       @FormDataParam( XMLA_ENABLED_FLAG ) String xmlaEnabledFlag, @FormDataParam( PARAMETERS ) String parameters,
       @FormDataParam( DATASOURCE_ACL ) RepositoryFileAclDto acl )
     throws PentahoAccessControlException {
-    Response response = null;
-    int statusCode = PlatformImportException.PUBLISH_GENERAL_ERROR;
+    int statusCode;
+
     try {
       AnalysisService service = new AnalysisService();
-      boolean overWriteInRepository = "True".equalsIgnoreCase( overwrite ) ? true : false;
-      boolean xmlaEnabled = "True".equalsIgnoreCase( xmlaEnabledFlag ) ? true : false;
+      boolean overWriteInRepository = "true".equalsIgnoreCase( overwrite );
+      boolean xmlaEnabled = "true".equalsIgnoreCase( xmlaEnabledFlag );
       service.putMondrianSchema( dataInputStream, schemaFileInfo, catalogName, origCatalogName, datasourceName,
           overWriteInRepository, xmlaEnabled, parameters, acl );
       statusCode = SUCCESS;
@@ -104,7 +104,7 @@ public class AnalysisDatasourceService {
       statusCode = PlatformImportException.PUBLISH_GENERAL_ERROR;
     }
 
-    response = Response.ok().status( statusCode ).type( MediaType.TEXT_PLAIN ).build();
+    Response response = Response.ok().status( statusCode ).type( MediaType.TEXT_PLAIN ).build();
     logger.debug( "putMondrianSchema Response " + response );
     return response;
   }

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/AnalysisDatasourceService.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
@@ -20,7 +20,6 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 import java.io.InputStream;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
@@ -86,10 +86,6 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
 
   private IMetadataDomainRepository metadataDomainRepository;
 
-  private static final String BEFORE_QUERY = " SELECT * FROM ("; //$NON-NLS-1$
-
-  private static final String AFTER_QUERY = ") tbl"; //$NON-NLS-1$
-
   private GeoContext geoContext;
 
   public DSWDatasourceServiceImpl() {
@@ -227,17 +223,15 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
     return true;
   }
 
-  private IPentahoResultSet executeQuery( String connectionName, String query, String previewLimit )
+  IPentahoResultSet executeQuery( String connectionName, String query, String previewLimit )
     throws QueryValidationException {
     SQLConnection sqlConnection = null;
     try {
       int limit = ( previewLimit != null && previewLimit.length() > 0 ) ? Integer.parseInt( previewLimit ) : -1;
-      sqlConnection = (SQLConnection) PentahoConnectionFactory.getConnection( IPentahoConnection.SQL_DATASOURCE,
-        connectionName, PentahoSessionHolder.getSession(),
-        new SimpleLogger( DatasourceServiceHelper.class.getName() ) );
+      sqlConnection = getSqlConnection(connectionName);
       sqlConnection.setMaxRows( limit );
       sqlConnection.setReadOnly( true );
-      return sqlConnection.executeQuery( BEFORE_QUERY + query + AFTER_QUERY );
+      return sqlConnection.executeQuery( query );
     } catch ( SQLException e ) {
       String error = "DatasourceServiceImpl.ERROR_0009_QUERY_VALIDATION_FAILED";
       if ( e.getSQLState().equals( "S0021" ) ) { // Column already exists
@@ -254,6 +248,12 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
         sqlConnection.close();
       }
     }
+  }
+
+  SQLConnection getSqlConnection( String connectionName ) {
+    return (SQLConnection) PentahoConnectionFactory.getConnection( IPentahoConnection.SQL_DATASOURCE,
+      connectionName, PentahoSessionHolder.getSession(),
+      new SimpleLogger( DatasourceServiceHelper.class.getName() ) );
   }
 
   public SerializedResultSet doPreview( String connectionName, String query, String previewLimit )

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
@@ -228,7 +228,7 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
     SQLConnection sqlConnection = null;
     try {
       int limit = ( previewLimit != null && previewLimit.length() > 0 ) ? Integer.parseInt( previewLimit ) : -1;
-      sqlConnection = getSqlConnection(connectionName);
+      sqlConnection = getSqlConnection( connectionName );
       sqlConnection.setMaxRows( limit );
       sqlConnection.setReadOnly( true );
       return sqlConnection.executeQuery( query );

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImplTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImplTest.java
@@ -28,8 +28,12 @@ import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.junit.Test;
+import org.pentaho.platform.plugin.services.connections.sql.SQLConnection;
 
 import java.util.ArrayList;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
 
 
 public class DSWDatasourceServiceImplTest {
@@ -109,6 +113,22 @@ public class DSWDatasourceServiceImplTest {
     Mockito.verify( domainRepository ).removeDomain( domain2Models.getId() );
   }
 
+  @Test
+  public void queryIsExecuted_WithoutBeingWrappedIntoAnotherQuery() throws Exception {
+    final String query = "SELECT * FROM tableName;";
+    final String connName = "connectionToDb";
+    final String previewLimit = "5";
+
+    final SQLConnection connToDataBase = mock( SQLConnection.class );
+    doReturn( connToDataBase ).when( service ).getSqlConnection( connName );
+
+    doCallRealMethod().when( service ).executeQuery( eq( connName ), eq( query ), eq( previewLimit ) );
+
+    service.executeQuery( connName, query, previewLimit );
+
+    verify( connToDataBase ).executeQuery( query );
+  }
+
   private LogicalModel mockLogicalModel() {
     return mockLogicalModel( LOGICAL_MODEL_ID_DEFAULT );
   }
@@ -130,7 +150,7 @@ public class DSWDatasourceServiceImplTest {
 
   private IMetadataDomainRepository mockDomainRepository( Domain domainToReturn, String domainId ) {
     IMetadataDomainRepository domainRepository = Mockito.mock( IMetadataDomainRepository.class );
-    Mockito.doReturn( domainToReturn ).when( domainRepository ).getDomain( domainId );
+    doReturn( domainToReturn ).when( domainRepository ).getDomain( domainId );
 
     return domainRepository;
   }
@@ -138,9 +158,9 @@ public class DSWDatasourceServiceImplTest {
   private DSWDatasourceServiceImpl mockService( ModelerWorkspace workspace ) throws Exception {
     DSWDatasourceServiceImpl service = Mockito.mock( DSWDatasourceServiceImpl.class );
 
-    Mockito.doReturn( true ).when( service ).hasDataAccessPermission();
-    Mockito.doReturn( domainRepository ).when( service ).getMetadataDomainRepository();
-    Mockito.doReturn( workspace ).when( service ).createModelerWorkspace();
+    doReturn( true ).when( service ).hasDataAccessPermission();
+    doReturn( domainRepository ).when( service ).getMetadataDomainRepository();
+    doReturn( workspace ).when( service ).createModelerWorkspace();
 
     Mockito.doCallRealMethod().when( service ).deleteLogicalModel( DOMAIN_ID, MODEL_NAME );
 


### PR DESCRIPTION
- Executing sql query as it is, without wrapping it into another query (kettle data services by their [spec] (https://github.com/pentaho/pdi-dataservice-plugin/blob/master/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQL.java#L63) support only simple queries with one table)
- Small refactoring in AnalysisDatasourceService class
- Tests written
- Checkstyle applied