### PR TITLE
[BISERVER-13225] Unable to use 'SQL Query' source type with Data Service in Data Source Wizard

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/SqlQueriesNotSupportedException.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/SqlQueriesNotSupportedException.java
@@ -1,0 +1,34 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+*/
+
+package org.pentaho.platform.dataaccess.datasource.wizard.service;
+
+import java.io.Serializable;
+
+public class SqlQueriesNotSupportedException extends Exception implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  public SqlQueriesNotSupportedException() {
+    super();
+  }
+
+  public SqlQueriesNotSupportedException( String message ) {
+    super( message );
+  }
+
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
@@ -36,6 +36,8 @@ import org.pentaho.agilebi.modeler.gwt.GwtModelerWorkspaceHelper;
 import org.pentaho.commons.connection.IPentahoConnection;
 import org.pentaho.commons.connection.IPentahoResultSet;
 import org.pentaho.database.model.DatabaseConnection;
+import org.pentaho.database.model.IDatabaseConnection;
+import org.pentaho.database.model.IDatabaseType;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.InlineEtlPhysicalModel;
 import org.pentaho.metadata.model.LogicalModel;
@@ -58,8 +60,10 @@ import org.pentaho.platform.dataaccess.datasource.wizard.csv.FileUtils;
 import org.pentaho.platform.dataaccess.datasource.wizard.models.CsvFileInfo;
 import org.pentaho.platform.dataaccess.datasource.wizard.models.CsvTransformGeneratorException;
 import org.pentaho.platform.dataaccess.datasource.wizard.models.DatasourceDTO;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.DatasourceServiceException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.QueryValidationException;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.SqlQueriesNotSupportedException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.agile.AgileHelper;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.agile.CsvTransformGenerator;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.gwt.IDSWDatasourceService;
@@ -104,6 +108,8 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
    */
   protected static final String LM_PROP_VISIBLE = "visible";
 
+  private static final String DB_TYPE_ID_PENTAHO_DATA_SERVICE = "Pentaho Data Services";
+
   private IMetadataDomainRepository metadataDomainRepository;
 
   private static final String BEFORE_QUERY = " SELECT * FROM ("; //$NON-NLS-1$
@@ -112,12 +118,15 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
 
   private GeoContext geoContext;
 
+  private ConnectionServiceImpl connService;
+
   public DSWDatasourceServiceImpl() {
     this( new ConnectionServiceImpl() );
   }
 
-  public DSWDatasourceServiceImpl( ConnectionServiceImpl connectionService ) {
+  public DSWDatasourceServiceImpl( ConnectionServiceImpl connService ) {
     metadataDomainRepository = PentahoSystem.get( IMetadataDomainRepository.class, null );
+    this.connService = connService;
   }
 
   protected boolean hasDataAccessPermission() {
@@ -247,9 +256,11 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
   }
 
   private IPentahoResultSet executeQuery( String connectionName, String query, String previewLimit )
-    throws QueryValidationException {
+    throws QueryValidationException, SqlQueriesNotSupportedException {
     SQLConnection sqlConnection = null;
     try {
+      checkSqlQueriesSupported( connectionName );
+
       int limit = ( previewLimit != null && previewLimit.length() > 0 ) ? Integer.parseInt( previewLimit ) : -1;
       sqlConnection = (SQLConnection) PentahoConnectionFactory.getConnection( IPentahoConnection.SQL_DATASOURCE,
         connectionName, PentahoSessionHolder.getSession(),
@@ -257,6 +268,9 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       sqlConnection.setMaxRows( limit );
       sqlConnection.setReadOnly( true );
       return sqlConnection.executeQuery( BEFORE_QUERY + query + AFTER_QUERY );
+    } catch ( SqlQueriesNotSupportedException e ) {
+      logger.error( e.getLocalizedMessage() );
+      throw e;
     } catch ( SQLException e ) {
       String error = "DatasourceServiceImpl.ERROR_0009_QUERY_VALIDATION_FAILED";
       if ( e.getSQLState().equals( "S0021" ) ) { // Column already exists
@@ -275,6 +289,29 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
     }
   }
 
+  /**
+   * Method is designed to check whether sql queries can be executed via connection with a {@core connName}.
+   * For now we can't allow sql queries for connections, that are based on Pentaho Data Services.
+   * See BISERVER-13225 for more info.
+   *
+   * @param connName
+   *          name of connection, to be examined for sql queries support
+   * @throws ConnectionServiceException
+   *            if an error occurs while receiving connection with {@code connectionName}
+   * @throws SqlQueriesNotSupportedException
+   *            if query is not supported for a connection with a {@code connectionName}
+   */
+  void checkSqlQueriesSupported( String connName )
+    throws ConnectionServiceException, SqlQueriesNotSupportedException {
+    IDatabaseConnection conn = connService.getConnectionByName( connName );
+    IDatabaseType dbType = conn.getDatabaseType();
+
+    if ( dbType.getName().equals( DB_TYPE_ID_PENTAHO_DATA_SERVICE ) ) {
+      throw new SqlQueriesNotSupportedException( Messages
+        .getErrorString( "DatasourceServiceImpl.ERROR_0024_SQL_QUERIES_NOT_SUPPORTED_FOR_PENTAHO_DATA_SERVICE" ) );
+    }
+  }
+
   public SerializedResultSet doPreview( String connectionName, String query, String previewLimit )
     throws DatasourceServiceException {
     if ( !hasDataAccessPermission() ) {
@@ -288,10 +325,10 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       returnResultSet = DatasourceServiceHelper.getSerializeableResultSet( connectionName, query,
         Integer.parseInt( previewLimit ), PentahoSessionHolder.getSession() );
     } catch ( QueryValidationException e ) {
-      logger.error( Messages.getErrorString(
-        "DatasourceServiceImpl.ERROR_0009_QUERY_VALIDATION_FAILED", e.getLocalizedMessage() ), e ); //$NON-NLS-1$
       throw new DatasourceServiceException( Messages.getErrorString(
         "DatasourceServiceImpl.ERROR_0009_QUERY_VALIDATION_FAILED", e.getLocalizedMessage() ), e ); //$NON-NLS-1$
+    } catch ( SqlQueriesNotSupportedException e ) {
+      throw new DatasourceServiceException( e.getLocalizedMessage(), e ); //$NON-NLS-1$
     }
     return returnResultSet;
 
@@ -362,10 +399,10 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       throw new DatasourceServiceException( Messages.getErrorString(
         "DatasourceServiceImpl.ERROR_0011_UNABLE_TO_GENERATE_MODEL", smge.getLocalizedMessage() ), smge ); //$NON-NLS-1$
     } catch ( QueryValidationException e ) {
-      logger.error( Messages.getErrorString(
-        "DatasourceServiceImpl.ERROR_0009_QUERY_VALIDATION_FAILED", e.getLocalizedMessage() ), e ); //$NON-NLS-1$
       throw new DatasourceServiceException( Messages.getErrorString(
         "DatasourceServiceImpl.ERROR_0009_QUERY_VALIDATION_FAILED", e.getLocalizedMessage() ), e ); //$NON-NLS-1$
+    } catch ( SqlQueriesNotSupportedException e ) {
+      throw new DatasourceServiceException( e.getLocalizedMessage(), e ); //$NON-NLS-1$
     }
   }
 
@@ -584,6 +621,8 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       throw new DatasourceServiceException( Messages
         .getErrorString( "DatasourceServiceImpl.ERROR_0011_UNABLE_TO_GENERATE_MODEL", e.getLocalizedMessage() ),
         e ); //$NON-NLS-1$
+    } catch ( SqlQueriesNotSupportedException e ) {
+      throw new DatasourceServiceException( e.getLocalizedMessage(), e ); //$NON-NLS-1$
     } catch ( Exception e ) {
       logger.error( Messages.getErrorString( "DatasourceServiceImpl.ERROR_0011_UNABLE_TO_GENERATE_MODEL", //$NON-NLS-1$
         e.getLocalizedMessage() ), e );

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages.properties
@@ -74,6 +74,7 @@ DatasourceServiceImpl.ERROR_0019_UNABLE_TO_DROP_TABLE=Unable to drop table {0} f
 DatasourceServiceImpl.ERROR_0020_UNABLE_TO_DELETE_CATALOG=Unable to delete mondrian catalog {0} for datasource {1}: {2}
 DatasourceServiceImpl.ERROR_0021_DUPLICATE_COLUMN_NAMES=Your query returns non-unique column names. Please make sure to alias any duplicated column names before continuing.
 DatasourceServiceImpl.ERROR_0022_UNABLE_TO_PROCESS_LOGICAL_MODEL=Unable to process logical model for domain id: {0}.
+DatasourceServiceImpl.ERROR_0024_SQL_QUERIES_NOT_SUPPORTED_FOR_PENTAHO_DATA_SERVICE=The connection is a Pentaho Data Service and can only be used with "Database Table(s)" Source Type
 
 DatasourceServiceHelper.ERROR_0001_QUERY_VALIDATION_FAILED==Query validation failed: {0}
 


### PR DESCRIPTION
- Before executing SQL, checking whether sql queries can be executed via a given connection.
If connection is not allowed, throw SqlQueriesNotSupportedException with an exact message, that should be handled in the caller-methods.
- Removed some duplicated logging
- Tests written
- Checkstyle applied