### PR TITLE
[BISERVER-14142] Import Metadata-Pen Server fails to import localization

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataTempFilesListBundleDto.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataTempFilesListBundleDto.java
@@ -12,61 +12,79 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Created by dstepanov on 12/06/17.
  */
-
 @XmlRootElement
 public class MetadataTempFilesListBundleDto implements Serializable {
   private static final long serialVersionUID = 4526978475946122862L;
-  String originalFileName;
-  String tempFileName;
-  String id;
 
-  public MetadataTempFilesListBundleDto() {
-  }
+  private static final String ORIG_NAME = "origName";
+  private static final String TEMP_NAME = "tempName";
+  private final String originalFileName;
+  private final String tempFileName;
 
   public MetadataTempFilesListBundleDto( String localFileName, String fileName ) {
-    this.originalFileName = fileName;
-    this.tempFileName = localFileName;
+    this.originalFileName = localFileName;
+    this.tempFileName = fileName;
   }
 
-  @SuppressWarnings( "nls" )
   @Override
   public String toString() {
-    return "MetadataTempFilesListBundleDto [id=" + id + ", tempFileName=" + tempFileName + ", originalFileName="
-      + originalFileName + "]";
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId( String id ) {
-    this.id = id;
+    return toJson().toString();
   }
 
   public String getOriginalFileName() {
     return originalFileName;
   }
 
-  public void setOriginalFileName( String originalFileName ) {
-    this.originalFileName = originalFileName;
-  }
-
   public String getTempFileName() {
     return tempFileName;
   }
 
-  public void setTempFileName( String tempFileName ) {
-    this.tempFileName = tempFileName;
+  JSONObject toJson() {
+    Map<String, String> attrs = new HashMap<>();
+    attrs.put( ORIG_NAME, originalFileName );
+    attrs.put( TEMP_NAME, tempFileName );
+    return new JSONObject( attrs );
+  }
+
+  static MetadataTempFilesListBundleDto fromJson( JSONObject json ) {
+    try {
+      return new MetadataTempFilesListBundleDto(
+        json.getString( ORIG_NAME ), json.getString( TEMP_NAME ) );
+    } catch ( JSONException e ) {
+      throw new IllegalStateException( e );
+    }
+  }
+
+  @Override public boolean equals( Object o ) {
+    if ( this == o ) {
+      return true;
+    }
+    if ( o == null || getClass() != o.getClass() ) {
+      return false;
+    }
+    MetadataTempFilesListBundleDto that = (MetadataTempFilesListBundleDto) o;
+    return Objects.equals( originalFileName, that.originalFileName )
+      && Objects.equals( tempFileName, that.tempFileName );
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash( originalFileName, tempFileName );
   }
 }


### PR DESCRIPTION
Localization files are imported and saved with a unique ".tmp" name.
The logic to determine what locale a message file is is based on the
file name, and the .tmp name was screwing up the locale determination.

The existing code attempted to store both the "originalFileName"
and the tempFileName, but was setting the values incorrectly.
This change sets the original and tempname correctly, and
stores both in the JSON constructed list of locale bundles.

https://jira.pentaho.com/browse/BISERVER-14142