### PR TITLE
[SP-6665] Backport of SME-294 - fix: Ensure SME models don't show as Analysis datasources

### DIFF
--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisServiceTest.java
@@ -252,7 +252,10 @@ public class AnalysisServiceTest {
     // Does not have an xmi
     final MondrianCatalog foodmartCatalog3 = new MondrianCatalog( "foodmart3", "info", "file:///place",
       new MondrianSchema( "foodmart3", Collections.emptyList() ) );
-    final List<MondrianCatalog> catalogs = Arrays.asList( foodmartCatalog, foodmartCatalog2, foodmartCatalog3 );
+    // Does not have xmi and should not be listed
+    final MondrianCatalog foodmartCatalog4 = new MondrianCatalog( "foodmart4", "DataAccessNotListedCatalog=true", "file:///place",
+      new MondrianSchema( "foodmart4", Collections.emptyList() ) );
+    final List<MondrianCatalog> catalogs = Arrays.asList( foodmartCatalog, foodmartCatalog2, foodmartCatalog3, foodmartCatalog4 );
     doReturn( catalogs ).when( catalogService ).listCatalogs( Mockito.<IPentahoSession>any(), eq( false ) );
     final HashSet<String> domainIds = Sets.newHashSet( "foodmart.xmi", "foodmart2.xmi", "sample.xmi" );
     doReturn( domainIds ).when( metadataRepository ).getDomainIds();


### PR DESCRIPTION
Cherry picked from commit https://github.com/pentaho/data-access/commit/2a1f19e79fb15913cac65d2f906f3267dd341b11