### PR TITLE
[PPP-4022] Japanese character in the data source name causes data inconsistency and an errors to occur

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/models/DatasourceModel.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/models/DatasourceModel.java
@@ -12,11 +12,12 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara.  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.models;
 
+import com.google.gwt.regexp.shared.RegExp;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.metadata.model.Category;
 import org.pentaho.metadata.model.Domain;
@@ -304,8 +305,9 @@ public class DatasourceModel extends XulEventSourceAdapter
       throw new IllegalStateException(
         "DatasourceName must not be null, cannot generate a valid table name" ); //$NON-NLS-1$
     }
-    return datasourceName.trim().replace( " ", "_" )  //$NON-NLS-1$ //$NON-NLS-2$
-      .replaceAll( "[^A-Za-z0-9_-]", "" )          //$NON-NLS-1$ //$NON-NLS-2$
+    // this regexp is not working on the Java side, but it works on the JS side
+    // see http://www.gwtproject.org/javadoc/latest/com/google/gwt/regexp/shared/RegExp.html
+    return RegExp.compile( "[^\\p{L}\\p{N}_-]", "gu" ).replace( datasourceName.trim().replace( " ", "_" ), "" )
       .toLowerCase();       // change to lower to handle case sensitivity of quoted table names in postgresql (which
       // defaults all tables to lowercase)... BISERVER-5231
   }

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/models/DatasourceModelTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/models/DatasourceModelTest.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara.  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.wizard.models;
@@ -52,125 +52,116 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
-@SuppressWarnings("nls")
+@SuppressWarnings( "nls" )
 public class DatasourceModelTest {
 
   @Test
   public void test() {
     DatasourceModel datasourceModel = new DatasourceModel();
     //    Assert.assertNull(datasourceModel.getCsvModel().getSelectedFile());
-    Assert.assertNull(datasourceModel.getQuery());
-    assertNull(datasourceModel.getModelInfo().getFileInfo().getTmpFilename());
-    Assert.assertEquals(DatasourceType.NONE, datasourceModel.getDatasourceType());
-    datasourceModel.setDatasourceType(DatasourceType.SQL);
-    Assert.assertEquals(false, datasourceModel.isValidated());
-    datasourceModel.setGuiStateModel(contructRelationalModel(datasourceModel.getGuiStateModel()));
-    Assert.assertEquals(true, datasourceModel.isValidated());
-    datasourceModel.setDatasourceType(DatasourceType.CSV);
-    Assert.assertEquals(false, datasourceModel.isValidated());
+    Assert.assertNull( datasourceModel.getQuery() );
+    assertNull( datasourceModel.getModelInfo().getFileInfo().getTmpFilename() );
+    Assert.assertEquals( DatasourceType.NONE, datasourceModel.getDatasourceType() );
+    datasourceModel.setDatasourceType( DatasourceType.SQL );
+    Assert.assertEquals( false, datasourceModel.isValidated() );
+    datasourceModel.setGuiStateModel( contructRelationalModel( datasourceModel.getGuiStateModel() ) );
+    Assert.assertEquals( true, datasourceModel.isValidated() );
+    datasourceModel.setDatasourceType( DatasourceType.CSV );
+    Assert.assertEquals( false, datasourceModel.isValidated() );
     //    datasourceModel.setCsvModel(constructCsvModel(datasourceModel.getCsvModel()));    
-    Assert.assertEquals(false, datasourceModel.isValidated());
-    datasourceModel.setModelInfo( TestUtil.createModel());
-    assertEquals(false, datasourceModel.isValidated());
+    Assert.assertEquals( false, datasourceModel.isValidated() );
+    datasourceModel.setModelInfo( TestUtil.createModel() );
+    assertEquals( false, datasourceModel.isValidated() );
   }
 
-  private GuiStateModel contructRelationalModel(GuiStateModel guiStateModel) {
+  private GuiStateModel contructRelationalModel( GuiStateModel guiStateModel ) {
     IDatabaseConnection connection = new DatabaseConnection();
-    connection.setAccessType(DatabaseAccessType.NATIVE);
+    connection.setAccessType( DatabaseAccessType.NATIVE );
     //    connection.setDriverClass("org.hsqldb.jdbcDriver");
-    connection.setName("SampleData");
-    connection.setPassword("password");
+    connection.setName( "SampleData" );
+    connection.setPassword( "password" );
     //    connection.setUrl("jdbc:hsqldb:file:target/test-classes/solution1/system/data/sampledata");
-    connection.setUsername("pentaho_user");
+    connection.setUsername( "pentaho_user" );
     List<IDatabaseConnection> connectionList = new ArrayList<IDatabaseConnection>();
-    connectionList.add(connection);
-    guiStateModel.setConnections(connectionList);
-    guiStateModel.setPreviewLimit("10");
+    connectionList.add( connection );
+    guiStateModel.setConnections( connectionList );
+    guiStateModel.setPreviewLimit( "10" );
     guiStateModel.validateRelational();
     LogicalColumn logColumn = new LogicalColumn();
-    logColumn.setDataType(DataType.NUMERIC);
+    logColumn.setDataType( DataType.NUMERIC );
     List<AggregationType> aggTypeList = new ArrayList<AggregationType>();
-    aggTypeList.add(AggregationType.AVERAGE);
-    logColumn.setAggregationList(aggTypeList);
-    logColumn.setName(new LocalizedString("En", "Column1"));
+    aggTypeList.add( AggregationType.AVERAGE );
+    logColumn.setAggregationList( aggTypeList );
+    logColumn.setName( new LocalizedString( "En", "Column1" ) );
     BusinessData businessData = new BusinessData();
     List<List<String>> dataSample = new ArrayList<List<String>>();
     List<String> rowData = new ArrayList<String>();
-    rowData.add("Data1");
-    rowData.add("Data2");
-    rowData.add("Data3");
-    rowData.add("Data4");
-    dataSample.add(rowData);
+    rowData.add( "Data1" );
+    rowData.add( "Data2" );
+    rowData.add( "Data3" );
+    rowData.add( "Data4" );
+    dataSample.add( rowData );
 
     String locale = LocaleHelper.getLocale().toString();
 
     SqlPhysicalModel model = new SqlPhysicalModel();
     SqlDataSource dataSource = new SqlDataSource();
-    dataSource.setDatabaseName("SampleData");
-    model.setDatasource(dataSource);
-    SqlPhysicalTable table = new SqlPhysicalTable(model);
-    model.getPhysicalTables().add(table);
-    table.setTargetTableType(TargetTableType.INLINE_SQL);
-    table.setTargetTable("select * from customers");
+    dataSource.setDatabaseName( "SampleData" );
+    model.setDatasource( dataSource );
+    SqlPhysicalTable table = new SqlPhysicalTable( model );
+    model.getPhysicalTables().add( table );
+    table.setTargetTableType( TargetTableType.INLINE_SQL );
+    table.setTargetTable( "select * from customers" );
 
-    SqlPhysicalColumn column = new SqlPhysicalColumn(table);
-    column.setTargetColumn("customername");
-    column.setName(new LocalizedString(locale, "Customer Name"));
-    column.setDescription(new LocalizedString(locale, "Customer Name Desc"));
-    column.setDataType(DataType.STRING);
+    SqlPhysicalColumn column = new SqlPhysicalColumn( table );
+    column.setTargetColumn( "customername" );
+    column.setName( new LocalizedString( locale, "Customer Name" ) );
+    column.setDescription( new LocalizedString( locale, "Customer Name Desc" ) );
+    column.setDataType( DataType.STRING );
 
-    table.getPhysicalColumns().add(column);
+    table.getPhysicalColumns().add( column );
 
     LogicalModel logicalModel = new LogicalModel();
-    model.setId("MODEL");
-    model.setName(new LocalizedString(locale, "My Model"));
-    model.setDescription(new LocalizedString(locale, "A Description of the Model"));
+    model.setId( "MODEL" );
+    model.setName( new LocalizedString( locale, "My Model" ) );
+    model.setDescription( new LocalizedString( locale, "A Description of the Model" ) );
 
     LogicalTable logicalTable = new LogicalTable();
-    logicalTable.setPhysicalTable(table);
+    logicalTable.setPhysicalTable( table );
 
-    logicalModel.getLogicalTables().add(logicalTable);
+    logicalModel.getLogicalTables().add( logicalTable );
 
     LogicalColumn logicalColumn = new LogicalColumn();
-    logicalColumn.setId("LC_CUSTOMERNAME");
-    logicalColumn.setPhysicalColumn(column);
+    logicalColumn.setId( "LC_CUSTOMERNAME" );
+    logicalColumn.setPhysicalColumn( column );
 
-    logicalTable.addLogicalColumn(logicalColumn);
+    logicalTable.addLogicalColumn( logicalColumn );
 
     Category mainCategory = new Category();
-    mainCategory.setId("CATEGORY");
-    mainCategory.setName(new LocalizedString(locale, "Category"));
-    mainCategory.addLogicalColumn(logicalColumn);
+    mainCategory.setId( "CATEGORY" );
+    mainCategory.setName( new LocalizedString( locale, "Category" ) );
+    mainCategory.addLogicalColumn( logicalColumn );
 
-    logicalModel.getCategories().add(mainCategory);
+    logicalModel.getCategories().add( mainCategory );
 
     Domain domain = new Domain();
-    domain.addPhysicalModel(model);
-    domain.addLogicalModel(logicalModel);
+    domain.addPhysicalModel( model );
+    domain.addLogicalModel( logicalModel );
     List<LocaleType> localeTypeList = new ArrayList<LocaleType>();
-    localeTypeList.add(new LocaleType("Code", "Locale Description"));
-    domain.setLocales(localeTypeList);
-    businessData.setData(dataSample);
-    businessData.setDomain(domain);
-    guiStateModel.setLocaleCode("en");
-    guiStateModel.setLogicalModels(domain.getLogicalModels());
+    localeTypeList.add( new LocaleType( "Code", "Locale Description" ) );
+    domain.setLocales( localeTypeList );
+    businessData.setData( dataSample );
+    businessData.setDomain( domain );
+    guiStateModel.setLocaleCode( "en" );
+    guiStateModel.setLogicalModels( domain.getLogicalModels() );
     guiStateModel.validateRelational();
     return guiStateModel;
   }
 
-  @Test
-  public void testGenerateTablename() throws Exception {
-    DatasourceModel model = new DatasourceModel();
-
-    model.setDatasourceName("ABcdef$GhijkLmNopqRSTuvwxy&z 1234567890");
-    assertEquals("abcdefghijklmnopqrstuvwxyz_1234567890", model.generateTableName());
-
-    model.setDatasourceName("!@#$%^&*()=+?><';:.|{}~`");
-    assertEquals("", model.generateTableName());
-  }
-
-  @Test(expected = IllegalStateException.class)
+  @Test( expected = IllegalStateException.class )
   public void testGenerateTablename_nullDatasourceName() throws Exception {
     DatasourceModel model = new DatasourceModel();
     model.generateTableName();
@@ -179,60 +170,63 @@ public class DatasourceModelTest {
   @Test
   public void testRelationalDatasourceDTO() throws Exception {
 
-    DatasourceModel datasourceModel = new DatasourceModel();
-    datasourceModel.setDatasourceName("testDatasource");
-    datasourceModel.setDatasourceType(DatasourceType.SQL);
-    datasourceModel.setGuiStateModel(contructRelationalModel(datasourceModel.getGuiStateModel()));
-    datasourceModel.setSelectedRelationalConnection(datasourceModel.getGuiStateModel().getConnections().get(0));
+    DatasourceModel datasourceModel = spy( new DatasourceModel() );
+    doReturn( "testdatasource" ).when( datasourceModel ).generateTableName();
+    datasourceModel.setDatasourceName( "testDatasource" );
+    datasourceModel.setDatasourceType( DatasourceType.SQL );
+    datasourceModel.setGuiStateModel( contructRelationalModel( datasourceModel.getGuiStateModel() ) );
+    datasourceModel.setSelectedRelationalConnection( datasourceModel.getGuiStateModel().getConnections().get( 0 ) );
 
-    DatasourceDTO dto = DatasourceDTO.generateDTO(datasourceModel);
-    assertNotNull(dto);
-    assertEquals(datasourceModel.getDatasourceName(), dto.getDatasourceName());
-    assertEquals(datasourceModel.getDatasourceType(), dto.getDatasourceType());
-    assertEquals(datasourceModel.getQuery(), dto.getQuery());
-    assertEquals(datasourceModel.getSelectedRelationalConnection().getName(), dto.getConnectionName());
+    DatasourceDTO dto = DatasourceDTO.generateDTO( datasourceModel );
+    assertNotNull( dto );
+    assertEquals( datasourceModel.getDatasourceName(), dto.getDatasourceName() );
+    assertEquals( datasourceModel.getDatasourceType(), dto.getDatasourceType() );
+    assertEquals( datasourceModel.getQuery(), dto.getQuery() );
+    assertEquals( datasourceModel.getSelectedRelationalConnection().getName(), dto.getConnectionName() );
 
-    DatasourceModel datasourceModel2 = new DatasourceModel();
+    DatasourceModel datasourceModel2 = spy( new DatasourceModel() );
+    doReturn( "testdatasource" ).when( datasourceModel2 ).generateTableName();
 
     IDatabaseConnection connection = new DatabaseConnection();
-    connection.setAccessType(DatabaseAccessType.NATIVE);
+    connection.setAccessType( DatabaseAccessType.NATIVE );
     //    connection.setDriverClass("org.hsqldb.jdbcDriver");
-    connection.setName("SampleData");
-    connection.setPassword("password");
+    connection.setName( "SampleData" );
+    connection.setPassword( "password" );
     //    connection.setUrl("jdbc:hsqldb:file:target/test-classes/solution1/system/data/sampledata");
-    connection.setUsername("pentaho_user");
-    datasourceModel2.getGuiStateModel().setConnections(Collections.singletonList(connection));
+    connection.setUsername( "pentaho_user" );
+    datasourceModel2.getGuiStateModel().setConnections( Collections.singletonList( connection ) );
 
-    DatasourceDTO.populateModel(dto, datasourceModel2);
+    DatasourceDTO.populateModel( dto, datasourceModel2 );
 
-    assertEquals(datasourceModel.getDatasourceName(), datasourceModel2.getDatasourceName());
-    assertEquals(datasourceModel.getDatasourceType(), datasourceModel2.getDatasourceType());
-    assertEquals(datasourceModel.getQuery(), datasourceModel2.getQuery());
-    assertEquals(datasourceModel.getSelectedRelationalConnection().getName(), datasourceModel2
-        .getSelectedRelationalConnection().getName());
+    assertEquals( datasourceModel.getDatasourceName(), datasourceModel2.getDatasourceName() );
+    assertEquals( datasourceModel.getDatasourceType(), datasourceModel2.getDatasourceType() );
+    assertEquals( datasourceModel.getQuery(), datasourceModel2.getQuery() );
+    assertEquals( datasourceModel.getSelectedRelationalConnection().getName(), datasourceModel2
+        .getSelectedRelationalConnection().getName() );
 
   }
 
   @Test
   public void testDatasourceDTOSerialization() throws Exception {
 
-    PentahoSystem.registerObjectFactory(new TestObjectFactory());
+    PentahoSystem.registerObjectFactory( new TestObjectFactory() );
 
-    DatasourceModel datasourceModel = new DatasourceModel();
-    datasourceModel.setDatasourceName("testDatasource");
-    datasourceModel.setDatasourceType(DatasourceType.SQL);
-    datasourceModel.setGuiStateModel(contructRelationalModel(datasourceModel.getGuiStateModel()));
-    datasourceModel.setSelectedRelationalConnection(datasourceModel.getGuiStateModel().getConnections().get(0));
+    DatasourceModel datasourceModel = spy( new DatasourceModel() );
+    doReturn( "testdatasource" ).when( datasourceModel ).generateTableName();
+    datasourceModel.setDatasourceName( "testDatasource" );
+    datasourceModel.setDatasourceType( DatasourceType.SQL );
+    datasourceModel.setGuiStateModel( contructRelationalModel( datasourceModel.getGuiStateModel() ) );
+    datasourceModel.setSelectedRelationalConnection( datasourceModel.getGuiStateModel().getConnections().get( 0 ) );
 
-    DatasourceDTO dto = DatasourceDTO.generateDTO(datasourceModel);
-    assertNotNull(dto);
+    DatasourceDTO dto = DatasourceDTO.generateDTO( datasourceModel );
+    assertNotNull( dto );
     InMemoryDSWDatasourceServiceImpl service = new InMemoryDSWDatasourceServiceImpl();
-    String dtoString = service.serializeModelState(dto);
-    assertNotNull(dtoString);
-    assertTrue(dtoString.contains("testDatasource"));
+    String dtoString = service.serializeModelState( dto );
+    assertNotNull( dtoString );
+    assertTrue( dtoString.contains( "testDatasource" ) );
 
-    DatasourceDTO dto2 = service.deSerializeModelState(dtoString);
+    DatasourceDTO dto2 = service.deSerializeModelState( dtoString );
 
-    assertEquals(dto, dto2);
+    assertEquals( dto, dto2 );
   }
 }

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImplTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImplTest.java
@@ -746,7 +746,8 @@ public class DSWDatasourceServiceImplTest {
   public void testDeSerializeModelStateValidString() throws Exception {
     PentahoSystem.registerObjectFactory( new TestObjectFactory() );
 
-    DatasourceModel datasourceModel = new DatasourceModel();
+    DatasourceModel datasourceModel = spy( new DatasourceModel() );
+    doReturn( "testdatasource" ).when( datasourceModel ).generateTableName();
     datasourceModel.setDatasourceName( "testDatasource" );
     datasourceModel.setDatasourceType( DatasourceType.CSV );
 


### PR DESCRIPTION
- RegExp was modified in order to accept all alphanumeric unicode characters. Since GWT's RegExp is not supporting unicode flag on Java side (and pattern with unicode character class) the modified method is not working on the Java side, but works as expected on the JS side. That's why generateTableName() was mocked in tests and testGenerateTablename() method was removed.
- checkstyle fixes