### PR TITLE
BACKLOG-17562: Upgrade data-access jackrabbit version to 2.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
     <jaxws-spring.version>1.8</jaxws-spring.version>
     <ehcache-core.version>2.5.1</ehcache-core.version>
-    <jackrabbit-core.version>2.10.0</jackrabbit-core.version>
+    <jackrabbit-core.version>2.14.2</jackrabbit-core.version>
     <pentaho-xul.version>8.0-SNAPSHOT</pentaho-xul.version>
     <lucene-core.version>3.6.0</lucene-core.version>
     <dependency.org.springframework.spring-webmvc.version>4.3.2.RELEASE</dependency.org.springframework.spring-webmvc.version>


### PR DESCRIPTION
Upgrading jackrabbit version to 2.14.2
Refer to BACKLOG-17562 and PPP-3714 for details.
Related PRs being opened to upgrade other projects that depend on jackrabbit.
@pentaho/rogueone @pentaho/rebelalliance

pentaho-platform: https://github.com/pentaho/pentaho-platform/pull/3708
pentaho-kettle: https://github.com/pentaho/pentaho-kettle/pull/4174
pdi-ee-plugin: https://github.com/pentaho/pdi-ee-plugin/pull/340