### PR TITLE
SP-2804  Backport of BISERVER-12964 - Localization - Test Connection dialog window isn't fully translated (Japanese and French) (6.1 Suite)

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages_de.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages_de.properties
@@ -28,9 +28,9 @@ ConnectionServiceImpl.ERROR_0005_UNABLE_TO_UPDATE_CONNECTION=Unable to update co
 ConnectionServiceImpl.ERROR_0006_UNABLE_TO_DELETE_CONNECTION=Unable to delete connection name\u0020: connection name was {0} caused by {1}
 ConnectionServiceImpl.ERROR_0007_DATAACCESS_PERMISSIONS_INIT_ERROR=Dataaccess permission initialization error
 ConnectionServiceImpl.ERROR_0008_UNABLE_TO_TEST_NULL_CONNECTION=Unable to test a null connection
-ConnectionServiceImpl.ERROR_0009_CONNECTION_FAILED=Connection to database [ {0} ] failed
+ConnectionServiceImpl.ERROR_0009_CONNECTION_FAILED=Verbindung zu Datenbank [ {0} ] fehlgeschlagen
 
-ConnectionServiceImpl.INFO_0001_CONNECTION_SUCCEED=Connection to database [ {0} ] succeeded
+ConnectionServiceImpl.INFO_0001_CONNECTION_SUCCEED=Verbindung zu Datenbank [ {0} ] erfolgreich
 ConnectionServiceImpl.INFO_0002_DEFAULT_AUTO_COMMIT=The default auto-commit state of connections created by this pool.
 ConnectionServiceImpl.INFO_0003_DEFAULT_READ_ONLY=The default read-only state of connections created by this pool.\nIf not set then the setReadOnly method will not be called.\n (Some drivers don't support read only mode, ex: Informix)
 ConnectionServiceImpl.INFO_0004_DEFAULT_TRANSACTION_ISOLATION=the default TransactionIsolation state of connections created by this pool. One of the following: (see javadoc)\n\n  * NONE\n  * READ_COMMITTED\n  * READ_UNCOMMITTED\n  * REPEATABLE_READ  * SERIALIZABLE\n

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages_fr.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages_fr.properties
@@ -28,9 +28,9 @@ ConnectionServiceImpl.ERROR_0005_UNABLE_TO_UPDATE_CONNECTION=Unable to update co
 ConnectionServiceImpl.ERROR_0006_UNABLE_TO_DELETE_CONNECTION=Unable to delete connection name\u0020: connection name was {0} caused by {1}
 ConnectionServiceImpl.ERROR_0007_DATAACCESS_PERMISSIONS_INIT_ERROR=Dataaccess permission initialization error
 ConnectionServiceImpl.ERROR_0008_UNABLE_TO_TEST_NULL_CONNECTION=Unable to test a null connection
-ConnectionServiceImpl.ERROR_0009_CONNECTION_FAILED=Connection to database [ {0} ] failed
+ConnectionServiceImpl.ERROR_0009_CONNECTION_FAILED=La connexion \u00e0 la base de donn\u00e9es [{0}] a \u00e9chou\u00e9
 
-ConnectionServiceImpl.INFO_0001_CONNECTION_SUCCEED=Connection to database [ {0} ] succeeded
+ConnectionServiceImpl.INFO_0001_CONNECTION_SUCCEED=La connexion \u00e0 la base de donn\u00e9es [{0}] a r\u00e9ussi
 ConnectionServiceImpl.INFO_0002_DEFAULT_AUTO_COMMIT=The default auto-commit state of connections created by this pool.
 ConnectionServiceImpl.INFO_0003_DEFAULT_READ_ONLY=The default read-only state of connections created by this pool.\nIf not set then the setReadOnly method will not be called.\n (Some drivers don't support read only mode, ex: Informix)
 ConnectionServiceImpl.INFO_0004_DEFAULT_TRANSACTION_ISOLATION=the default TransactionIsolation state of connections created by this pool. One of the following: (see javadoc)\n\n  * NONE\n  * READ_COMMITTED\n  * READ_UNCOMMITTED\n  * REPEATABLE_READ  * SERIALIZABLE\n

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages_ja.properties
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/messages/messages_ja.properties
@@ -28,9 +28,9 @@ ConnectionServiceImpl.ERROR_0005_UNABLE_TO_UPDATE_CONNECTION=Unable to update co
 ConnectionServiceImpl.ERROR_0006_UNABLE_TO_DELETE_CONNECTION=Unable to delete connection name\u0020: connection name was {0} caused by {1}
 ConnectionServiceImpl.ERROR_0007_DATAACCESS_PERMISSIONS_INIT_ERROR=Dataaccess permission initialization error
 ConnectionServiceImpl.ERROR_0008_UNABLE_TO_TEST_NULL_CONNECTION=Unable to test a null connection
-ConnectionServiceImpl.ERROR_0009_CONNECTION_FAILED=Connection to database [ {0} ] failed
+ConnectionServiceImpl.ERROR_0009_CONNECTION_FAILED=\u30c7\u30fc\u30bf\u30d9\u30fc\u30b9 [ {0} ] \u3078\u306e\u63a5\u7d9a\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002
 
-ConnectionServiceImpl.INFO_0001_CONNECTION_SUCCEED=Connection to database [ {0} ] succeeded
+ConnectionServiceImpl.INFO_0001_CONNECTION_SUCCEED=\u30c7\u30fc\u30bf\u30d9\u30fc\u30b9 [ {0} ] \u3078\u306e\u63a5\u7d9a\u306b\u6210\u529f\u3057\u307e\u3057\u305f\u3002
 ConnectionServiceImpl.INFO_0002_DEFAULT_AUTO_COMMIT=The default auto-commit state of connections created by this pool.
 ConnectionServiceImpl.INFO_0003_DEFAULT_READ_ONLY=The default read-only state of connections created by this pool.\nIf not set then the setReadOnly method will not be called.\n (Some drivers don't support read only mode, ex: Informix)
 ConnectionServiceImpl.INFO_0004_DEFAULT_TRANSACTION_ISOLATION=the default TransactionIsolation state of connections created by this pool. One of the following: (see javadoc)\n\n  * NONE\n  * READ_COMMITTED\n  * READ_UNCOMMITTED\n  * REPEATABLE_READ  * SERIALIZABLE\n


### PR DESCRIPTION
"Test Connection" dialog was fixed