### PR TITLE
[SP-4827] - Backport of PPP-4266 - Use of Vulnerable Component: commons-fileupload-1.3.2.jar (CVE-2016-1000031 | sonatype-2014-01730) (7.1 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,17 +369,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>commons-fileupload</groupId>
-        <artifactId>commons-fileupload</artifactId>
-        <version>${commons-fileupload.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>


### PR DESCRIPTION
This is a series of PRs, please see: https://github.com/pentaho/maven-parent-poms/pull/86