### PR TITLE
[SP-6432] Backport of PPP-4947 - When exporting a JDBC connection using API the password gets assigned a null value it cannot be reused anywhere else (9.3 Suite)

### DIFF
--- a/core/src/it/resources/system/data-access/settings.xml
+++ b/core/src/it/resources/system/data-access/settings.xml
@@ -24,6 +24,14 @@
   <!-- default view acls for user or role -->
   <data-access-default-view-acls>31</data-access-default-view-acls>
 
+  <!-- The number of threads used for preloading a user's available data sources, 
+     a process which is started upon login.
+     Available data sources are displayed in the "Manage Data sources" dialog and in 
+     applications such as Analyzer and Interactive Reporting. When the preloading 
+     process is not complete, the user has to wait when accessing these.
+     The default number of threads is the number of CPU cores in the system -->
+  <data-access-datasource-load-threads>10</data-access-datasource-load-threads>
+
   <!-- settings for Agile Data Access -->
   <data-access-staging-jndi>Hibernate</data-access-staging-jndi>
 

--- a/core/src/test/resources/solutionACL/system/data-access/settings.xml
+++ b/core/src/test/resources/solutionACL/system/data-access/settings.xml
@@ -5,7 +5,12 @@
   <!-- how far ahead to set the browser's cache -->
   <max-age>2628001</max-age>
   <cache>true</cache>
-    
+
+  <!-- Nullify password on jdbc get connection endpoint -->
+  <nullify-password>true</nullify-password>
+  <!-- If nullify-password is set to false then we can enable password encryption on jdbc get connection endpoint -->
+  <encrypt-password>true</encrypt-password>
+
   <!-- roles with data access permissions -->
   <data-access-roles>Administrator</data-access-roles>
   <!-- users with data access permissions -->


### PR DESCRIPTION
(cherry picked from commits da5a6bf7c4abdaaf2f2f0aef15c9995fcef2933b and eae61074ebb9c53b91ead4fc291e25260a513d18)

Original PRs:

- [data-access#1228](https://github.com/pentaho/data-access/pull/1228): "/core/src/it/resources/system/data-access/settings.xml" did not exist on the 9.3 code line, so I added it
- [data-access#1230](https://github.com/pentaho/data-access/pull/1230)

@bcostahitachivantara @renato-s @andreramos89 