### PR TITLE
[PPP-4448] Use of Vulnerable Component - XStream 1.4.10

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -379,15 +379,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>xmlpull</groupId>
-      <artifactId>xmlpull</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>xpp3</groupId>
-      <artifactId>xpp3_min</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.sun.grizzly</groupId>
       <artifactId>grizzly-framework</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,6 @@
     <dependency.com.google.gwt.gwt-codeserver.version>2.5.1</dependency.com.google.gwt.gwt-codeserver.version>
     <dependency.com.allen_sauer.gwt-dnd.version>3.1.2</dependency.com.allen_sauer.gwt-dnd.version>
     <fontbox.version>0.1.0</fontbox.version>
-    <xpp3_min.version>1.1.4c</xpp3_min.version>
-    <xmlpull.version>1.1.3.1</xmlpull.version>
     <jsr311-api.version>1.1.1</jsr311-api.version>
     <commons-gwt.version>9.0.0.0-SNAPSHOT</commons-gwt.version>
     <saxon.version>9.1.0.8</saxon.version>
@@ -84,7 +82,6 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <junit-dep.version>4.4</junit-dep.version>
     <jaxb-api.version>2.2.2</jaxb-api.version>
-    <dependency.com.thoughtworks.xstream.xstream.version>1.4.10</dependency.com.thoughtworks.xstream.xstream.version>
     <mimepull.version>1.9.3</mimepull.version>
     <dependency.com.google.gwt.gwt-incubator.version>2.1.0</dependency.com.google.gwt.gwt-incubator.version>
     <jaxb-xjc.version>2.1.2</jaxb-xjc.version>
@@ -395,39 +392,6 @@
         <groupId>pentaho-kettle</groupId>
         <artifactId>kettle-core</artifactId>
         <version>${pdi.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>xmlpull</groupId>
-        <artifactId>xmlpull</artifactId>
-        <version>${xmlpull.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>xpp3</groupId>
-        <artifactId>xpp3_min</artifactId>
-        <version>${xpp3_min.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>${dependency.com.thoughtworks.xstream.xstream.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>
@@ -1113,12 +1077,6 @@
         <groupId>org.pentaho</groupId>
         <artifactId>pentaho-metadata</artifactId>
         <version>${pentaho-metadata.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.pentaho</groupId>


### PR DESCRIPTION
This is part of a series of PRs. See https://github.com/pentaho/maven-parent-poms/pull/170 for details.

**Don't merge before the PR above.**

Reorganizing exclusions and transitive dependencies of `pentaho-metadata` and `xstream`.