### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -156,9 +156,16 @@
     <dependency org="org.mockito" 						 name="mockito-all" 								 rev="1.8.0" 			transitive="false" conf="test->default"/>
     <!--dependency org="com.google.collections" name="google-collections" rev="1.0-rc5" transitive="false" conf="test->default"/-->
     <dependency org="org.aspectj"            name="aspectjrt"          rev="1.6.6"   transitive="false" conf="test->default"/>
-    <dependency org="com.sun.jersey.jersey-test-framework"  name="jersey-test-framework-core"     rev="1.5" conf="test->default"/>
-    <dependency org="com.sun.jersey.jersey-test-framework"  name="jersey-test-framework-grizzly"  rev="1.5" conf="test->default"/>
-    <dependency org="com.sun.jersey.contribs"               name="jersey-multipart"               rev="1.5" conf="test->default"/>
+    <dependency org="com.sun.jersey.jersey-test-framework"  name="jersey-test-framework-core"     rev="1.19.1" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.jersey.jersey-test-framework"  name="jersey-test-framework-grizzly"  rev="1.19.1" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-framework" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-lzma" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-portunif" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-rcm" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-servlet-webserver" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-utils" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-http" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-http-servlet" rev="1.9.45" transitive="false" conf="test->default"/>
 
     <dependency org="commons-codec" name="commons-codec" rev="1.9" transitive="false" conf="test->default"/>
     <dependency org="org.springframework" name="spring-mock" rev="${dependency.spring.mock.revision}" transitive="false" conf="test->default"/>
@@ -215,19 +222,20 @@
     <dependency org="pentaho" name="simple-jndi" rev="${dependency.pentaho-simple-jndi.revision}" conf="test->default" transitive="false"/>
 
     <!-- jersey -->
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.5"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.5" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.19.1" transitive="false"/>
+    <dependency org="org.jvnet.mimepull" name="mimepull" rev="1.9.3" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.19.1" transitive="false"/>
 
     <!-- jersey -->
-    <dependency org="com.sun.jersey" name="jersey-core" rev="1.5" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-json" rev="1.5" transitive="false"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-spring" rev="1.5" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-client" rev="1.5" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-server" rev="1.5" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-core" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-json" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-spring" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-client" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-server" rev="1.19.1" transitive="false"/>
     <dependency org="javax.ws.rs" name="jsr311-api" rev="1.1.1" transitive="false"/>
 
     <!-- wadl -->
-    <dependency org="com.sun.jersey.contribs" name="wadl-resourcedoc-doclet" rev="1.19" transitive="false" />
+    <dependency org="com.sun.jersey.contribs" name="wadl-resourcedoc-doclet" rev="1.19.1" transitive="false" />
 
      <override org="pentaho-kettle" rev="${dependency.kettle.revision}" />
      


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor