### PR TITLE
Revert "[ANALYZER-3559]-When filtering the date field (format YYYY-MM-DD HH:MM:SS.0) it shows "The report has no data""

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvUtils.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvUtils.java
@@ -466,8 +466,6 @@ public class CsvUtils extends PentahoBase {
         return DataType.DATE;
       case 4:
         return DataType.BOOLEAN;
-      case 9:
-        return DataType.TIMESTAMP;
       default:
         return DataType.STRING;
     }

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvUtilsTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvUtilsTest.java
@@ -324,11 +324,6 @@ public class CsvUtilsTest {
     testAssumeColumnDetails_Dates( asList( "2015/11/10 11:57:33" ), "yyyy/MM/dd HH:mm:ss" );
   }
 
-  @Test
-  public void testTimestampFormat() {
-    testAssumeColumnDetails_Dates( asList( "2015-11-10 11:57:33.0" ), "yyyy-MM-dd hh:mm:ss.0" );
-  }
-
   private void testAssumeColumnDetails_Dates( List<String> samples, String dateFormat ) {
     utils.assumeColumnDetails( columnInfo, samples );
     assertEquals( DataType.DATE, columnInfo.getDataType() );


### PR DESCRIPTION
Reverts pentaho/data-access#955