### PR TITLE
[SP-4828] - Backport of PPP-4266 - Use of Vulnerable Component: commons-fileupload-1.3.2.jar (CVE-2016-1000031 | sonatype-2014-01730) (7.1 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
     <dependency.org.springframework.spring-test.version>4.3.2.RELEASE</dependency.org.springframework.spring-test.version>
     <dependency.org.codehaus.jettison.jettison.version>1.2</dependency.org.codehaus.jettison.jettison.version>
     <dependency.com.google.gwt.gwt-codeserver.version>2.5.1</dependency.com.google.gwt.gwt-codeserver.version>
-    <commons-fileupload.version>1.3.2</commons-fileupload.version>
     <dependency.com.allen_sauer.gwt-dnd.version>3.1.2</dependency.com.allen_sauer.gwt-dnd.version>
     <fontbox.version>0.1.0</fontbox.version>
     <xpp3_min.version>1.1.4c</xpp3_min.version>
@@ -337,17 +336,6 @@
         <groupId>commons-digester</groupId>
         <artifactId>commons-digester</artifactId>
         <version>${commons-digester.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-fileupload</groupId>
-        <artifactId>commons-fileupload</artifactId>
-        <version>${commons-fileupload.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>


### PR DESCRIPTION
This is a series of PRs, please see: https://github.com/pentaho/maven-parent-poms/pull/85