### PR TITLE
[SP-3708][BISERVER-10582]-Database Connection Options List gets cut off when you have more than 5 parameters

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/public/datasourceEditorDialog.css
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/public/datasourceEditorDialog.css
@@ -380,3 +380,13 @@ aggregation-dialog-checkbox-label {
 #options-parameter-tree .gwt-ScrollTable .dataWrapper {
   height: 100% !important;
 }
+
+@-moz-document url-prefix() {
+  #puc_options-parameter-tree .gwt-ScrollTable {
+    height: 330px !important;
+    overflow: auto !important;
+  }
+  #puc_options-parameter-tree .gwt-ScrollTable .dataWrapper {
+    height: 100% !important;
+  }
+}


### PR DESCRIPTION
 - fixed for firefox