### PR TITLE
[BISERVER-12726] l10n: "Next >" button caption is translatd incorrectly onto the German language

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/public/main_wizard_panel_de.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/public/main_wizard_panel_de.properties
@@ -2,7 +2,7 @@ WIZARD_TITLE=Datenquellen-Assistent
 CURRENT_STEP=Aktueller Schritt
 PREVIEW=Vorschau
 BACK=&lt; Zur\u00fcck
-NEXT=&gt; Weiter
+NEXT=Weiter &gt;
 FINISH=Beenden
 CANCEL=Abbrechen
 


### PR DESCRIPTION
@mchen-len-son , could you please merge this PR?