### PR TITLE
[PPP-4481] Use of Vulnerable Component: Components/h2-1.2.131.jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -453,11 +453,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>pentaho</groupId>
       <artifactId>metastore</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
     <icu4j.version>4_4_1_1</icu4j.version>
     <axiom-api.version>1.2.7</axiom-api.version>
     <geronimo-spec-jta.version>1.0.1B-rc4</geronimo-spec-jta.version>
-    <h2.version>1.0.78</h2.version>
     <pentaho-actionsequence-dom.version>9.2.0.0-SNAPSHOT</pentaho-actionsequence-dom.version>
     <commons-math.version>1.1</commons-math.version>
     <commons-database.version>9.2.0.0-SNAPSHOT</commons-database.version>
@@ -418,18 +417,6 @@
         <artifactId>hsqldb</artifactId>
         <version>${hsqldb.version}</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>${h2.version}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>pentaho</groupId>


### PR DESCRIPTION
Removing unused `com.h2database:h2` dependency.

See https://github.com/pentaho/maven-parent-poms/pull/245 for more details.