### PR TITLE
Revert "[BISERVER-13338] - Data source domain object mutation while re-parsing"

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardService.java
@@ -219,7 +219,7 @@ public class DataSourceWizardService extends DatasourceService {
     XmiParser xmiParser = createXmiParser();
     Domain domain = null;
     try {
-      domain = xmiParser.parseXmi( metadataFile, true );
+      domain = xmiParser.parseXmi( metadataFile );
     } catch ( Exception e ) {
       throw new DswPublishValidationException( DswPublishValidationException.Type.INVALID_XMI, e.getMessage() );
     }

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/ui/importing/MetadataImportDialogController.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/ui/importing/MetadataImportDialogController.java
@@ -313,8 +313,7 @@ public class MetadataImportDialogController extends AbstractXulDialogController<
             }
           } );
       } else {
-        onImportError( "[server data error]" + "\nwrong code: " + response.getStatusCode()
-                + "\nresponse text: " + response.getText() );
+        onImportError( "[server data error] , wrong code: " + response.getStatusCode() );
       }
     }
 


### PR DESCRIPTION
Reverts pentaho/data-access#943 due to regression found. See BACKLOG-19112.