### PR TITLE
UPLOAD_ANALYSIS: uploadInput -> uploadAnalysis

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/api/resources/AnalysisResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/api/resources/AnalysisResource.java
@@ -58,7 +58,7 @@ import static javax.ws.rs.core.Response.Status.*;
 @Path( "/data-access/api/datasource/analysis" )
 public class AnalysisResource {
 
-  protected static final String UPLOAD_ANALYSIS = "uploadInput";
+  protected static final String UPLOAD_ANALYSIS = "uploadAnalysis";
   protected static final String CATALOG_ID = "catalogId";
   protected static final String ORIG_CATALOG_NAME = "origCatalogName";
   protected static final String DATASOURCE_NAME = "datasourceName";


### PR DESCRIPTION
The documentation (https://help.pentaho.com/Documentation/5.3/0R0/070/010/0B0/0I0) says `uploadAnalysis` but they code says `uploadInput` - which is correct? Can we either get this merged or update the documentation?
