### PR TITLE
[BISERVER-14025] Missing xmi in API Documentation of deleting metadat…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/MetadataService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/MetadataService.java
@@ -96,6 +96,8 @@ public class MetadataService extends DatasourceService {
     } catch ( ConnectionServiceException e ) {
       throw new PentahoAccessControlException();
     }
+
+    metadataId = metadataId.endsWith( ".xmi" ) ? metadataId : metadataId + ".xmi";
     metadataDomainRepository.removeDomain( metadataId );
   }
 


### PR DESCRIPTION
…a source

@pentaho/tatooine 
@e-cuellar @mdamour1976 

The domainID used to remove the metadata source ends with the extension (.xmi). Thus, I added the extension when missing. 

Regarding the 200 OK response, due to the asynchronous nature of the api method, when the call ends we don't know yet if the action will success or not. Therefore, unless you're not authorized to delete the Metadata datasource (401 response), it always returns 200 OK. Even if you try to delete a metadata with a domain that doesn't exist it returns 200 OK. But I believe that this is the right behaviour since we are talking about an asynchronous method.