### PR TITLE
[BISERVER-13755]-l10n - overlapping text on the Data Source Wizard dialogue

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/public/datasourceEditorDialog.css
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/public/datasourceEditorDialog.css
@@ -169,6 +169,12 @@ aggregation-dialog-checkbox-label {
   padding-bottom: 10px;
 }
 
+#step_grid td>div.xul-label {
+    word-wrap: break-word !important;
+    white-space: normal !important;
+    padding-right: 10px !important;
+}
+
 .roundedbutton-label {
   white-space: nowrap;
 }


### PR DESCRIPTION
 -fixed