### PR TITLE
[PDI-17775] Process Files step no longer supports HTTP scheme

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -374,11 +374,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-vfs2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.sun.grizzly</groupId>
       <artifactId>grizzly-framework</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
     <dependency.com.google.gwt.gwt-incubator.version>2.1.0</dependency.com.google.gwt.gwt-incubator.version>
     <jaxb-xjc.version>2.1.2</jaxb-xjc.version>
     <pentaho-modeler.version>9.0.0.0-SNAPSHOT</pentaho-modeler.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <jersey.version>1.19.1</jersey.version>
     <guava.version>17.0</guava.version>
     <jempbox.version>0.2.0</jempbox.version>
@@ -1169,11 +1168,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-vfs2</artifactId>
-        <version>${commons-vfs2.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @ssamora 

* [PDI-17775] Cleaning up version references to old commons-vfs2, unifying under maven parent pom.  Removing unused, declared dependency reference.

This PR is a part of a series of PR to upgrade commons-vfs2 and fix VFS issues with HTTP:
- https://github.com/pentaho/apache-vfs-browser/pull/60
- https://github.com/pentaho/big-data-plugin/pull/1929
- https://github.com/webdetails/cpk/pull/85
- https://github.com/pentaho/data-access/pull/1083
- https://github.com/pentaho/maven-parent-poms/pull/185
- https://github.com/pentaho/mondrian/pull/1177
- https://github.com/pentaho/pdi-jms-plugin/pull/73
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/102
- https://github.com/pentaho/pdi-plugins-ee/pull/139
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/82
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/51
- https://github.com/pentaho/pentaho-big-data-ee/pull/426
- https://github.com/pentaho/pentaho-commons-database/pull/177
- https://github.com/pentaho/pentaho-data-mining/pull/24
- https://github.com/pentaho/pentaho-det-ee/pull/608
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/21
- https://github.com/pentaho/pentaho-karaf-assembly/pull/615
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/277
- https://github.com/pentaho/pentaho-kettle/pull/7130
- https://github.com/pentaho/pentaho-metaverse/pull/614
- https://github.com/pentaho/pentaho-osgi-bundles/pull/347
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1493
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/328
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/765
- https://github.com/pentaho/pentaho-platform/pull/4598
- https://github.com/pentaho/pentaho-reporting/pull/1305
- https://github.com/pentaho/pentaho-s3-vfs/pull/87
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/14