### PR TITLE
[SP-6689]-Backport of PPP-4862 - Use Pentaho-kettle's XMLParserFactoryProducer in Data-acccess (10.2 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/api/AnalysisService.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import org.pentaho.di.core.xml.XMLParserFactoryProducer;
 
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 
@@ -350,7 +351,7 @@ public class AnalysisService extends DatasourceService {
 
   // for unit test
   XMLInputFactory getXMLInputFactory() {
-    return XMLInputFactory.newInstance();
+    return XMLParserFactoryProducer.createSecureXMLInputFactory();
   }
 
   String getSchemaName( String encoding, InputStream inputStream ) throws XMLStreamException, IOException {


### PR DESCRIPTION
[SP-6689]-Backport of PPP-4862 - Use Pentaho-kettle's XMLParserFactoryProducer in Data-acccess (10.2 Suite)

[SP-6689]: https://hv-eng.atlassian.net/browse/SP-6689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ