### PR TITLE
[PDI-15515] - Removing legacy esapi encoder from the projects

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -552,8 +552,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.owasp.esapi</groupId>
-      <artifactId>esapi</artifactId>
+      <groupId>org.owasp.encoder</groupId>
+      <artifactId>encoder</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
     <maven-failsafe-plugin.reuseForks>false</maven-failsafe-plugin.reuseForks>
 
-    <esapi.version>2.0.1</esapi.version>
+    <encoder.version>1.2</encoder.version>
     <metastore.version>7.1-SNAPSHOT</metastore.version>
     <jsr311-api.version>1.1.1</jsr311-api.version>
     <eigenbase-xom.version>1.3.1</eigenbase-xom.version>
@@ -1590,9 +1590,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.owasp.esapi</groupId>
-        <artifactId>esapi</artifactId>
-        <version>${esapi.version}</version>
+        <groupId>org.owasp.encoder</groupId>
+        <artifactId>encoder</artifactId>
+        <version>${encoder.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
Removing legacy esapi encoder from the projects and replacing it by org.owasp.encoder