### PR TITLE
[PPP-4182] Use of vulnerable component dom4j-1.6.1.jar  CVE-2018-1000632

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DSWDatasourceServiceImpl.java
@@ -89,8 +89,6 @@ import org.pentaho.platform.util.web.SimpleUrlFactory;
 
 import com.thoughtworks.xstream.XStream;
 
-import static java.util.stream.Collectors.toList;
-
 public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
 
   private static final Log logger = LogFactory.getLog( DSWDatasourceServiceImpl.class );
@@ -582,7 +580,11 @@ public class DSWDatasourceServiceImpl implements IDSWDatasourceService {
       component.setAction( PMDUIComponent.ACTION_LIST_MODELS );
       Document document = component.getXmlContent();
 
-      return ( (List<Node>) document.selectNodes( "//model_name" ) ).stream().map( x -> x.getText() ).collect( toList() );
+      ArrayList<String> datasourceNames = new ArrayList<>();
+      for ( Node node : document.selectNodes( "//model_name" ) ) {
+        datasourceNames.add( node.getText() );
+      }
+      return datasourceNames;
     }
   }
 


### PR DESCRIPTION
Fixes regression in `DSWDatasourceServiceImpl` due to:

> Axis2 does not work when using Java 8 features in the implementation class, because axis somehow has a problem analyzing that bytecode.
> 
> As a workaround, removing Java 8 features (e.g. streams) in the skeleton implementation solved it in my case. You can use those features anywhere except in the web service implementation class (when using Axis2).

Reverts some work in #1019 and rewrites the code so no streams are used.

@pedrofvteixeira @ricardosilva88 @graimundo 
