### PR TITLE
[REVERT]:BISERVER-13407 ValidationQuery and Pooling options not sent to DB when datasource is defined in Manage DataSources Perspective

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceImpl.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceImpl.java
@@ -18,7 +18,6 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
-import java.util.Properties;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -278,15 +277,9 @@ public class ConnectionServiceImpl extends PentahoBase implements IConnectionSer
           pentahoConnection = PentahoConnectionFactory
             .getConnection( IPentahoConnection.SQL_DATASOURCE, connection.getDatabaseName(), null, this );
         } else {
-          if ( connection.isUsingConnectionPool() ) {
-            Properties props = new Properties();
-            props.put( IPentahoConnection.CONNECTION_NAME, connection.getName() );
-            pentahoConnection = PentahoConnectionFactory.getConnection( IPentahoConnection.SQL_DATASOURCE, props, null, this );
-          } else {
-            pentahoConnection = PentahoConnectionFactory.getConnection( IPentahoConnection.SQL_DATASOURCE, driverClass,
-              dialect.getURLWithExtraOptions( connection ), connection.getUsername(),
-              getConnectionPassword( connection.getName(), connection.getPassword() ), null, this );
-          }
+          pentahoConnection = PentahoConnectionFactory.getConnection( IPentahoConnection.SQL_DATASOURCE, driverClass,
+          dialect.getURLWithExtraOptions( connection ), connection.getUsername(),
+          getConnectionPassword( connection.getName(), connection.getPassword() ), null, this );
         }
       } catch ( DatabaseDialectException e ) {
         throw new ConnectionServiceException( e );

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceImplTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceImplTest.java
@@ -324,30 +324,25 @@ public class ConnectionServiceImplTest {
 
   @Test( expected = ConnectionServiceException.class )
   public void testTestConnection_Null() throws Exception {
-    testTestConnection( DatabaseAccessType.JNDI, null, "NONGENERIC", false );
+    testTestConnection( DatabaseAccessType.JNDI, null, "NONGENERIC" );
   }
 
   @Test
   public void testTestConnection_Native() throws Exception {
-    testTestConnection( DatabaseAccessType.NATIVE, mockDBConnection, "NONGENERIC", false );
+    testTestConnection( DatabaseAccessType.NATIVE, mockDBConnection, "NONGENERIC" );
   }
 
   @Test
   public void testTestConnection_JNDI() throws Exception {
-    testTestConnection( DatabaseAccessType.JNDI, mockDBConnection, "NONGENERIC", false );
+    testTestConnection( DatabaseAccessType.JNDI, mockDBConnection, "NONGENERIC" );
   }
 
   @Test
   public void testTestConnection_NativeGenericConnection() throws Exception {
-    testTestConnection( DatabaseAccessType.NATIVE, mockDBConnection, "GENERIC", false );
+    testTestConnection( DatabaseAccessType.NATIVE, mockDBConnection, "GENERIC" );
   }
 
-  @Test
-  public void testTestConnection_NativeGenericConnectionPool() throws Exception {
-    testTestConnection( DatabaseAccessType.NATIVE, mockDBConnection, "GENERIC", true );
-  }
-
-  private void testTestConnection( DatabaseAccessType accessType, IDatabaseConnection connection, String database, boolean isPool ) throws Exception {
+  private void testTestConnection( DatabaseAccessType accessType, IDatabaseConnection connection, String database) throws Exception {
     doNothing().when( connectionServiceImpl ).ensureDataAccessPermission();
     doReturn( "connectionPassword" ).when( connectionServiceImpl ).getConnectionPassword( anyString(), anyString() );
 
@@ -357,7 +352,6 @@ public class ConnectionServiceImplTest {
     doReturn( database ).when( databaseType ).getShortName();
     doReturn( accessType ).when( mockDBConnection ).getAccessType();
     doReturn( "DATABASENAME" ).when( mockDBConnection ).getDatabaseName();
-    doReturn( isPool ).when( mockDBConnection ).isUsingConnectionPool();
     assertTrue( connectionServiceImpl.testConnection( connection ) );
     verify( sqlConnection ).close();
   }


### PR DESCRIPTION
reverting changes for http://jira.pentaho.com/browse/BISERVER-13407 due to http://jira.pentaho.com/browse/BACKLOG-13455
http://jira.pentaho.com/browse/BACKLOG-13429