### PR TITLE
[SP-3443][BACKLOG-15723] - Backport of BISERVER-13589 - CLONE - CSV Data Source: Error Log is blank when the field length is less than the actual data coming in (7.0 Suite)

### DIFF
--- a/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImpl.java
+++ b/src/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/CsvDatasourceServiceImpl.java
@@ -161,7 +161,11 @@ public class CsvDatasourceServiceImpl extends PentahoBase implements ICsvDatasou
 
         ArrayList<String> combinedErrors = new ArrayList<String>( modelInfo.getCsvInputErrors() );
         combinedErrors.addAll( modelInfo.getTableOutputErrors() );
-        stats.setErrors( combinedErrors );
+        if ( stats.getErrors() != null && stats.getErrors().size() > 0 ) {
+          stats.getErrors().addAll( combinedErrors );
+        } else {
+          stats.setErrors( combinedErrors );
+        }
 
         // wait until it it done
         while ( !stats.isRowsFinished() ) {


### PR DESCRIPTION
 - now error list complete instead of rewrite