### PR TITLE
[BACKLOG-16359] - Connection Name should be quoted in case it contain…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogController.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogController.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.ui.importing;
@@ -498,7 +498,7 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
     // If user selects manual data source, pass in whatever parameters they specify even if it is empty.
     String parameters = importDialogModel.getParameters();
     if ( availableRadio.isSelected() ) {
-      parameters = "Datasource=" + connectionList.getValue();
+      parameters = datasourceParam( connectionList.getValue() );
     }
     // Parameters would contain either the data source from connectionList drop-down
     // or the parameters manually entered (even if list is empty)
@@ -506,6 +506,10 @@ public class AnalysisImportDialogController extends AbstractXulDialogController<
     parameters += ";overwrite=" + String.valueOf( isEditMode ? isEditMode : overwrite );
     Hidden queryParameters = new Hidden( "parameters", parameters );
     mainFormPanel.add( queryParameters );
+  }
+
+  protected String datasourceParam( String datasourceName ) {
+    return "Datasource=\"" + datasourceName + "\"";
   }
 
   // TODO - this method should be removed after it is removed by MetadataImportDialogController

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogControllerTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogControllerTest.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.apache.commons.lang.reflect.FieldUtils;
 
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 
@@ -30,6 +30,12 @@ import static org.junit.Assert.assertEquals;
  * @author Vadim_Polynkov.
  */
 public class AnalysisImportDialogControllerTest {
+
+  @Test
+  public void testDatasourceParamGetsQuoted() throws Exception {
+    AnalysisImportDialogController controller = new AnalysisImportDialogController();
+    assertEquals( "Datasource=\"semi;name\"", controller.datasourceParam( "semi;name" ) );
+  }
 
   @Test
   public void testHandleParam() throws Exception {


### PR DESCRIPTION
…s semi-colons which are used for separating paramters