### PR TITLE
[BACKLOG-38287] [Database Connection] -- The parameters section for pooling tab are not visible

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/public/dataaccess-databasedialog.xul
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/public/dataaccess-databasedialog.xul
@@ -8,7 +8,7 @@
 
   <!-- Remove pooling parameters from the pooling tab -->
   <label id="pool-parameter-description-label" flex="0" height="20" width="535"/>
-  <tree id="pool-parameter-tree" removeelement="false" flex="0" height="125"/>
+  <tree id="pool-parameter-tree" removeelement="false" flex="1" height="125"/>
   <button id="restore-defaults-button" removeelement="false"/>
   <!-- End remove pooling parameters -->
 


### PR DESCRIPTION
@pentaho/wcag , Please review
This PR is part of https://github.com/pentaho/pentaho-commons-database/pull/242