### PR TITLE
[BACKLOG-16051] Using the dsInfo.getId() which returns the non-escaped

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/ui/service/JdbcDatasourceService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/ui/service/JdbcDatasourceService.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.ui.service;
@@ -186,7 +186,7 @@ public class JdbcDatasourceService implements IUIDatasourceAdminService {
   public void remove( IDatasourceInfo dsInfo, Object callback ) {
     final XulServiceCallback<Boolean> responseCallback = (XulServiceCallback<Boolean>) callback;
     RequestBuilder deleteConnectionBuilder = new RequestBuilder( RequestBuilder.DELETE,
-      getBaseURL() + NameUtils.URLEncode( "deletebyname?name={0}", dsInfo.getName() ) );
+      getBaseURL() + NameUtils.URLEncode( "deletebyname?name={0}", dsInfo.getId() ) );
     try {
       deleteConnectionBuilder.sendRequest( null, new RequestCallback() {
         public void onResponseReceived( Request request, Response response ) {


### PR DESCRIPTION
name while preparing the url for deleting the datasource. The
dsInfo.getName() has been changed to escape the html characters.