### PR TITLE
fix: Ensure SME models don't show as Analysis datasources [SME-294]

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -57,7 +57,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter;
 
 public class AnalysisService extends DatasourceService {
 
@@ -75,7 +77,7 @@ public class AnalysisService extends DatasourceService {
   private static final String ANNOTATIONS_FILE = "annotations.xml";
   private static final Log logger = LogFactory.getLog( AnalysisService.class );
   private static final String ANNOTATION_FOLDER = RepositoryFile.SEPARATOR + "etc"
-      + RepositoryFile.SEPARATOR + "mondrian" + RepositoryFile.SEPARATOR;
+    + RepositoryFile.SEPARATOR + "mondrian" + RepositoryFile.SEPARATOR;
 
   /*
    * register the handler in the PentahoSpringObjects.xml for MondrianImportHandler
@@ -119,9 +121,10 @@ public class AnalysisService extends DatasourceService {
     Set<String> ids = metadataDomainRepository.getDomainIds();
     for ( MondrianCatalog mondrianCatalog : mockMondrianCatalogList ) {
       String domainId = mondrianCatalog.getName() + METADATA_EXT;
-      if ( !ids.contains( domainId ) || !isDSWDatasource( domainId ) ) {
-        analysisIds.add( mondrianCatalog.getName() );
-      }
+      if ( (!ids.contains( domainId ) || !isDSWDatasource( domainId )) && !isSMEDatasource( domainId ) ) {
+          analysisIds.add( mondrianCatalog.getName() );
+        }
+
     }
     return analysisIds;
 
@@ -170,9 +173,9 @@ public class AnalysisService extends DatasourceService {
         IPlatformImportBundle mondrianBundle = new RepositoryFileImportBundle.Builder()
           .input( annots ).path( ANNOTATION_FOLDER + catName )
           .name( ANNOTATIONS_FILE ).charSet( "UTF-8" ).overwriteFile( true )
-          .mime( "text/xml" ) .withParam( "domain-id", catName )
+          .mime( "text/xml" ).withParam( "domain-id", catName )
           .build();
-          // do import
+        // do import
         importer.importFile( mondrianBundle );
         logger.debug( "imported mondrian annotations" );
         annots.close();
@@ -191,7 +194,7 @@ public class AnalysisService extends DatasourceService {
   }
 
   public RepositoryFileAclDto getAnalysisDatasourceAcl( String analysisId )
-      throws PentahoAccessControlException, FileNotFoundException {
+    throws PentahoAccessControlException, FileNotFoundException {
     checkAnalysisExists( analysisId );
 
     if ( aclAwareMondrianCatalogService != null ) {
@@ -202,7 +205,7 @@ public class AnalysisService extends DatasourceService {
   }
 
   public void setAnalysisDatasourceAcl( String analysisId, RepositoryFileAclDto aclDto )
-      throws PentahoAccessControlException, FileNotFoundException {
+    throws PentahoAccessControlException, FileNotFoundException {
     checkAnalysisExists( analysisId );
 
     final RepositoryFileAcl acl = aclDto == null ? null : repositoryFileAclAdapter.unmarshal( aclDto );
@@ -239,16 +242,16 @@ public class AnalysisService extends DatasourceService {
     throws PlatformImportException {
     boolean overWriteInRepository = determineOverwriteFlag( parameters, overwrite );
     IPlatformImportBundle bundle =
-        createPlatformBundle(
-          parameters, dataInputStream, catalogName, overWriteInRepository, fileName, xmlaEnabledFlag, acl );
+      createPlatformBundle(
+        parameters, dataInputStream, catalogName, overWriteInRepository, fileName, xmlaEnabledFlag, acl );
     if ( isChangeCatalogName( origCatalogName, bundle ) ) {
       IMondrianCatalogService catalogService =
-          PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
+        PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
       catalogService.removeCatalog( origCatalogName, PentahoSessionHolder.getSession() );
     }
     if ( isOverwriteAnnotations( parameters, overWriteInRepository ) ) {
       IMondrianCatalogService catalogService =
-          PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
+        PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
       MondrianCatalog catalog = catalogService.getCatalog( bundle.getName(), PentahoSessionHolder.getSession() );
       if ( catalog != null ) {
         catalogService.removeCatalog( bundle.getName(), PentahoSessionHolder.getSession() );
@@ -256,7 +259,6 @@ public class AnalysisService extends DatasourceService {
     }
     importer.importFile( bundle );
   }
-
 
   private boolean isChangeCatalogName( final String origCatalogName, final IPlatformImportBundle bundle ) {
     // MONDRIAN-1731
@@ -306,7 +308,7 @@ public class AnalysisService extends DatasourceService {
       bytes = IOUtils.toByteArray( dataInputStream );
       if ( bytes.length == 0 && catalogName != null ) {
         MondrianCatalogRepositoryHelper helper =
-            new MondrianCatalogRepositoryHelper( PentahoSystem.get( IUnifiedRepository.class ) );
+          new MondrianCatalogRepositoryHelper( PentahoSystem.get( IUnifiedRepository.class ) );
         Map<String, InputStream> fileData = helper.getModrianSchemaFiles( catalogName );
         dataInputStream = fileData.get( "schema.xml" );
         bytes = IOUtils.toByteArray( dataInputStream );
@@ -317,7 +319,7 @@ public class AnalysisService extends DatasourceService {
 
     String datasource = getValue( parameters, "Datasource" );
     String domainId =
-        this.determineDomainCatalogName( parameters, catalogName, fileName, new ByteArrayInputStream( bytes ) );
+      this.determineDomainCatalogName( parameters, catalogName, fileName, new ByteArrayInputStream( bytes ) );
     String sep = ";";
     if ( StringUtils.isEmpty( parameters ) ) {
       parameters = "Provider=mondrian";
@@ -326,7 +328,7 @@ public class AnalysisService extends DatasourceService {
     }
 
     RepositoryFileImportBundle.Builder bundleBuilder =
-        new RepositoryFileImportBundle.Builder().input( new ByteArrayInputStream( bytes ) ).charSet( UTF_8 ).hidden(
+      new RepositoryFileImportBundle.Builder().input( new ByteArrayInputStream( bytes ) ).charSet( UTF_8 ).hidden(
         false ).name( domainId ).overwriteFile( overWriteInRepository ).mime( MONDRIAN_MIME_TYPE ).withParam(
         PARAMETERS, parameters ).withParam( DOMAIN_ID, domainId );
     if ( acl != null ) {
@@ -371,7 +373,7 @@ public class AnalysisService extends DatasourceService {
 
       while ( reader.next() != XMLStreamReader.END_DOCUMENT ) {
         if ( reader.getEventType() == XMLStreamReader.START_ELEMENT
-            && reader.getLocalName().equalsIgnoreCase( "Schema" ) ) {
+          && reader.getLocalName().equalsIgnoreCase( "Schema" ) ) {
           domainId = reader.getAttributeValue( "", "name" );
           if ( domainId == null ) {
             domainId = reader.getAttributeValue( null, "name" );
@@ -388,6 +390,7 @@ public class AnalysisService extends DatasourceService {
 
     return domainId;
   }
+
   /**
    * helper method to calculate the domain id from the parameters, file name, or pass catalog
    *
@@ -453,12 +456,16 @@ public class AnalysisService extends DatasourceService {
 
   private void fileNameValidation( final String fileName ) throws PlatformImportException {
     if ( fileName == null ) {
-      throw new PlatformImportException( Messages.getString( "AnalysisService.ERROR_001_ANALYSIS_DATASOURCE_ERROR" ),
-          PlatformImportException.PUBLISH_GENERAL_ERROR );
+      throw new PlatformImportException(
+        Messages.getString( "AnalysisService.ERROR_001_ANALYSIS_DATASOURCE_ERROR" ),
+        PlatformImportException.PUBLISH_GENERAL_ERROR
+      );
     }
     if ( fileName.endsWith( METADATA_EXT ) ) {
-      throw new PlatformImportException( Messages.getString( "AnalysisService.ERROR_002_ANALYSIS_DATASOURCE_ERROR" ),
-          PlatformImportException.PUBLISH_GENERAL_ERROR );
+      throw new PlatformImportException(
+        Messages.getString( "AnalysisService.ERROR_002_ANALYSIS_DATASOURCE_ERROR" ),
+        PlatformImportException.PUBLISH_GENERAL_ERROR
+      );
     }
   }
 }

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/MetadataService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/MetadataService.java
@@ -91,7 +91,8 @@ public class MetadataService extends DatasourceService {
 
   public MetadataService() {
     if ( metadataDomainRepository instanceof IAclAwarePentahoMetadataDomainRepositoryImporter ) {
-      aclAwarePentahoMetadataDomainRepositoryImporter = (IAclAwarePentahoMetadataDomainRepositoryImporter) metadataDomainRepository;
+      aclAwarePentahoMetadataDomainRepositoryImporter =
+        (IAclAwarePentahoMetadataDomainRepositoryImporter) metadataDomainRepository;
     }
   }
 
@@ -106,14 +107,24 @@ public class MetadataService extends DatasourceService {
   }
 
   public List<String> getMetadataDatasourceIds() {
+    List<String> ids;
     if ( dataSourceAwareMetadataDomainRepository != null ) {
-      return new ArrayList<>( dataSourceAwareMetadataDomainRepository.getMetadataDomainIds() );
+      ids = new ArrayList<>( dataSourceAwareMetadataDomainRepository.getMetadataDomainIds() );
+    } else {
+      ids = getDatasourceIds( this::isMetadataDatasource );
     }
-    return getDatasourceIds( this::isMetadataDatasource );
+    var metadataIds = new ArrayList<String>();
+    for ( String id : ids ) {
+      if ( !isSMEDatasource( id ) ) {
+        metadataIds.add( id );
+      }
+    }
+    return metadataIds;
   }
 
   public MetadataTempFilesListDto uploadMetadataFilesToTempDir( InputStream metadataFile,
-     List<InputStream> localeFileStreams, List<String> localeFileNames ) throws Exception {
+                                                                List<InputStream> localeFileStreams, List<String> localeFileNames )
+    throws Exception {
 
     String fileName = uploadFile( metadataFile );
     MetadataTempFilesListDto dto = new MetadataTempFilesListDto();
@@ -128,8 +139,9 @@ public class MetadataService extends DatasourceService {
         fileName = uploadFile( inputStream );
 
         MetadataTempFilesListBundleDto bundle = new MetadataTempFilesListBundleDto(
-            localeFileNames.get( cntr ),
-            fileName );
+          localeFileNames.get( cntr ),
+          fileName
+        );
         bundles.add( bundle );
 
         logger.info( "locale file uploaded: " + fileName );
@@ -141,7 +153,8 @@ public class MetadataService extends DatasourceService {
     return dto;
   }
 
-  protected InputStream extractXmiFile( InputStream metadataFile, FormDataContentDisposition schemaFileInfo ) throws IOException {
+  protected InputStream extractXmiFile( InputStream metadataFile, FormDataContentDisposition schemaFileInfo )
+    throws IOException {
     String fileNameMain = schemaFileInfo.getFileName();
     ZipInputStream zis = null;
     ByteArrayOutputStream xmi = null;
@@ -180,8 +193,7 @@ public class MetadataService extends DatasourceService {
   }
 
   public MetadataTempFilesListDto uploadMetadataFilesToTempDir( InputStream metadataFile, FormDataContentDisposition schemaFileInfo,
-      List<FormDataBodyPart> localeFiles ) throws Exception {
-
+                                                                List<FormDataBodyPart> localeFiles ) throws Exception {
 
     List<InputStream> bundles = null;
     List<String> fileNames = null;
@@ -209,7 +221,8 @@ public class MetadataService extends DatasourceService {
     throws PentahoAccessControlException, PlatformImportException,
     Exception {
     if ( StringUtils.isEmpty( domainId ) ) {
-      throw new PlatformImportException( Messages.getString( "MetadataDatasourceService.ERROR_005_DOMAIN_NAME_EMPTY" ) );
+      throw new PlatformImportException(
+        Messages.getString( "MetadataDatasourceService.ERROR_005_DOMAIN_NAME_EMPTY" ) );
     }
     List<InputStream> localeFileStreams = null;
     List<String> localeFileNames = null;
@@ -231,10 +244,11 @@ public class MetadataService extends DatasourceService {
   }
 
   public void importMetadataDatasource( String domainId, InputStream metadataFile, boolean overwrite,
-      List<InputStream> localeFileStreams, List<String> localeFileNames, RepositoryFileAclDto acl )
+                                        List<InputStream> localeFileStreams, List<String> localeFileNames, RepositoryFileAclDto acl )
     throws PentahoAccessControlException, PlatformImportException, Exception {
     if ( StringUtils.isEmpty( domainId ) ) {
-      throw new PlatformImportException( Messages.getString( "MetadataDatasourceService.ERROR_005_DOMAIN_NAME_EMPTY" ) );
+      throw new PlatformImportException(
+        Messages.getString( "MetadataDatasourceService.ERROR_005_DOMAIN_NAME_EMPTY" ) );
     }
     accessValidation();
 
@@ -242,7 +256,7 @@ public class MetadataService extends DatasourceService {
     Object reservedCharsObject = fr.doGetReservedChars().getEntity();
     String reservedChars = objectToString( reservedCharsObject );
     if ( reservedChars != null
-        && domainId.matches( ".*[" + reservedChars.replaceAll( "/", "" ) + "]+.*" ) ) {
+      && domainId.matches( ".*[" + reservedChars.replaceAll( "/", "" ) + "]+.*" ) ) {
       String msg = prohibitedSymbolMessage( domainId, fr );
       throw new PlatformImportException( msg, PlatformImportException.PUBLISH_PROHIBITED_SYMBOLS_ERROR );
     }
@@ -255,11 +269,15 @@ public class MetadataService extends DatasourceService {
     // it will unlikely contain that suffix, so let's add it forcibly.
     domainId = forceXmiSuffix( domainId );
 
-    RepositoryFileImportBundle.Builder bundleBuilder = createNewRepositoryFileImportBundleBuilder( metadataFile, overwrite, domainId, acl );
+    RepositoryFileImportBundle.Builder
+      bundleBuilder =
+      createNewRepositoryFileImportBundleBuilder( metadataFile, overwrite, domainId, acl );
 
     if ( localeFileStreams != null ) {
       for ( int i = 0; i < localeFileStreams.size(); i++ ) {
-        IPlatformImportBundle localizationBundle =  createNewRepositoryFileImportBundle( localeFileStreams.get( i ), localeFileNames.get( i ), domainId );
+        IPlatformImportBundle
+          localizationBundle =
+          createNewRepositoryFileImportBundle( localeFileStreams.get( i ), localeFileNames.get( i ), domainId );
         bundleBuilder.addChildBundle( localizationBundle );
       }
     }
@@ -273,12 +291,14 @@ public class MetadataService extends DatasourceService {
 
   public boolean isContainsModel( String tempFileName ) throws Exception {
     XmiParser xmiParser = new XmiParser();
-    byte[] is = IOUtils.toByteArray( createInputStreamFromFile( internalGetUploadDir() + File.separatorChar + tempFileName ) );
+    byte[]
+      is =
+      IOUtils.toByteArray( createInputStreamFromFile( internalGetUploadDir() + File.separatorChar + tempFileName ) );
     Domain domain = xmiParser.parseXmi( new java.io.ByteArrayInputStream( is ) );
     return isContainsModel( domain );
   }
 
-  protected  boolean isContainsModel( Domain domain ) throws Exception {
+  protected boolean isContainsModel( Domain domain ) throws Exception {
     return !DatasourceService.isMetadataDatasource( domain ) && domain.getLogicalModels().size() > 1;
   }
 
@@ -286,7 +306,9 @@ public class MetadataService extends DatasourceService {
       boolean overwrite, RepositoryFileAclDto acl ) throws PentahoAccessControlException, PlatformImportException, Exception {
 
     String metadataTempFileName = fileList.getXmiFileName();
-    InputStream metaDataFileInputStream = createInputStreamFromFile( internalGetUploadDir() + File.separatorChar + metadataTempFileName );
+    InputStream
+      metaDataFileInputStream =
+      createInputStreamFromFile( internalGetUploadDir() + File.separatorChar + metadataTempFileName );
     List<MetadataTempFilesListBundleDto> locBundles = fileList.getBundles();
     List<String> localeFileNames = new ArrayList<String>();
     List<InputStream> localeFileStreams = new ArrayList<InputStream>();
@@ -294,7 +316,8 @@ public class MetadataService extends DatasourceService {
     if ( locBundles != null ) {
       for ( MetadataTempFilesListBundleDto bundle : locBundles ) {
         localeFileNames.add( bundle.getOriginalFileName() );
-        localeFileStreams.add( createInputStreamFromFile( internalGetUploadDir() + File.separatorChar + bundle.getTempFileName() ) );
+        localeFileStreams.add(
+          createInputStreamFromFile( internalGetUploadDir() + File.separatorChar + bundle.getTempFileName() ) );
       }
     }
 
@@ -343,7 +366,7 @@ public class MetadataService extends DatasourceService {
     }
     if ( metadataDomainRepository instanceof IPentahoMetadataDomainRepositoryExporter ) {
       Map<String, InputStream> domainFilesData =
-          ( (IPentahoMetadataDomainRepositoryExporter) metadataDomainRepository ).getDomainFilesData( domainId );
+        ( (IPentahoMetadataDomainRepositoryExporter) metadataDomainRepository ).getDomainFilesData( domainId );
       if ( domainFilesData == null || domainFilesData.isEmpty() ) {
         throw new FileNotFoundException();
       }
@@ -358,7 +381,8 @@ public class MetadataService extends DatasourceService {
     String illegalCharacterList = (String) fr.doGetReservedCharactersDisplay().getEntity();
     //For metadata \ is a legal character and must be removed from the message list before returning the message list to the user
     illegalCharacterList = illegalCharacterList.replaceAll( "\\,", "" );
-    return Messages.getString( "MetadataDatasourceService.ERROR_003_PROHIBITED_SYMBOLS_ERROR", domainId, illegalCharacterList );
+    return Messages.getString(
+      "MetadataDatasourceService.ERROR_003_PROHIBITED_SYMBOLS_ERROR", domainId, illegalCharacterList );
   }
 
   protected String objectToString( Object o ) throws InterruptedException {
@@ -366,7 +390,8 @@ public class MetadataService extends DatasourceService {
   }
 
   protected void publish( IPentahoSession pentahoSession ) throws InterruptedException {
-    PentahoSystem.publish( pentahoSession, org.pentaho.platform.engine.services.metadata.MetadataPublisher.class.getName() );
+    PentahoSystem.publish(
+      pentahoSession, org.pentaho.platform.engine.services.metadata.MetadataPublisher.class.getName() );
   }
 
   protected IPentahoSession getSession() throws InterruptedException {
@@ -394,17 +419,16 @@ public class MetadataService extends DatasourceService {
   }
 
   protected RepositoryFileImportBundle.Builder createNewRepositoryFileImportBundleBuilder( InputStream metadataFile,
-      boolean overWriteInRepository, String domainId, RepositoryFileAclDto acl ) {
+                                                                                           boolean overWriteInRepository, String domainId, RepositoryFileAclDto acl ) {
     final RepositoryFileImportBundle.Builder
-        builder =
-        new RepositoryFileImportBundle.Builder().input( metadataFile ).charSet( "UTF-8" ).hidden( false )
-            .overwriteFile( overWriteInRepository ).mime( "text/xmi+xml" ).withParam( "domain-id", domainId );
+      builder =
+      new RepositoryFileImportBundle.Builder().input( metadataFile ).charSet( "UTF-8" ).hidden( false )
+        .overwriteFile( overWriteInRepository ).mime( "text/xmi+xml" ).withParam( "domain-id", domainId );
     if ( acl != null ) {
       builder.acl( repositoryFileAclAdapter.unmarshal( acl ) ).applyAclSettings( true );
     }
     return builder;
   }
-
 
   protected InputStream createInputStreamFromFile( String fileName ) throws FileNotFoundException {
     return new FileInputStream( fileName );

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -256,9 +256,12 @@ public class AnalysisServiceTest {
     // Does not have an xmi
     final MondrianCatalog foodmartCatalog3 = new MondrianCatalog( "foodmart3", "info", "file:///place",
       new MondrianSchema( "foodmart3", Collections.emptyList() ) );
-    final List<MondrianCatalog> catalogs = Arrays.asList( foodmartCatalog, foodmartCatalog2, foodmartCatalog3 );
+    // Has xmi and it is a SME model
+    final MondrianCatalog foodmartCatalog4 = new MondrianCatalog( "foodmart4", "info", "file:///place",
+      new MondrianSchema( "foodmart4", Collections.emptyList() ) );
+    final List<MondrianCatalog> catalogs = Arrays.asList( foodmartCatalog, foodmartCatalog2, foodmartCatalog3, foodmartCatalog4 );
     doReturn( catalogs ).when( catalogService ).listCatalogs( Mockito.<IPentahoSession>any(), eq( false ) );
-    final HashSet<String> domainIds = Sets.newHashSet( "foodmart.xmi", "foodmart2.xmi", "sample.xmi" );
+    final HashSet<String> domainIds = Sets.newHashSet( "foodmart.xmi", "foodmart2.xmi", "foodmart4.xmi", "sample.xmi" );
     doReturn( domainIds ).when( metadataRepository ).getDomainIds();
 
     Domain mockDomain = mock( Domain.class );
@@ -272,6 +275,12 @@ public class AnalysisServiceTest {
     LogicalModel mockLogicalModel2 = mock( LogicalModel.class );
     when( mockLogicalModel2.getProperty( "AGILE_BI_GENERATED_SCHEMA" ) ).thenReturn( true );
     when( mockDomain2.getLogicalModels() ).thenReturn( Arrays.asList( mockLogicalModel2 ) );
+
+    Domain mockDomain3 = mock( Domain.class );
+    when( metadataRepository.getDomain( "foodmart4.xmi") ).thenReturn( mockDomain3 );
+    LogicalModel mockLogicalModel3 = mock( LogicalModel.class );
+    when( mockLogicalModel3.getProperty( "SME_GENERATED_SCHEMA" ) ).thenReturn( true );
+    when( mockDomain3.getLogicalModels() ).thenReturn( Arrays.asList( mockLogicalModel3 ) );
 
     final List<String> response = analysisService.getAnalysisDatasourceIds();
     assertEquals( Arrays.asList( "foodmart", "foodmart3" ), response );

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/DatasourceServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/DatasourceServiceTest.java
@@ -167,6 +167,7 @@ public class DatasourceServiceTest {
     List<LogicalModel> logicalModelList = new ArrayList<>(  );
     LogicalModel model = new LogicalModel();
     LogicalModel model2 = new LogicalModel();
+    LogicalModel model3 = new LogicalModel();
     // when
     assertFalse( DatasourceService.isMetadataDatasource( (Domain) null ) );
     assertTrue( DatasourceService.isMetadataDatasource( domain ) );
@@ -183,6 +184,11 @@ public class DatasourceServiceTest {
     logicalModelList.add( model2 );
     assertFalse( DatasourceService.isMetadataDatasource( domain ) );
 
+    model3.setProperty( "SME_GENERATED_SCHEMA", true );
+    logicalModelList.clear();
+    logicalModelList.add( model3 );
+    assertFalse( DatasourceService.isDSWDatasource( domain ) );
+
   }
 
   @Test
@@ -192,6 +198,7 @@ public class DatasourceServiceTest {
     List<LogicalModel> logicalModelList = new ArrayList<>();
     LogicalModel model = new LogicalModel();
     LogicalModel model2 = new LogicalModel();
+    LogicalModel model3 = new LogicalModel();
     // when
     assertFalse( DatasourceService.isDSWDatasource( (Domain) null ) );
     assertFalse( DatasourceService.isDSWDatasource( domain ) );
@@ -207,6 +214,31 @@ public class DatasourceServiceTest {
     logicalModelList.clear();
     logicalModelList.add( model2 );
     assertTrue( DatasourceService.isDSWDatasource( domain ) );
+
+    model3.setProperty( "SME_GENERATED_SCHEMA", true );
+    logicalModelList.clear();
+    logicalModelList.add( model3 );
+    assertFalse( DatasourceService.isDSWDatasource( domain ) );
+
+  }
+
+  @Test
+  public void isSMEDatasourceTest() throws Exception {
+    // given
+    Domain domain = mock( Domain.class );
+    List<LogicalModel> logicalModelList = new ArrayList<>();
+    LogicalModel model = new LogicalModel();
+    LogicalModel model2 = new LogicalModel();
+    // when
+    assertFalse( DatasourceService.isSMEDatasource( (Domain) null ) );
+    assertFalse( DatasourceService.isSMEDatasource( domain ) );
+
+    logicalModelList.add( model );
+    when( domain.getLogicalModels() ).thenReturn( logicalModelList );
+    assertFalse( DatasourceService.isSMEDatasource( domain ) );
+
+    model.setProperty( "SME_GENERATED_SCHEMA", true );
+    assertTrue( DatasourceService.isSMEDatasource( domain ) );
 
   }
 

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/MetadataServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/MetadataServiceTest.java
@@ -179,10 +179,12 @@ public class MetadataServiceTest {
   public void testGetMetadataDatasourceIds() {
     // SETUP
     String id = "domainId";
-    String threadCountAsString = "1";
+    String smeId = "smeDomainId";
+    String threadCountAsString = "2";
     List<String> mockMetadataIdsList = new ArrayList<String>();
     Set<String> mockSet = new HashSet<String>();
     mockSet.add( id );
+    mockSet.add( smeId );
     mockMetadataIdsList.add( id );
     Domain domain = new Domain();
     domain.setId( id );
@@ -190,11 +192,17 @@ public class MetadataServiceTest {
     LogicalModel model = new LogicalModel();
     logicalModelList.add( model );
     domain.setLogicalModels( logicalModelList );
+    Domain smeDomain = new Domain();
+    smeDomain.setId( smeId );
+    LogicalModel smeModel = new LogicalModel();
+    domain.setLogicalModels( List.of(smeModel) );
 
     /** simulate parent {@link DatasourceService} default constructor */
     metadataService.dataSourceAwareMetadataDomainRepository = null;
     when( metadataService.metadataDomainRepository.getDomainIds() ).thenReturn( mockSet );
     when( metadataService.metadataDomainRepository.getDomain( id ) ).thenReturn( domain );
+    when( metadataService.metadataDomainRepository.getDomain( smeId ) ).thenReturn( smeDomain );
+    when( metadataService.isSMEDatasource( smeId ) ).thenReturn( true );
     when( metadataService.pluginResourceLoader.getPluginSetting( any(), anyString() ) )
         .thenReturn( threadCountAsString );
 


### PR DESCRIPTION
Relates to SME-294 and to https://github.com/pentaho/semantic-model-editor/pull/324
Add conditions with new property for logical models created by Semantic Model Editor to ensure SME models don't show up in the Manage Datasources menu