### PR TITLE
[BACKLOG-16058] Changes UtilHtmlSanitizer function params and moves name sanitization from ConnectionService to ConnectionServiceImpl

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
@@ -93,7 +93,7 @@ public class ConnectionService {
     IDatabaseConnection conn = null;
     Response response;
     try {
-      conn = connectionService.getConnectionByName( sanitizer.safeEscapeHtml( name ) );
+      conn = connectionService.getConnectionByName( name );
       if ( conn != null ) {
         response = Response.ok().entity( conn.getId() ).build();
       } else {
@@ -236,7 +236,6 @@ public class ConnectionService {
   @Facet( name = "Unsupported" )
   public Response testConnection( DatabaseConnection connection ) throws ConnectionServiceException {
     boolean success = false;
-    sanitizer.sanitizeConnectionParameters( connection );
     applySavedPassword( connection );
     success = connectionService.testConnection( connection );
     if ( success ) {
@@ -319,7 +318,6 @@ public class ConnectionService {
   @Facet( name = "Unsupported" )
   public Response deleteConnection( DatabaseConnection connection ) throws ConnectionServiceException {
     try {
-      sanitizer.sanitizeConnectionParameters( connection );
       boolean success = connectionService.deleteConnection( connection );
       if ( success ) {
         return Response.ok().build();
@@ -345,7 +343,7 @@ public class ConnectionService {
   @Path( "/deletebyname" )
   public Response deleteConnectionByName( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
     try {
-      boolean success = connectionService.deleteConnection( sanitizer.safeEscapeHtml( name ) );
+      boolean success = connectionService.deleteConnection( name );
       if ( success ) {
         return Response.ok().build();
       } else {
@@ -414,11 +412,7 @@ public class ConnectionService {
   @Facet( name = "Unsupported" )
   public IDatabaseConnectionList getConnections() throws ConnectionServiceException {
     IDatabaseConnectionList databaseConnections = new DefaultDatabaseConnectionList();
-    List<IDatabaseConnection> conns = connectionService.getConnections();
-    for ( IDatabaseConnection conn : conns ) {
-      sanitizer.unsanitizeConnectionParameters( conn );
-      hidePassword( conn );
-    }
+    List<IDatabaseConnection> conns = connectionService.getConnections( true );
     databaseConnections.setDatabaseConnections( conns );
     return databaseConnections;
   }
@@ -437,8 +431,7 @@ public class ConnectionService {
   @Produces( { APPLICATION_JSON } )
   @Facet( name = "Unsupported" )
   public IDatabaseConnection getConnectionByName( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
-    IDatabaseConnection conn = connectionService.getConnectionByName( sanitizer.safeEscapeHtml( name ) );
-    sanitizer.unsanitizeConnectionParameters( conn );
+    IDatabaseConnection conn = connectionService.getConnectionByName( name );
     hidePassword( conn );
     return conn;
   }
@@ -457,7 +450,7 @@ public class ConnectionService {
   @Produces( { APPLICATION_JSON } )
   @Facet( name = "Unsupported" )
   public Response isConnectionExist( @QueryParam( "name" ) String name ) throws ConnectionServiceException {
-    boolean exists = connectionService.isConnectionExist( sanitizer.safeEscapeHtml( name ) );
+    boolean exists = connectionService.isConnectionExist( name );
     try {
       if ( exists ) {
         return Response.ok().build();
@@ -483,7 +476,7 @@ public class ConnectionService {
     IDatabaseConnection conn = null;
     Response response;
     try {
-      conn = connectionService.getConnectionByName( sanitizer.safeEscapeHtml( name ) );
+      conn = connectionService.getConnectionByName( name );
       sanitizer.unsanitizeConnectionParameters( conn );
       hidePassword( conn );
       response = Response.ok().entity( conn ).build();

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/utils/UtilHtmlSanitizer.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/utils/UtilHtmlSanitizer.java
@@ -18,7 +18,6 @@
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl.utils;
 
 import org.apache.commons.lang.StringEscapeUtils;
-import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
 
 /**
@@ -26,7 +25,7 @@ import org.pentaho.database.model.IDatabaseConnection;
  */
 public class UtilHtmlSanitizer {
 
-  public void sanitizeConnectionParameters( DatabaseConnection connection ) {
+  public void sanitizeConnectionParameters( IDatabaseConnection connection ) {
     String safeName = safeEscapeHtml( connection.getName() );
     connection.setName( safeName );
 

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceImplTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceImplTest.java
@@ -25,6 +25,7 @@ import org.mockito.stubbing.Answer;
 import org.pentaho.commons.connection.IPentahoConnection;
 import org.pentaho.database.IDatabaseDialect;
 import org.pentaho.database.model.DatabaseAccessType;
+import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.database.model.IDatabaseType;
 import org.pentaho.platform.api.data.DBDatasourceServiceException;
@@ -44,6 +45,7 @@ import org.pentaho.platform.plugin.services.connections.sql.SQLConnection;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -193,6 +195,26 @@ public class ConnectionServiceImplTest {
     List<IDatabaseConnection> connectionList = connectionServiceImpl.getConnections();
     verify( connectionServiceImpl ).getConnections();
     assertEquals( connectionList, mockConnectionList );
+  }
+
+  @Test
+  public void testGetConnectionsPasswords() throws Exception {
+    doNothing().when( connectionServiceImpl ).ensureDataAccessPermission();
+    List<IDatabaseConnection> mockConnectionList = new ArrayList<>();
+    IDatabaseConnection mockConnection = new DatabaseConnection();
+    mockConnectionList.add( mockConnection );
+    mockConnection.setPassword( "testPassword" );
+    doReturn( mockConnectionList ).when( connectionServiceImpl.datasourceMgmtSvc ).getDatasources();
+    List<IDatabaseConnection> connectionList = connectionServiceImpl.getConnections();
+    verify( connectionServiceImpl ).getConnections();
+
+    // Default getConnections() method does not hide password
+    assertEquals( "testPassword", mockConnectionList.get( 0 ).getPassword() );
+
+    // Hide passwords
+    connectionList = connectionServiceImpl.getConnections( true );
+    verify( connectionServiceImpl ).getConnections();
+    assertEquals( null, mockConnectionList.get( 0 ).getPassword() );
   }
 
   @Test
@@ -380,9 +402,10 @@ public class ConnectionServiceImplTest {
     assertTrue( connectionServiceImpl.testConnection( connection ) );
     verify( sqlConnection ).close();
     if ( DatabaseAccessType.JNDI == accessType ) {
-      verify( connection ).getDatabaseName();
+      // Default is times(1), will get called 2x due to testConnection() change
+      verify( connection, atLeastOnce() ).getDatabaseName();
     } else {
-      verify( connection ).getName();
+      verify( connection, atLeastOnce() ).getName();
     }
   }
 


### PR DESCRIPTION
@pentaho/rogueone Please review

Needed to make this change because other code areas were referencing the ConnectionServiceImpl instead of ConnectionService and querying for data connections with unsanitized parameters.