### PR TITLE
[SP-4576] Backport of BISERVER-13521 - Import Metadata dialog buttons…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/ui/importing/MetadataImportDialogController.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/ui/importing/MetadataImportDialogController.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2018 Hitachi Vantara Corporation..  All rights reserved.
 */
 
 package org.pentaho.platform.dataaccess.datasource.ui.importing;
@@ -425,6 +425,7 @@ public class MetadataImportDialogController extends AbstractXulDialogController<
     fileLabel.setValue( resBundle.getString( "importDialog.XMI_FILE", "XMI File" ) + ":" );
     super.showDialog();
     createWorkingForm();
+    getDialog().center();
   }
 
   public void reShowDialog() {


### PR DESCRIPTION
… not showing when it opens (7.1 Suite)
@pentaho-lmartins @ricardosilva88

This pull request is part 2 of two pull requests and must be merged last.
The other pull request is:
https://github.com/pentaho/pentaho-commons-xul/pull/151