### PR TITLE
BISERVER-14281 - Unable to export metadata data sources

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResource.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/resources/MetadataResource.java
@@ -372,6 +372,11 @@ public class MetadataResource {
 
   protected Map<String, InputStream> getDomainFilesData( String domainId ) {
     domainId = domainId.toLowerCase().endsWith( XMI_EXTENSION ) ? domainId : domainId + XMI_EXTENSION;
+
+    int a = 0;
+    int b = 1;
+    a = b;
+
     return ( (IPentahoMetadataDomainRepositoryExporter) metadataDomainRepository ).getDomainFilesData( domainId );
   }
 


### PR DESCRIPTION
[TEST] Adding test commit to force recompilation of Metadata Resource class for BISERVER-14281

@pentaho-lmartins 