### PR TITLE
[BISERVER-13375] Fixed addition parameters with specific characters

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogController.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogController.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.ui.importing;
@@ -29,6 +29,7 @@ import org.pentaho.gwt.widgets.client.utils.NameUtils;
 import org.pentaho.gwt.widgets.client.utils.i18n.ResourceBundle;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
 import org.pentaho.platform.dataaccess.datasource.IDatasourceInfo;
+import org.pentaho.platform.dataaccess.datasource.utils.DataSourceInfoUtil;
 import org.pentaho.platform.dataaccess.datasource.wizard.DatasourceMessages;
 import org.pentaho.platform.dataaccess.datasource.wizard.controllers.MessageHandler;
 import org.pentaho.ui.database.event.IConnectionAutoBeanFactory;
@@ -61,8 +62,6 @@ import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
-import com.google.gwt.http.client.URL;
-import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.FileUpload;
 import com.google.gwt.user.client.ui.FlowPanel;
@@ -452,7 +451,7 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
   public String convertToNLSMessage( String results, String fileName ) {
     String msg = results;
     int code = new Integer( results ).intValue();
-    switch( code ) {
+    switch ( code ) {
       case 1:
         msg = messages.getString( "Mondrian.ERROR_OO1_PUBLISH" );
         break;
@@ -707,7 +706,8 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
     boolean hasParameters = false;
     boolean connectionFound = false;
     String paramName = name.toString();
-    String paramValue = value.toString();
+    //Unescape quotes is used, because value can contain &quot; elements.
+    String paramValue = DataSourceInfoUtil.unescapeQuotes( value.toString() );
     if ( paramName.equalsIgnoreCase( "Datasource" ) ) {
       for ( IDatabaseConnection connection : importDialogModel.getConnectionList() ) {
         if ( connection.getName().equals( paramValue ) ) {
@@ -774,13 +774,13 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
           int i, len = responseValue.length();
           for ( i = 0; i < len; i++ ) {
             ch = responseValue.charAt( i );
-            switch( state ) {
+            switch ( state ) {
               case 0: //new name/value pair
                 paramHandled = handleParam( name, value );
                 if ( !hasParameters ) {
                   hasParameters = paramHandled;
                 }
-                switch( ch ) {
+                switch ( ch ) {
                   case ';':
                     break;
                   default:
@@ -789,7 +789,7 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
                 }
                 break;
               case 1: //looking for equals
-                switch( ch ) {
+                switch ( ch ) {
                   case '=':
                     state = 2;
                     break;
@@ -798,7 +798,7 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
                 }
                 break;
               case 2: //about to parse the value
-                switch( ch ) {
+                switch ( ch ) {
                   case '"':
                     state = 3;
                     break;
@@ -811,7 +811,7 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
                 }
                 break;
               case 3: //parse value till closing quote.
-                switch( ch ) {
+                switch ( ch ) {
                   case '"':
                     state = 0;
                     break;
@@ -820,7 +820,7 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
                 }
                 break;
               case 4:
-                switch( ch ) {
+                switch ( ch ) {
                   case ';':
                     state = 0;
                     break;

--- a/src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogModel.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogModel.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.ui.importing;
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.pentaho.database.model.IDatabaseConnection;
+import org.pentaho.platform.dataaccess.datasource.utils.DataSourceInfoUtil;
 import org.pentaho.ui.xul.XulEventSourceAdapter;
 import org.pentaho.ui.xul.stereotype.Bindable;
 
@@ -119,8 +120,8 @@ public class AnalysisImportDialogModel extends XulEventSourceAdapter {
           result += sep;
         }
         //add name / value pair
-        value = currentParameter.getValue();
-        //TODO: check if the value contains a quote character. currently not supported.
+        //Escape is used, because value can contain quotes and it is parse-unsafe.
+        value = DataSourceInfoUtil.escapeQuotes( currentParameter.getValue() );
         if ( //if the value is not quoted
           ( !( value.startsWith( quot ) && value.endsWith( quot ) ) )
             //and the value contains the separator

--- a/src/org/pentaho/platform/dataaccess/datasource/utils/DataSourceInfoUtil.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/utils/DataSourceInfoUtil.java
@@ -1,0 +1,111 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright ( c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.dataaccess.datasource.utils;
+
+import java.util.Map;
+import java.util.LinkedHashMap;
+
+/**
+ * @author Vadim_Polynkov
+ */
+public class DataSourceInfoUtil {
+
+  public static String escapeQuotes( final String text ) {
+    return text.replaceAll( "\"", "&quot;" );
+  }
+
+  public static String unescapeQuotes( final String text ) {
+    return text.replaceAll( "&quot;", "\"" );
+  }
+
+  public static Map<String, String> parseDataSourceInfo( final String text ) {
+    Map<String, String> parameters = new LinkedHashMap<String, String>();
+
+    StringBuilder name = new StringBuilder();
+    StringBuilder value = new StringBuilder();
+    int state = 0;
+    char ch;
+    int i, len = text.length();
+    for ( i = 0; i < len; i++ ) {
+      ch = text.charAt( i );
+      switch ( state ) {
+        case 0: //new name/value pair
+          if ( name.length() != 0 ) {
+            parameters.put( name.toString(), value.toString() );
+            name.setLength( 0 );
+            value.setLength( 0 );
+          }
+          switch ( ch ) {
+            case ';':
+              break;
+            default:
+              state = 1;
+              name.append( ch );
+          }
+          break;
+        case 1: //looking for equals
+          switch ( ch ) {
+            case '=':
+              state = 2;
+              break;
+            default:
+              name.append( ch );
+          }
+          break;
+        case 2: //about to parse the value
+          switch ( ch ) {
+            case '"':
+              state = 3;
+              break;
+            case ';':
+              state = 0;
+              break;
+            default:
+              value.append( ch );
+              state = 4;
+          }
+          break;
+        case 3: //parse value till closing quote.
+          switch ( ch ) {
+            case '"':
+              state = 0;
+              break;
+            default:
+              value.append( ch );
+          }
+          break;
+        case 4:
+          switch ( ch ) {
+            case ';':
+              state = 0;
+              break;
+            default:
+              value.append( ch );
+          }
+          break;
+        default:
+
+      }
+    }
+    if ( name.length() != 0 ) {
+      parameters.put( name.toString(), value.toString() );
+    }
+    return parameters;
+  }
+
+}

--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
@@ -25,19 +25,22 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.codehaus.enunciate.Facet;
 import org.pentaho.platform.dataaccess.datasource.api.resources.AnalysisResource;
 import org.pentaho.platform.dataaccess.datasource.api.resources.DataSourceWizardResource;
 import org.pentaho.platform.dataaccess.datasource.api.resources.MetadataResource;
+import org.pentaho.platform.dataaccess.datasource.utils.DataSourceInfoUtil;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import org.pentaho.platform.web.http.api.resources.JaxbList;
 
+import java.util.Map;
+
 @Path( "/data-access/api/datasource" )
 public class DatasourceResource {
-  
   /**
    * Get the data source wizard info (parameters) for a specific data source wizard id
    * 
@@ -54,10 +57,27 @@ public class DatasourceResource {
     IMondrianCatalogService mondrianCatalogService =
         PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
     MondrianCatalog catalog = mondrianCatalogService.getCatalog( catalogId, PentahoSessionHolder.getSession() );
-    String parameters = catalog.getDataSourceInfo();
+    //dataSourceInfo can contain XML-escaped characters
+    String parameters = prepareDataSourceInfo( catalog.getDataSourceInfo() );
+    //after preparation, parameters have escaped only quotes
     return Response.ok().entity( parameters ).build();
   }
-  
+
+  static String prepareDataSourceInfo( String dataSourceInfo ) {
+    StringBuilder sb = new StringBuilder();
+    Map<String, String> parameters = DataSourceInfoUtil.parseDataSourceInfo( dataSourceInfo );
+    parameters.forEach( ( key, value ) -> {
+      String unescapedValue = StringEscapeUtils.unescapeXml( value );
+      String valueWithEscapedQuotes = DataSourceInfoUtil.escapeQuotes( unescapedValue );
+      sb.append( key );
+      sb.append( "=\"" );
+      sb.append( valueWithEscapedQuotes );
+      sb.append( "\"" );
+      sb.append( ";" );
+    } );
+    return sb.toString();
+  }
+
   /**
    * Get list of IDs of analysis datasource
    *
@@ -101,7 +121,6 @@ public class DatasourceResource {
   public Response doGetAnalysisFilesAsDownload( @PathParam( "analysisId" ) String analysisId ) {
     return new AnalysisResource().downloadSchema( analysisId );
   }
-  
   /**
    * Remove the analysis data for a given analysis ID
    * 

--- a/test-src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogControllerTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogControllerTest.java
@@ -1,0 +1,65 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+*/
+
+
+package org.pentaho.platform.dataaccess.datasource.ui.importing;
+
+import org.junit.Test;
+import org.apache.commons.lang.reflect.FieldUtils;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Vadim_Polynkov.
+ */
+public class AnalysisImportDialogControllerTest {
+
+  @Test
+  public void testHandleParam() throws Exception {
+    final StringBuilder dsInputName = new StringBuilder( "DataSource" );
+    final StringBuilder dsInputValue = new StringBuilder( "DS &quot;Test's&quot; & <Fun>" );
+    final String dsExpectedValue = "DS \"Test's\" & <Fun>";
+
+    final StringBuilder dspInputName = new StringBuilder( "DynamicSchemaProcessor" );
+    final StringBuilder dspInputValue = new StringBuilder( "DSP's & &quot;Other&quot; <stuff>" );
+    final String dspExpectedValueDSP = "DSP's & \"Other\" <stuff>";
+
+    AnalysisImportDialogController controller = new AnalysisImportDialogController();
+    AnalysisImportDialogModel importDialogModel = new AnalysisImportDialogModel();
+
+    importDialogModel.setAnalysisParameters( new ArrayList<>() );
+    importDialogModel.setParameterMode( true );
+
+    Field modelField = FieldUtils.getDeclaredField( AnalysisImportDialogController.class, "importDialogModel", true );
+    modelField.setAccessible( true );
+    FieldUtils.writeField( modelField, controller, importDialogModel );
+
+    controller.handleParam( dsInputName, dsInputValue );
+    controller.handleParam( dspInputName, dspInputValue );
+
+    ParameterDialogModel parameterFirst = controller.getDialogResult().getAnalysisParameters().get( 0 );
+    ParameterDialogModel parameterSecond = controller.getDialogResult().getAnalysisParameters().get( 1 );
+
+    assertEquals( parameterFirst.getValue(), dsExpectedValue );
+    assertEquals( parameterSecond.getValue(), dspExpectedValueDSP );
+    assertEquals( controller.getDialogResult().getParameters(),
+      "DataSource=\"DS &quot;Test's&quot; & <Fun>\";DynamicSchemaProcessor=\"DSP's & &quot;Other&quot; <stuff>\"" );
+  }
+}

--- a/test-src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogModelTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogModelTest.java
@@ -1,0 +1,50 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+*/
+
+package org.pentaho.platform.dataaccess.datasource.ui.importing;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * @author Vadim_Polynkov.
+ */
+public class AnalysisImportDialogModelTest {
+
+  @Test
+  public void testGetParameters_OnlyQuotesEscaped() {
+    AnalysisImportDialogModel analysisImportDialogModel = new AnalysisImportDialogModel();
+    List<ParameterDialogModel> parameters = new ArrayList<>();
+
+    final String expectedValue = "DataSource=\"DS &quot;Test's&quot; & <Fun>\";"
+      + "DynamicSchemaProcessor=\"DSP's & &quot;Other&quot; <stuff>\"";
+
+    ParameterDialogModel parameter = new ParameterDialogModel( "DataSource", "DS \"Test's\" & <Fun>" );
+    parameters.add( 0, parameter );
+    parameter = new ParameterDialogModel( "DynamicSchemaProcessor", "DSP's & \"Other\" <stuff>" );
+    parameters.add( 1, parameter );
+
+    analysisImportDialogModel.setAnalysisParameters( parameters );
+    analysisImportDialogModel.setParameterMode( true );
+    String dataSourceInfo = analysisImportDialogModel.getParameters();
+
+    Assert.assertEquals( dataSourceInfo, expectedValue );
+  }
+}

--- a/test-src/org/pentaho/platform/dataaccess/datasource/utils/DataSourceInfoUtilTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/utils/DataSourceInfoUtilTest.java
@@ -1,0 +1,53 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+
+package org.pentaho.platform.dataaccess.datasource.utils;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Vadim_Polynkov.
+ */
+public class DataSourceInfoUtilTest {
+
+  @Test
+  public void testEscapeQuotes() {
+    String value = "DS \"Test's\" & <Fun>";
+    String expectedValue = "DS &quot;Test's&quot; & <Fun>";
+    assertEquals( DataSourceInfoUtil.escapeQuotes( value ), expectedValue );
+  }
+
+  @Test
+  public void testUnescapeQuotes() {
+    String value = "DS &quot;Test's&quot; & <Fun>";
+    String expectedValue = "DS \"Test's\" & <Fun>";
+    assertEquals( DataSourceInfoUtil.unescapeQuotes( value ), expectedValue );
+  }
+
+  @Test
+  public void testParseDataSourceInfo() {
+    String value = "DataSource=\"DS &quot;Test's&quot; & <Fun>\";Param=\"TestValue";
+    Map map = DataSourceInfoUtil.parseDataSourceInfo( value );
+    assertEquals( map.get( "DataSource" ), "DS &quot;Test's&quot; & <Fun>" );
+    assertEquals( map.get( "Param" ), "TestValue" );
+  }
+}

--- a/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceTest.java
+++ b/test-src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceTest.java
@@ -1,0 +1,45 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Vadim_Polynkov.
+ */
+public class DatasourceResourceTest {
+
+  @Test
+  public void testPrepareDataSourceInfo_OnlyQuotesEscaped() {
+    StringBuilder dataSourceInfo = new StringBuilder();
+    dataSourceInfo.append( "DataSource=" )
+      .append( "\"DS &quot;Test&apos;s&quot; &amp; &lt;Fun&gt;\";" )
+      .append( "DynamicSchemaProcessor=" )
+      .append( "\"DSP&apos;s &amp; &quot;Other&quot; &lt;stuff&gt;\";" );
+
+    StringBuilder expectedResult = new StringBuilder();
+    expectedResult.append( "DataSource=" )
+      .append( "\"DS &quot;Test's&quot; & <Fun>\";" )
+      .append( "DynamicSchemaProcessor=" )
+      .append( "\"DSP's & &quot;Other&quot; <stuff>\";" );
+
+    String result = DatasourceResource.prepareDataSourceInfo( dataSourceInfo.toString() );
+    assertEquals( result, expectedResult.toString() );
+  }
+}


### PR DESCRIPTION
@pamval , @mbatchelor , @e-cuellar , @pentaho-nbaker  please review.

This PR is related to [PR in pentaho-platform](https://github.com/pentaho/pentaho-platform/pull/3286).
[jira issue](http://jira.pentaho.com/browse/BISERVER-13375), [previous PR](https://github.com/pentaho/pentaho-platform/pull/3270)
This PR needs resolve ENGOPS issue http://jira.pentaho.com/browse/ENGOPS-2643.
Don't merge this PR until the issue is closed.
This PR has "Still Broken Tests" message. This tests are not related to my changes. I don't see quick fix of them.

This PR contains following changes:
1. [DataSourceInfoUtil](https://github.com/pentaho/data-access/compare/master...VadimPolynkov:BISERVER-13375?expand=1#diff-e0ef69a5d7659ee402ff424b26e54ff2R26) class is added for custom escape and unescape quotes. In addition, it has [method](https://github.com/pentaho/data-access/compare/master...VadimPolynkov:BISERVER-13375?expand=1#diff-e0ef69a5d7659ee402ff424b26e54ff2R36) for parse parameters string (dataSourceInfo). It is necessary for minimize the use [mondrian.olap.Util](https://github.com/pentaho/mondrian/blob/master/mondrian/src/main/java/mondrian/olap/Util.java#L2735) in data-access for parsing.
This methods are used for display parameters on [ui](https://github.com/VadimPolynkov/data-access/blob/3d3da2acb23e053ea2972d4e65ef75e5cb07f8ba/src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogController.java#L710) and for [prepare parameters](https://github.com/VadimPolynkov/data-access/blob/3d3da2acb23e053ea2972d4e65ef75e5cb07f8ba/src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogModel.java#L124) before sending to pentaho-platform.

2. DatasourceResource replaces all escaped symbols by original, then escapes quotes for parsing string with parameters in xul side ([link](https://github.com/VadimPolynkov/data-access/blob/3d3da2acb23e053ea2972d4e65ef75e5cb07f8ba/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResource.java#L62)).
3. AnalysisImportDialogModel.getParameters method escapes all inner quotes in values, and frames value in original quote before concatenation ([link](https://github.com/VadimPolynkov/data-access/blob/3d3da2acb23e053ea2972d4e65ef75e5cb07f8ba/src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogModel.java#L124-L131)).
4. Xul side doesn't have escapeXml java method like org.apache.commons.lang.StringEscapeUtils.escapeXml, therefore custom quote escape [method](https://github.com/VadimPolynkov/data-access/blob/3d3da2acb23e053ea2972d4e65ef75e5cb07f8ba/src/org/pentaho/platform/dataaccess/datasource/utils/DataSourceInfoUtil.java#L28) is used.
5. Inner quotes in value are obstacle for parser, therefore quotes is escaped in values.
