### PR TITLE
[CLEANUP] Fix DataSourceWizardServiceTest.java

### DIFF
--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/DataSourceWizardServiceTest.java
@@ -17,7 +17,7 @@
 
 package org.pentaho.platform.dataaccess.datasource.api;
 
-import org.apache.tika.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Removing Tika dependency as it was a transative dependency that, now, does not exist.