### PR TITLE
Address BACKLOG-36864: Fix dialog scroll behaviour while zoomed

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.xul
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/public/modeler.xul
@@ -9,6 +9,7 @@
           buttons="accept,cancel"
           pen:responsive="true"
           pen:sizingmode="fillviewportwidth"
+          pen:minimumHeightCategory="content"
           pen:widthcategory="large"
           ondialogaccept="modelerDialogController.onAccept()"
           ondialogcancel='modelerDialogController.onCancel()'
@@ -729,6 +730,7 @@
           onload="colResolver.init()"
           pen:responsive="true"
           pen:sizingmode="fillviewportwidth"
+          pen:minimumHeightCategory="content"
           pen:widthcategory="extrasmall"
           buttons="accept, cancel"
           buttonalign="right"


### PR DESCRIPTION
On certain zoom levels (> 200%) / screen sizes, the dialog content wouldn't occupy all the area available in the dialog container, resulting in a big white gap below the dialog action buttons.