### PR TITLE
[SP-2689] Backport of BISERVER-13225 - Unable to use 'SQL Query' source type with Data Service in Data Source Wizard (6.1 Suite)

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/SqlQueriesNotSupportedException.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/SqlQueriesNotSupportedException.java
@@ -1,0 +1,34 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+*/
+
+package org.pentaho.platform.dataaccess.datasource.wizard.service;
+
+import java.io.Serializable;
+
+public class SqlQueriesNotSupportedException extends Exception implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  public SqlQueriesNotSupportedException() {
+    super();
+  }
+
+  public SqlQueriesNotSupportedException( String message ) {
+    super( message );
+  }
+
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages.properties
@@ -74,6 +74,7 @@ DatasourceServiceImpl.ERROR_0019_UNABLE_TO_DROP_TABLE=Unable to drop table {0} f
 DatasourceServiceImpl.ERROR_0020_UNABLE_TO_DELETE_CATALOG=Unable to delete mondrian catalog {0} for datasource {1}: {2}
 DatasourceServiceImpl.ERROR_0021_DUPLICATE_COLUMN_NAMES=Your query returns non-unique column names. Please make sure to alias any duplicated column names before continuing.
 DatasourceServiceImpl.ERROR_0022_UNABLE_TO_PROCESS_LOGICAL_MODEL=Unable to process logical model for domain id: {0}.
+DatasourceServiceImpl.ERROR_0024_SQL_QUERIES_NOT_SUPPORTED_FOR_PENTAHO_DATA_SERVICE=The connection is a Pentaho Data Service and can only be used with "Database Table(s)" Source Type
 
 DatasourceServiceHelper.ERROR_0001_QUERY_VALIDATION_FAILED==Query validation failed: {0}
 


### PR DESCRIPTION
- Before executing SQL, checking whether sql queries can be executed via a given connection.
If connection is not allowed, throw SqlQueriesNotSupportedException with an exact message, that should be handled in the caller-methods.
- Removed some duplicated logging
- Tests written
- Checkstyle applied