### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -356,6 +356,12 @@
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.aspectj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
     <mondrian.version>8.3.0.0-SNAPSHOT</mondrian.version>
     <log4j.version>1.2.17</log4j.version>
     <dependency.pentaho.simple-jndi.version>1.0.2</dependency.pentaho.simple-jndi.version>
-    <xml-apis.version>1.3.04</xml-apis.version>
     <pentaho-metadata.version>8.3.0.0-SNAPSHOT</pentaho-metadata.version>
     <org.eclipse.swt.gtk.linux.x86_64.version>4.6</org.eclipse.swt.gtk.linux.x86_64.version>
     <derby.version>10.2.1.6</derby.version>
@@ -127,7 +126,6 @@
     <concurrent.version>1.3.4</concurrent.version>
     <dependency.reporting-library.group>pentaho-library</dependency.reporting-library.group>
     <pentaho-connections.version>8.3.0.0-SNAPSHOT</pentaho-connections.version>
-    <xercesImpl.version>2.9.1</xercesImpl.version>
     <junit.version>4.12</junit.version>
   </properties>
   <dependencyManagement>
@@ -753,18 +751,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>${xercesImpl.version}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>${mockito.version}</version>
@@ -1274,7 +1260,6 @@
       <dependency>
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis</artifactId>
-        <version>${xml-apis.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 