### PR TITLE
[SP-5088] [BISERVER-14142] Import Metadata-Pen Server fails to import…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataTempFilesListBundleDto.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataTempFilesListBundleDto.java
@@ -12,61 +12,79 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Created by dstepanov on 12/06/17.
  */
-
 @XmlRootElement
 public class MetadataTempFilesListBundleDto implements Serializable {
   private static final long serialVersionUID = 4526978475946122862L;
-  String originalFileName;
-  String tempFileName;
-  String id;
 
-  public MetadataTempFilesListBundleDto() {
-  }
+  private static final String ORIG_NAME = "origName";
+  private static final String TEMP_NAME = "tempName";
+  private final String originalFileName;
+  private final String tempFileName;
 
   public MetadataTempFilesListBundleDto( String localFileName, String fileName ) {
-    this.originalFileName = fileName;
-    this.tempFileName = localFileName;
+    this.originalFileName = localFileName;
+    this.tempFileName = fileName;
   }
 
-  @SuppressWarnings( "nls" )
   @Override
   public String toString() {
-    return "MetadataTempFilesListBundleDto [id=" + id + ", tempFileName=" + tempFileName + ", originalFileName="
-      + originalFileName + "]";
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId( String id ) {
-    this.id = id;
+    return toJson().toString();
   }
 
   public String getOriginalFileName() {
     return originalFileName;
   }
 
-  public void setOriginalFileName( String originalFileName ) {
-    this.originalFileName = originalFileName;
-  }
-
   public String getTempFileName() {
     return tempFileName;
   }
 
-  public void setTempFileName( String tempFileName ) {
-    this.tempFileName = tempFileName;
+  JSONObject toJson() {
+    Map<String, String> attrs = new HashMap<>();
+    attrs.put( ORIG_NAME, originalFileName );
+    attrs.put( TEMP_NAME, tempFileName );
+    return new JSONObject( attrs );
+  }
+
+  static MetadataTempFilesListBundleDto fromJson( JSONObject json ) {
+    try {
+      return new MetadataTempFilesListBundleDto(
+        json.getString( ORIG_NAME ), json.getString( TEMP_NAME ) );
+    } catch ( JSONException e ) {
+      throw new IllegalStateException( e );
+    }
+  }
+
+  @Override public boolean equals( Object o ) {
+    if ( this == o ) {
+      return true;
+    }
+    if ( o == null || getClass() != o.getClass() ) {
+      return false;
+    }
+    MetadataTempFilesListBundleDto that = (MetadataTempFilesListBundleDto) o;
+    return Objects.equals( originalFileName, that.originalFileName )
+      && Objects.equals( tempFileName, that.tempFileName );
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash( originalFileName, tempFileName );
   }
 }

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataTempFilesListDto.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataTempFilesListDto.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by Dmitriy Stepanov on 12/06/17.
@@ -33,44 +34,37 @@ import java.util.List;
 @XmlRootElement
 public class MetadataTempFilesListDto implements Serializable {
   private static final long serialVersionUID = 595741423349391476L;
+  private static final String BUNDLES_KEY = "bundles";
   String xmiFileName;
-  List<MetadataTempFilesListBundleDto> bundles = new ArrayList<MetadataTempFilesListBundleDto>( 0 );
+  private List<MetadataTempFilesListBundleDto> bundles = new ArrayList<>( 0 );
   String id;
 
   public MetadataTempFilesListDto() {
     super();
   }
 
-  public MetadataTempFilesListDto( String fileList ) {
+
+  public MetadataTempFilesListDto( String fileListJson ) {
     this();
-    JSONObject jsonResponse = null;
     try {
-      jsonResponse = new JSONObject( fileList );
-
-
+      JSONObject jsonResponse = new JSONObject( fileListJson );
       xmiFileName = jsonResponse.getString( "xmiFileName" );
-      JSONArray jsonBundles = null;
-      try {
-        jsonBundles = jsonResponse.getJSONArray( "bundles" );
-      } catch ( JSONException e ) {
-        // ignored
-      }
 
-      if ( jsonBundles != null ) {
+      if ( jsonResponse.has( BUNDLES_KEY ) ) {
+        JSONArray jsonBundles = jsonResponse.getJSONArray( BUNDLES_KEY );
         for ( int i = 0; i < jsonBundles.length(); i++ ) {
-          bundles.add( new MetadataTempFilesListBundleDto( (String) jsonBundles.get( i ), xmiFileName ) );
+          bundles.add( MetadataTempFilesListBundleDto.fromJson( (JSONObject) jsonBundles.get( i ) ) );
         }
       }
     } catch ( JSONException e ) {
-      e.printStackTrace();
+      throw new IllegalStateException( e );
     }
 
   }
 
-  @SuppressWarnings( "nls" )
   @Override
   public String toString() {
-    return "MetadataTempFilesListDto [id=" + id + ", xmiFileName=" + xmiFileName + ", bundles=" + bundles + "]";
+    return toJSONString();
   }
 
   public String toJSONString() {
@@ -79,18 +73,14 @@ public class MetadataTempFilesListDto implements Serializable {
       if ( xmiFileName != null ) {
         obj.put( "xmiFileName", xmiFileName );
       }
-
-      JSONArray list = new JSONArray();
-      for ( int i = 0; i < bundles.size(); i++ ) {
-        MetadataTempFilesListBundleDto bundleDto = bundles.get( i );
-        list.put( bundleDto.getTempFileName() );
-      }
-
-      if ( list.length() > 0 ) {
-        obj.put( "bundles", list );
+      if ( !bundles.isEmpty() ) {
+        obj.put( BUNDLES_KEY, new JSONArray(
+          bundles.stream()
+            .map( MetadataTempFilesListBundleDto::toJson )
+            .collect( Collectors.toList() ) ) );
       }
     } catch ( JSONException e ) {
-      // ignored
+      throw new IllegalStateException( e );
     }
     return obj.toString();
   }
@@ -118,4 +108,5 @@ public class MetadataTempFilesListDto implements Serializable {
   public List<MetadataTempFilesListBundleDto> getBundles() {
     return bundles;
   }
+
 }

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataTempFilesListDtoTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataTempFilesListDtoTest.java
@@ -12,53 +12,63 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.dataaccess.datasource.api.resources;
 
+import com.google.common.collect.ImmutableMap;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
+import java.util.Arrays;
+import java.util.Objects;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Dmitriy Stepanov on 15/06/17.
  */
 public class MetadataTempFilesListDtoTest {
 
-  private String list = "{\"xmiFileName\":\"admin-4424584292793114069.tmp\"}";
-  private String list2 =
-      "{\"xmiFileName\":\"filename.tmp\",\"bundles\":[\"bundle-1-name.tmp\",\"bundle-N-name.tmp\"]}";
 
-  @Test
-  public void constructorParse() {
-    try {
-      MetadataTempFilesListDto dto = new MetadataTempFilesListDto( list );
-      dto = new MetadataTempFilesListDto( list2 );
-    } catch ( Exception e ) {
-      fail();
-    }
+  @Test public void testRoundTrip() throws JSONException {
+    JSONArray bundles = new JSONArray( Arrays.asList(
+      new MetadataTempFilesListBundleDto(
+        "messages_ja.properties", "sometempname.tmp" ).toJson(),
+      new MetadataTempFilesListBundleDto(
+        "messages_en.properties", "sometempname2.tmp" ).toJson() ) );
+    JSONObject fileListJson = new JSONObject( ImmutableMap.of( "xmiFileName", "theXmiFileName",
+      "bundles", bundles ) );
+
+    MetadataTempFilesListDto fileList = new MetadataTempFilesListDto( fileListJson.toString() );
+
+    JSONObject jsonFromFilesList = new JSONObject( fileList.toJSONString() );
+    assertEquals( jsonFromFilesList.get( "xmiFileName" ), fileListJson.get( "xmiFileName" ) );
+
+    MetadataTempFilesListDto rehydrated = new MetadataTempFilesListDto( fileList.toJSONString() );
+
+    assertTrue( eq( fileList, rehydrated ) );
+    assertEquals( "messages_ja.properties", fileList.getBundles().get( 0 ).getOriginalFileName() );
+    assertEquals( "sometempname.tmp", fileList.getBundles().get( 0 ).getTempFileName() );
+
+    assertEquals( "messages_en.properties", fileList.getBundles().get( 1 ).getOriginalFileName() );
+    assertEquals( "sometempname2.tmp", fileList.getBundles().get( 1 ).getTempFileName() );
   }
 
-  @Test
-  public void testToJSONString() {
-    try {
-      MetadataTempFilesListDto dto = new MetadataTempFilesListDto( list );
-      assertEquals( "admin-4424584292793114069.tmp", dto.getXmiFileName() );
-      assertEquals( 0, dto.getBundles().size() );
-      assertEquals( list, dto.toJSONString() );
-
-      dto = new MetadataTempFilesListDto( list2 );
-      assertEquals( "filename.tmp", dto.getXmiFileName() );
-      assertEquals( 2, dto.getBundles().size() );
-      assertEquals( "filename.tmp", dto.getBundles().get(0).getOriginalFileName() );
-      assertEquals( "bundle-1-name.tmp", dto.getBundles().get(0).getTempFileName() );
-      assertEquals( "filename.tmp", dto.getBundles().get(1).getOriginalFileName() );
-      assertEquals( "bundle-N-name.tmp", dto.getBundles().get(1).getTempFileName() );
-      assertEquals( list2, dto.toJSONString() );
-    } catch ( Exception e ) {
-      fail();
-    }
+  @Test public void testBundleRoundTrip() {
+    MetadataTempFilesListBundleDto bundle = new MetadataTempFilesListBundleDto(
+      "localeName", "fileName" );
+    assertEquals( MetadataTempFilesListBundleDto.fromJson( bundle.toJson() ), bundle );
   }
+
+
+  private boolean eq( MetadataTempFilesListDto thiz, MetadataTempFilesListDto that ) {
+    return Objects.equals( thiz.xmiFileName, that.xmiFileName )
+      && Objects.equals( thiz.getBundles(), that.getBundles() );
+  }
+
 }


### PR DESCRIPTION
… localization (#1061)

Localization files are imported and saved with a unique ".tmp" name.
The logic to determine what locale a message file is is based on the
file name, and the .tmp name was screwing up the locale determination.

The existing code attempted to store both the "originalFileName"
and the tempFileName, but was setting the values incorrectly.
This change sets the original and tempname correctly, and
stores both in the JSON constructed list of locale bundles.

https://jira.pentaho.com/browse/BISERVER-14142

@smmribeiro @bantonio82 