### PR TITLE
[PPP-4447] Use of vulnerable component - Tika Core 1.1x

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -494,11 +494,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
     <jcr.version>2.0</jcr.version>
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
     <ehcache-core.version>2.5.1</ehcache-core.version>
-    <jackrabbit-core.version>2.14.2</jackrabbit-core.version>
     <commons-xul.version>9.0.0.0-SNAPSHOT</commons-xul.version>
     <lucene-core.version>3.6.0</lucene-core.version>
     <commons-collections.version>3.2.2</commons-collections.version>
@@ -1261,12 +1260,6 @@
             <groupId>*</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.jackrabbit</groupId>
-        <artifactId>jackrabbit-core</artifactId>
-        <version>${jackrabbit-core.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
Replaces #1074. Don't need `jackrabbit-core`, it's a transitive of `pentaho-platform-repository`.

**Do not merge before https://github.com/pentaho/maven-parent-poms/pull/178!**

@ssamora @RPAraujo