### PR TITLE
[BACKLOG-41287]-Upgrading data-access from Java EE to Jakarta EE to be compatiable with Tomcat-10.X

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -145,7 +145,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
+      <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
       <version>${commons-fileupload.version}</version>
     </dependency>
     <dependency>

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/UploadFileDebugServlet.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/UploadFileDebugServlet.java
@@ -33,7 +33,7 @@ import org.apache.commons.fileupload2.core.DiskFileItemFactory;
 import org.apache.commons.fileupload2.core.FileItem;
 import org.apache.commons.fileupload2.core.FileItemFactory;
 import org.apache.commons.fileupload2.core.FileUploadException;
-import org.apache.commons.fileupload2.jakarta.servlet5.JakartaServletFileUpload;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.utils.PentahoSystemHelper;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.messages.Messages;

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/FileUploadServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/FileUploadServiceTest.java
@@ -31,7 +31,6 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpSessionBindingEvent;
 import jakarta.servlet.http.HttpSessionBindingListener;
-import jakarta.servlet.http.HttpSessionContext;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -54,7 +53,6 @@ public class FileUploadServiceTest {
   
   public static final String TMP_FILE_PATH = File.separatorChar + "system" + File.separatorChar + File.separatorChar + "tmp" + File.separatorChar; //$NON-NLS-1$ //$NON-NLS-2$
 
-  @Ignore
   @Test
   public void testUpload() throws Exception {
 
@@ -188,10 +186,6 @@ public class FileUploadServiceTest {
 
     public int getMaxInactiveInterval() {
       return this.maxInactiveInterval;
-    }
-
-    public HttpSessionContext getSessionContext() {
-      throw new UnsupportedOperationException("getSessionContext");
     }
 
     public Object getAttribute(String name) {


### PR DESCRIPTION
[BACKLOG-41287]-Upgrading data-access from Java EE to Jakarta EE to be compatiable with Tomcat-10.X

[BACKLOG-41287]: https://hv-eng.atlassian.net/browse/BACKLOG-41287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ