### PR TITLE
[SME-294] fix: Ensure SME models don't show as Analysis datasources 

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 
 public class AnalysisService extends DatasourceService {
@@ -75,7 +76,7 @@ public class AnalysisService extends DatasourceService {
   private static final String ANNOTATIONS_FILE = "annotations.xml";
   private static final Log logger = LogFactory.getLog( AnalysisService.class );
   private static final String ANNOTATION_FOLDER = RepositoryFile.SEPARATOR + "etc"
-      + RepositoryFile.SEPARATOR + "mondrian" + RepositoryFile.SEPARATOR;
+    + RepositoryFile.SEPARATOR + "mondrian" + RepositoryFile.SEPARATOR;
 
   /*
    * register the handler in the PentahoSpringObjects.xml for MondrianImportHandler
@@ -119,9 +120,12 @@ public class AnalysisService extends DatasourceService {
     Set<String> ids = metadataDomainRepository.getDomainIds();
     for ( MondrianCatalog mondrianCatalog : mockMondrianCatalogList ) {
       String domainId = mondrianCatalog.getName() + METADATA_EXT;
-      if ( !ids.contains( domainId ) || !isDSWDatasource( domainId ) ) {
+      String createdWithProperty = mondrianCatalog.getConnectProperties().get( "CreatedWith" );
+      if ( ( !ids.contains( domainId ) || !isDSWDatasource( domainId ) ) &&
+        ( createdWithProperty == null || !createdWithProperty.equalsIgnoreCase( "SME" ) ) ) {
         analysisIds.add( mondrianCatalog.getName() );
       }
+
     }
     return analysisIds;
 
@@ -170,9 +174,9 @@ public class AnalysisService extends DatasourceService {
         IPlatformImportBundle mondrianBundle = new RepositoryFileImportBundle.Builder()
           .input( annots ).path( ANNOTATION_FOLDER + catName )
           .name( ANNOTATIONS_FILE ).charSet( "UTF-8" ).overwriteFile( true )
-          .mime( "text/xml" ) .withParam( "domain-id", catName )
+          .mime( "text/xml" ).withParam( "domain-id", catName )
           .build();
-          // do import
+        // do import
         importer.importFile( mondrianBundle );
         logger.debug( "imported mondrian annotations" );
         annots.close();
@@ -191,7 +195,7 @@ public class AnalysisService extends DatasourceService {
   }
 
   public RepositoryFileAclDto getAnalysisDatasourceAcl( String analysisId )
-      throws PentahoAccessControlException, FileNotFoundException {
+    throws PentahoAccessControlException, FileNotFoundException {
     checkAnalysisExists( analysisId );
 
     if ( aclAwareMondrianCatalogService != null ) {
@@ -202,7 +206,7 @@ public class AnalysisService extends DatasourceService {
   }
 
   public void setAnalysisDatasourceAcl( String analysisId, RepositoryFileAclDto aclDto )
-      throws PentahoAccessControlException, FileNotFoundException {
+    throws PentahoAccessControlException, FileNotFoundException {
     checkAnalysisExists( analysisId );
 
     final RepositoryFileAcl acl = aclDto == null ? null : repositoryFileAclAdapter.unmarshal( aclDto );
@@ -230,7 +234,8 @@ public class AnalysisService extends DatasourceService {
    * @param xmlaEnabledFlag
    * @param parameters
    * @param fileName
-   * @param acl acl information for the data source. This parameter is optional.
+   * @param acl
+   *   acl information for the data source. This parameter is optional.
    * @throws PlatformImportException
    */
   protected void processMondrianImport( InputStream dataInputStream, String catalogName, String origCatalogName,
@@ -239,16 +244,16 @@ public class AnalysisService extends DatasourceService {
     throws PlatformImportException {
     boolean overWriteInRepository = determineOverwriteFlag( parameters, overwrite );
     IPlatformImportBundle bundle =
-        createPlatformBundle(
-          parameters, dataInputStream, catalogName, overWriteInRepository, fileName, xmlaEnabledFlag, acl );
+      createPlatformBundle(
+        parameters, dataInputStream, catalogName, overWriteInRepository, fileName, xmlaEnabledFlag, acl );
     if ( isChangeCatalogName( origCatalogName, bundle ) ) {
       IMondrianCatalogService catalogService =
-          PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
+        PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
       catalogService.removeCatalog( origCatalogName, PentahoSessionHolder.getSession() );
     }
     if ( isOverwriteAnnotations( parameters, overWriteInRepository ) ) {
       IMondrianCatalogService catalogService =
-          PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
+        PentahoSystem.get( IMondrianCatalogService.class, PentahoSessionHolder.getSession() );
       MondrianCatalog catalog = catalogService.getCatalog( bundle.getName(), PentahoSessionHolder.getSession() );
       if ( catalog != null ) {
         catalogService.removeCatalog( bundle.getName(), PentahoSessionHolder.getSession() );
@@ -256,7 +261,6 @@ public class AnalysisService extends DatasourceService {
     }
     importer.importFile( bundle );
   }
-
 
   private boolean isChangeCatalogName( final String origCatalogName, final IPlatformImportBundle bundle ) {
     // MONDRIAN-1731
@@ -294,7 +298,8 @@ public class AnalysisService extends DatasourceService {
    * @param overWriteInRepository
    * @param fileName
    * @param xmlaEnabled
-   * @param acl acl information for the data source. This parameter is optional.
+   * @param acl
+   *   acl information for the data source. This parameter is optional.
    * @return IPlatformImportBundle
    */
   private IPlatformImportBundle createPlatformBundle( String parameters, InputStream dataInputStream,
@@ -306,7 +311,7 @@ public class AnalysisService extends DatasourceService {
       bytes = IOUtils.toByteArray( dataInputStream );
       if ( bytes.length == 0 && catalogName != null ) {
         MondrianCatalogRepositoryHelper helper =
-            new MondrianCatalogRepositoryHelper( PentahoSystem.get( IUnifiedRepository.class ) );
+          new MondrianCatalogRepositoryHelper( PentahoSystem.get( IUnifiedRepository.class ) );
         Map<String, InputStream> fileData = helper.getModrianSchemaFiles( catalogName );
         dataInputStream = fileData.get( "schema.xml" );
         bytes = IOUtils.toByteArray( dataInputStream );
@@ -317,7 +322,7 @@ public class AnalysisService extends DatasourceService {
 
     String datasource = getValue( parameters, "Datasource" );
     String domainId =
-        this.determineDomainCatalogName( parameters, catalogName, fileName, new ByteArrayInputStream( bytes ) );
+      this.determineDomainCatalogName( parameters, catalogName, fileName, new ByteArrayInputStream( bytes ) );
     String sep = ";";
     if ( StringUtils.isEmpty( parameters ) ) {
       parameters = "Provider=mondrian";
@@ -326,7 +331,7 @@ public class AnalysisService extends DatasourceService {
     }
 
     RepositoryFileImportBundle.Builder bundleBuilder =
-        new RepositoryFileImportBundle.Builder().input( new ByteArrayInputStream( bytes ) ).charSet( UTF_8 ).hidden(
+      new RepositoryFileImportBundle.Builder().input( new ByteArrayInputStream( bytes ) ).charSet( UTF_8 ).hidden(
         false ).name( domainId ).overwriteFile( overWriteInRepository ).mime( MONDRIAN_MIME_TYPE ).withParam(
         PARAMETERS, parameters ).withParam( DOMAIN_ID, domainId );
     if ( acl != null ) {
@@ -371,7 +376,7 @@ public class AnalysisService extends DatasourceService {
 
       while ( reader.next() != XMLStreamReader.END_DOCUMENT ) {
         if ( reader.getEventType() == XMLStreamReader.START_ELEMENT
-            && reader.getLocalName().equalsIgnoreCase( "Schema" ) ) {
+          && reader.getLocalName().equalsIgnoreCase( "Schema" ) ) {
           domainId = reader.getAttributeValue( "", "name" );
           if ( domainId == null ) {
             domainId = reader.getAttributeValue( null, "name" );
@@ -388,6 +393,7 @@ public class AnalysisService extends DatasourceService {
 
     return domainId;
   }
+
   /**
    * helper method to calculate the domain id from the parameters, file name, or pass catalog
    *
@@ -453,12 +459,16 @@ public class AnalysisService extends DatasourceService {
 
   private void fileNameValidation( final String fileName ) throws PlatformImportException {
     if ( fileName == null ) {
-      throw new PlatformImportException( Messages.getString( "AnalysisService.ERROR_001_ANALYSIS_DATASOURCE_ERROR" ),
-          PlatformImportException.PUBLISH_GENERAL_ERROR );
+      throw new PlatformImportException(
+        Messages.getString( "AnalysisService.ERROR_001_ANALYSIS_DATASOURCE_ERROR" ),
+        PlatformImportException.PUBLISH_GENERAL_ERROR
+      );
     }
     if ( fileName.endsWith( METADATA_EXT ) ) {
-      throw new PlatformImportException( Messages.getString( "AnalysisService.ERROR_002_ANALYSIS_DATASOURCE_ERROR" ),
-          PlatformImportException.PUBLISH_GENERAL_ERROR );
+      throw new PlatformImportException(
+        Messages.getString( "AnalysisService.ERROR_002_ANALYSIS_DATASOURCE_ERROR" ),
+        PlatformImportException.PUBLISH_GENERAL_ERROR
+      );
     }
   }
 }

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -120,9 +120,7 @@ public class AnalysisService extends DatasourceService {
     Set<String> ids = metadataDomainRepository.getDomainIds();
     for ( MondrianCatalog mondrianCatalog : mockMondrianCatalogList ) {
       String domainId = mondrianCatalog.getName() + METADATA_EXT;
-      String createdWithProperty = mondrianCatalog.getConnectProperties().get( "CreatedWith" );
-      if ( ( !ids.contains( domainId ) || !isDSWDatasource( domainId ) ) &&
-        ( createdWithProperty == null || !createdWithProperty.equalsIgnoreCase( "SME" ) ) ) {
+      if ( ( !ids.contains( domainId ) || !isDSWDatasource( domainId ) ) && shouldListCatalog( mondrianCatalog ) ) {
         analysisIds.add( mondrianCatalog.getName() );
       }
 
@@ -470,5 +468,10 @@ public class AnalysisService extends DatasourceService {
         PlatformImportException.PUBLISH_GENERAL_ERROR
       );
     }
+  }
+
+  private boolean shouldListCatalog( MondrianCatalog catalog ) {
+    String toIgnoreProperty = catalog.getConnectProperties().get( "DataAccessNotListedCatalog" );
+    return toIgnoreProperty == null || !toIgnoreProperty.equalsIgnoreCase( "true" );
   }
 }

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -256,8 +256,8 @@ public class AnalysisServiceTest {
     // Does not have an xmi
     final MondrianCatalog foodmartCatalog3 = new MondrianCatalog( "foodmart3", "info", "file:///place",
       new MondrianSchema( "foodmart3", Collections.emptyList() ) );
-    // Does not have xmi and is a SME model
-    final MondrianCatalog foodmartCatalog4 = new MondrianCatalog( "foodmart4", "CreatedWith=SME", "file:///place",
+    // Does not have xmi and should not be listed
+    final MondrianCatalog foodmartCatalog4 = new MondrianCatalog( "foodmart4", "DataAccessNotListedCatalog=true", "file:///place",
       new MondrianSchema( "foodmart4", Collections.emptyList() ) );
     final List<MondrianCatalog> catalogs = Arrays.asList( foodmartCatalog, foodmartCatalog2, foodmartCatalog3, foodmartCatalog4 );
     doReturn( catalogs ).when( catalogService ).listCatalogs( Mockito.<IPentahoSession>any(), eq( false ) );

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -256,7 +256,10 @@ public class AnalysisServiceTest {
     // Does not have an xmi
     final MondrianCatalog foodmartCatalog3 = new MondrianCatalog( "foodmart3", "info", "file:///place",
       new MondrianSchema( "foodmart3", Collections.emptyList() ) );
-    final List<MondrianCatalog> catalogs = Arrays.asList( foodmartCatalog, foodmartCatalog2, foodmartCatalog3 );
+    // Does not have xmi and is a SME model
+    final MondrianCatalog foodmartCatalog4 = new MondrianCatalog( "foodmart4", "CreatedWith=SME", "file:///place",
+      new MondrianSchema( "foodmart4", Collections.emptyList() ) );
+    final List<MondrianCatalog> catalogs = Arrays.asList( foodmartCatalog, foodmartCatalog2, foodmartCatalog3, foodmartCatalog4 );
     doReturn( catalogs ).when( catalogService ).listCatalogs( Mockito.<IPentahoSession>any(), eq( false ) );
     final HashSet<String> domainIds = Sets.newHashSet( "foodmart.xmi", "foodmart2.xmi", "sample.xmi" );
     doReturn( domainIds ).when( metadataRepository ).getDomainIds();


### PR DESCRIPTION
Relates to SME-294 and https://github.com/pentaho/semantic-model-editor/pull/341
Add conditions with new property in mondrianCatalogs created by Semantic Model Editor to ensure SME models don't show up in the Manage Datasources menu.