### PR TITLE
[BACKLOG-28357] Updates derby version, retrieves from parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
     <xml-apis.version>1.3.04</xml-apis.version>
     <pentaho-metadata.version>8.3.0.0-SNAPSHOT</pentaho-metadata.version>
     <org.eclipse.swt.gtk.linux.x86_64.version>4.6</org.eclipse.swt.gtk.linux.x86_64.version>
-    <derby.version>10.2.1.6</derby.version>
     <dependency.com.google.gwt.gwt-user.version>2.5.1</dependency.com.google.gwt.gwt-user.version>
     <enunciate-core-annotations.version>1.27</enunciate-core-annotations.version>
     <grizzly-framework.version>1.9.45</grizzly-framework.version>


### PR DESCRIPTION
Removal of the Apache Derby version in favor of retrieving a unified version from the Maven parent POM. At the time of this PR, the latest version of Apache Derby is 10.15.1.3. Other PRs related to this one are listed below:

https://github.com/pentaho/maven-parent-poms/pull/122
https://github.com/pentaho/pentaho-platform/pull/4399
https://github.com/pentaho/pentaho-kettle/pull/6402
https://github.com/pentaho/pentaho-reporting/pull/1256
https://github.com/pentaho/data-access/pull/1053