### PR TITLE
[PPP-3537] - Use of vulnerable component com.thoughtworks.xstream v1.…

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -33,7 +33,7 @@ dependency.pentaho-modeler.revision=7.0-SNAPSHOT
 dependency.pentaho-platform.revision=7.0-SNAPSHOT
 dependency.pentaho-xul.revision=7.0-SNAPSHOT
 dependency.pentaho.repository.revision=7.0-SNAPSHOT
-dependency.xstream.revision=1.4.2
+dependency.xstream.revision=1.4.9
 dependency.jettison.revision=1.2
 
 dependency.gwt.revision=2.5.1

--- a/ivy.xml
+++ b/ivy.xml
@@ -75,7 +75,11 @@
 
     <dependency org="dom4j" name="dom4j" rev="1.6.1"/>
     <dependency org="xml-apis" name="xml-apis" rev="1.3.04" transitive="false" conf="codegen,default->default"/>
-    <dependency org="com.thoughtworks.xstream" name="xstream" rev="${dependency.xstream.revision}"/>
+
+    <dependency org="xmlpull" name="xmlpull" rev="1.1.3.1" transitive="false"/>
+    <dependency org="xpp3" name="xpp3_min" rev="1.1.4c" transitive="false"/>
+    <dependency org="com.thoughtworks.xstream" name="xstream" rev="${dependency.xstream.revision}" transitive="false"/>
+
     <dependency org="stax" name="stax" rev="1.2.0"/>
     <dependency org="org.codehaus.jettison" name="jettison" rev="${dependency.jettison.revision}"/>
     <dependency org="jaxen" name="jaxen" rev="1.1.1" transitive="false" conf="default->default"/>


### PR DESCRIPTION
…4.2 CVE-2013-7285

- are added explicit dependencies to xmlpull and xpp3.

@rmansoor, @pamval, could you please take a look? - locally resolve pass and jars are retrived.
need a new build for doing this point: ".At least do a sniff test of the BA and the DI server."