### PR TITLE
feat: add description property to authorization actions [PPUC-64]

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/security/policy/rolebased/actions/DatasourceManageAction.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/security/policy/rolebased/actions/DatasourceManageAction.java
@@ -27,4 +27,9 @@ public class DatasourceManageAction implements IAuthorizationAction {
   public String getLocalizedDisplayName( String localeString ) {
     return Messages.getInstance().getString( NAME );
   }
+
+  @Override
+  public String getLocalizedDescription( String localeString ) {
+    return Messages.getInstance().getString( NAME + ".description" );
+  }
 }


### PR DESCRIPTION
This pull request introduces a new method `getLocalizedDescription` to the `DatasourceManageAction` class in the `core/src/main/java/org/pentaho/platform/dataaccess/security/policy/rolebased/actions/DatasourceManageAction.java` file. This method provides a localized description for the action, enhancing the class's support for internationalization.

Key change:

* Added the `getLocalizedDescription` method to return a localized description string based on the given locale. This complements the existing `getLocalizedDisplayName` method by providing additional context for the action.

should be merged after https://github.com/pentaho/pentaho-platform/pull/5911

@pentaho/millenniumfalcon please review