### PR TITLE
[SP-4850] Backport of BISERVER-14025 - Missing xmi in API Documentati…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/MetadataService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/MetadataService.java
@@ -96,7 +96,7 @@ public class MetadataService extends DatasourceService {
     } catch ( ConnectionServiceException e ) {
       throw new PentahoAccessControlException();
     }
-    metadataId = metadataId.endsWith( ".xmi" ) ? metadataId : metadataId + ".xmi";
+    metadataDomainRepository.removeDomain( forceXmiSuffix( metadataId ) );
   }
 
   public List<String> getMetadataDatasourceIds() {


### PR DESCRIPTION
…on of deleting metadata source (7.1 Suite)

Defect detected on 7.1 backport.
@pentaho-lmartins 