### PR TITLE
Revert "[PPP-3876]-Use of vulnerable component spring-security-core 4.1.9 cve-2017-4995"

### DIFF
--- a/core/src/test/resources/repository-test-override.spring-ext.xml
+++ b/core/src/test/resources/repository-test-override.spring-ext.xml
@@ -3,17 +3,16 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:sec="http://www.springframework.org/schema/security"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
-                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd">
+                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.1.xsd">
 
   <!-- Bean definitions in this file override bean definitions in repository.spring.xml. -->
-  <sec:authentication-manager>
-    <sec:authentication-provider>
-      <sec:user-service id="userDetailsService">
-        <sec:user password="password" name="joe" authorities="Authenticated, Admin"/>
-        <sec:user password="password" name="suzy" authorities="Authenticated"/>
-      </sec:user-service>
-    </sec:authentication-provider>
-  </sec:authentication-manager>
+
+  <sec:authentication-provider>
+    <sec:user-service id="userDetailsService">
+      <sec:user password="password" name="joe" authorities="Authenticated, Admin"/>
+      <sec:user password="password" name="suzy" authorities="Authenticated"/>
+    </sec:user-service>
+  </sec:authentication-provider>
 
   <sec:authentication-manager alias="authenticationManager"/>
 

--- a/core/src/test/resources/repository-test-security.spring.xml
+++ b/core/src/test/resources/repository-test-security.spring.xml
@@ -3,20 +3,20 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:sec="http://www.springframework.org/schema/security"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
-                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
+                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.1.xsd
                       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
   <!-- Bean definitions in this file override bean definitions in repository.spring.xml. -->
-  <sec:authentication-manager alias="authenticationManager">
-    <sec:authentication-provider>
-      <sec:user-service id="userDetailsService">
-        <sec:user password="password" name="joe" authorities="Authenticated, Admin"/>
-        <sec:user password="password" name="suzy" authorities="Authenticated"/>
-      </sec:user-service>
-    </sec:authentication-provider>
-  </sec:authentication-manager>
 
+  <sec:authentication-provider>
+    <sec:user-service id="userDetailsService">
+      <sec:user password="password" name="joe" authorities="Authenticated, Admin" />
+      <sec:user password="password" name="suzy" authorities="Authenticated" />
+    </sec:user-service>
+  </sec:authentication-provider>
 
+  <sec:authentication-manager alias="authenticationManager" />
+  
   <!-- 
   To enable RMI in a unit test, put jackrabbit-jcr-rmi-1.5.0.jar in dev-lib and add to Eclipse classpath.
   

--- a/core/src/test/resources/repository.spring-ext.xml
+++ b/core/src/test/resources/repository.spring-ext.xml
@@ -2,8 +2,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:util="http://www.springframework.org/schema/util"
-       xmlns:sec="http://www.springframework.org/schema/security"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd 
 						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.1.xsd
 						http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd"
        default-lazy-init="true">

--- a/core/src/test/resources/solutionACL/system/repository-test-override.spring.xml
+++ b/core/src/test/resources/solutionACL/system/repository-test-override.spring.xml
@@ -4,7 +4,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
+                      http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.1.xsd
                       http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd">
 
   <!-- Bean definitions in this file override bean definitions in repository.spring.xml. -->


### PR DESCRIPTION
Reverts pentaho/data-access#959

- Reverted as per the decisions made ( and captured ) at https://jira.pentaho.com/browse/PPP-3876?focusedCommentId=336291#comment-336291

Part of a bulk-revert, comprised of the PR list captured at https://jira.pentaho.com/browse/PPP-3876?focusedCommentId=321593#comment-321593:

@pentaho/rogueone @pamval @dkincade @mbatchelor @mdamour1976 @graimundo 

 ~Please **hold off merging** until we have triggered a "Revert PR" for all PRs outlined in https://jira.pentaho.com/browse/PPP-3876?focusedCommentId=321593#comment-321593~ ✅ 


## Issued Revert PRs

* https://github.com/pentaho/pentaho-engineering-samples/pull/61
* https://github.com/pentaho/marketplace/pull/147
* https://github.com/pentaho/data-access/pull/999
* https://github.com/pentaho/pentaho-kettle/pull/5176
* https://github.com/pentaho/pentaho-platform-ee/pull/1256
* https://github.com/pentaho/pentaho-karaf-assembly/pull/435
* https://github.com/pentaho/pdi-ee-plugin/pull/354
* https://github.com/pentaho/pentaho-platform/pull/4097
* https://github.com/pentaho/pentaho-osgi-bundles/pull/263
* https://github.com/pentaho/pentaho-reporting/pull/1123
* https://github.com/pentaho/pentaho-reportdesigner-ee/pull/104
* https://github.com/pentaho/pentaho-metadata-editor/pull/121
* https://github.com/pentaho/pentaho-metadata-editor-ee/pull/32


**Notes**

* https://github.com/pentaho/pentaho-ee/pull/860 not needing revert; a subsequent refactor of this project's assembly process has removed the impacted file
* https://github.com/pentaho/pdi-agile-bi-plugin/pull/87 not needing revert: as this project was retired / deprecated on Feb.14 , therefore not holding any files any longer
** https://github.com/pentaho/pdi-agile-bi-plugin/commit/67662b0a6c5f4161a290467e6f6d5f0d0f805908  