### PR TITLE
[BACKLOG-35287] Java 11 compatibility - fix broken unit tests, adding…

### DIFF
--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/resources/JDBCDatasourceResourceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/resources/JDBCDatasourceResourceTest.java
@@ -30,6 +30,7 @@ import org.pentaho.platform.dataaccess.datasource.api.DatasourceService;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.ConnectionServiceImpl;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -52,6 +53,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
+@PowerMockIgnore( "jdk.internal.reflect.*" )
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( { JDBCDatasourceResource.class, DatasourceService.class, LogFactory.class } )
 public class JDBCDatasourceResourceTest {

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvUtilsTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/CsvUtilsTest.java
@@ -166,6 +166,7 @@ public class CsvUtilsTest {
     }
   }
 
+  //TODO: test fails under Java 11 - see spike BACKLOG-35348
   @Test
   public void testAssumeColumnDetails_Numeric() {
     List<String> samples = asList( "100.00", "100.00", "100.08", "100.00", "100.12", "100.11" );
@@ -181,6 +182,7 @@ public class CsvUtilsTest {
     assertEquals( 4, columnInfo.getPrecision() );
   }
 
+  //TODO: test fails under Java 11 - see spike BACKLOG-35348
   @Test
   public void testAssumeColumnDetails_Currency() {
     List<String> samples = asList( "$101.04", "$100.3", "$100.3000", "$100.1", "$11100.32", "$7,100.433", "($500.00)" );


### PR DESCRIPTION
… TODOs for unit tests that only fail in Java 11 and may require logic fixes