### PR TITLE
[BACKLOG-48717] - use REST-specific object for list calls

### DIFF
--- a/api/src/main/resources/connection-api.yaml
+++ b/api/src/main/resources/connection-api.yaml
@@ -281,7 +281,7 @@ paths:
       operationId: getConnections
       tags:
         - connections
-      description: Returns the list of database connections
+      description: Returns the list of database connections. List results may include a response-only level property indicating the source scope of each connection.
       parameters:
         - name: projectDir
           in: query
@@ -301,7 +301,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IDatabaseConnectionList'
+                $ref: '#/components/schemas/LevelAwareDatabaseConnectionList'
         '500':
           description: Internal server error
           content:
@@ -574,10 +574,6 @@ components:
           description: Partitioning information
           items:
             type: object
-        level:
-          type: string
-          description: Connection level for list results
-          example: "Repository"
     IDatabaseConnectionList:
       type: object
       description: List of database connections (maps to org.pentaho.ui.database.event.IDatabaseConnectionList)
@@ -587,6 +583,25 @@ components:
           description: Array of database connections
           items:
             $ref: '#/components/schemas/IDatabaseConnection'
+    LevelAwareDatabaseConnection:
+      allOf:
+        - $ref: '#/components/schemas/IDatabaseConnection'
+        - type: object
+          description: Database connection returned by the list endpoint, including response-only source scope metadata.
+          properties:
+            level:
+              type: string
+              description: Connection level populated only in list results.
+              example: "Repository"
+    LevelAwareDatabaseConnectionList:
+      type: object
+      description: List of database connections returned by the list endpoint, where each item may include response-only level metadata.
+      properties:
+        databaseConnections:
+          type: array
+          description: Array of database connections
+          items:
+            $ref: '#/components/schemas/LevelAwareDatabaseConnection'
     IDatabaseConnectionPoolParameter:
       type: object
       description: Database connection pool parameter

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
@@ -32,15 +32,15 @@ import org.pentaho.platform.dataaccess.datasource.wizard.service.api.Connections
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.utils.UtilHtmlSanitizer;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.messages.Messages;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.model.CheckParameters200Response;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.model.LevelAwareDatabaseConnection;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.model.LevelAwareDatabaseConnectionList;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.security.authorization.core.exceptions.AuthorizationRuleException;
 import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
 import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
-import org.pentaho.ui.database.event.DefaultDatabaseConnectionList;
 import org.pentaho.ui.database.event.DefaultDatabaseConnectionPoolParameterList;
-import org.pentaho.ui.database.event.IDatabaseConnectionList;
 import org.pentaho.ui.database.event.IDatabaseConnectionPoolParameterList;
 
 import jakarta.ws.rs.WebApplicationException;
@@ -533,12 +533,12 @@ public class ConnectionService implements ConnectionsApi {
    *
    */
   @Override
-  public IDatabaseConnectionList getConnections( String projectDir, Boolean allLevels ) {
+  public LevelAwareDatabaseConnectionList getConnections( String projectDir, Boolean allLevels ) {
     try {
-      IDatabaseConnectionList databaseConnections = new DefaultDatabaseConnectionList();
-      List<IDatabaseConnection> conns = connectionService.getConnections( true );
-      for ( IDatabaseConnection conn : conns ) {
-        setConnectionLevel( conn, CONNECTION_LEVEL_REPOSITORY );
+      LevelAwareDatabaseConnectionList databaseConnections = new LevelAwareDatabaseConnectionList();
+      List<LevelAwareDatabaseConnection> conns = new ArrayList<>();
+      for ( IDatabaseConnection conn : connectionService.getConnections( true ) ) {
+        conns.add( withConnectionLevel( conn, CONNECTION_LEVEL_REPOSITORY ) );
       }
       databaseConnections.setDatabaseConnections( conns );
       return databaseConnections;
@@ -547,16 +547,64 @@ public class ConnectionService implements ConnectionsApi {
     }
   }
 
-  public IDatabaseConnectionList getConnections( String projectDir ) {
+  public LevelAwareDatabaseConnectionList getConnections( String projectDir ) {
     return getConnections( projectDir, Boolean.FALSE );
   }
 
-  public IDatabaseConnectionList getConnections() {
+  public LevelAwareDatabaseConnectionList getConnections() {
     return getConnections( null, Boolean.FALSE );
   }
 
-  protected void setConnectionLevel( IDatabaseConnection connection, String level ) {
-    connection.setLevel( level );
+  protected LevelAwareDatabaseConnection withConnectionLevel( IDatabaseConnection connection, String level ) {
+    LevelAwareDatabaseConnection responseConnection = toApiConnection( connection );
+    responseConnection.setLevel( level );
+    return responseConnection;
+  }
+
+  protected LevelAwareDatabaseConnection toApiConnection( IDatabaseConnection connection ) {
+    LevelAwareDatabaseConnection responseConnection = new LevelAwareDatabaseConnection();
+
+    responseConnection.setId( connection.getId() );
+    responseConnection.setName( connection.getName() );
+    responseConnection.setHostname( connection.getHostname() );
+    responseConnection.setDatabaseName( connection.getDatabaseName() );
+    responseConnection.setDatabasePort( connection.getDatabasePort() );
+    responseConnection.setUsername( connection.getUsername() );
+    responseConnection.setPassword( connection.getPassword() );
+    responseConnection.setDataTablespace( connection.getDataTablespace() );
+    responseConnection.setIndexTablespace( connection.getIndexTablespace() );
+    responseConnection.setSqlServerInstance( connection.getSQLServerInstance() );
+    responseConnection.setStreamingResults( connection.isStreamingResults() );
+    responseConnection.setQuoteAllFields( connection.isQuoteAllFields() );
+    responseConnection.setChanged( connection.getChanged() );
+    responseConnection.setUsingDoubleDecimalAsSchemaTableSeparator(
+      connection.isUsingDoubleDecimalAsSchemaTableSeparator() );
+    responseConnection.setInformixServername( connection.getInformixServername() );
+    responseConnection.setForcingIdentifiersToLowerCase( connection.isForcingIdentifiersToLowerCase() );
+    responseConnection.setForcingIdentifiersToUpperCase( connection.isForcingIdentifiersToUpperCase() );
+    responseConnection.setConnectSql( connection.getConnectSql() );
+    responseConnection.setUsingConnectionPool( connection.isUsingConnectionPool() );
+    responseConnection.setInitialPoolSize( connection.getInitialPoolSize() );
+    responseConnection.setMaximumPoolSize( connection.getMaximumPoolSize() );
+    responseConnection.setPartitioned( connection.isPartitioned() );
+    responseConnection.setAccessType( connection.getAccessType() == null ? null : connection.getAccessType().name() );
+    responseConnection.setDatabaseType( connection.getDatabaseType() );
+    if ( connection.getExtraOptions() != null ) {
+      responseConnection.setExtraOptions( connection.getExtraOptions() );
+    }
+    if ( connection.getExtraOptionsOrder() != null ) {
+      responseConnection.setExtraOptionsOrder( connection.getExtraOptionsOrder() );
+    }
+    if ( connection.getAttributes() != null ) {
+      responseConnection.setAttributes( connection.getAttributes() );
+    }
+    if ( connection.getConnectionPoolingProperties() != null ) {
+      responseConnection.setConnectionPoolingProperties( connection.getConnectionPoolingProperties() );
+    }
+    if ( connection.getPartitioningInformation() != null ) {
+      responseConnection.setPartitioningInformation( new ArrayList<>( connection.getPartitioningInformation() ) );
+    }
+    return responseConnection;
   }
 
   /**

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceRestApiTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceRestApiTest.java
@@ -17,9 +17,10 @@ import org.pentaho.database.model.DatabaseAccessType;
 import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.ConnectionServiceException;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.model.LevelAwareDatabaseConnection;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.model.LevelAwareDatabaseConnectionList;
 import org.pentaho.platform.engine.security.authorization.core.exceptions.AuthorizationRuleException;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.utils.UtilHtmlSanitizer;
-import org.pentaho.ui.database.event.IDatabaseConnectionList;
 import org.pentaho.ui.database.event.IDatabaseConnectionPoolParameterList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -88,6 +89,10 @@ public class ConnectionServiceRestApiTest {
     conn.setInformixServername( null );
 
     return conn;
+  }
+
+  private String getResponseLevel( LevelAwareDatabaseConnection connection ) {
+    return connection.getLevel();
   }
 
   /**
@@ -598,7 +603,7 @@ public class ConnectionServiceRestApiTest {
 
     when( connectionServiceImpl.getConnections( true ) ).thenReturn( connections );
 
-    IDatabaseConnectionList result = connectionService.getConnections();
+    LevelAwareDatabaseConnectionList result = connectionService.getConnections();
 
     assertNotNull( "Result should not be null", result );
     assertNotNull( "Connections list should not be null", result.getDatabaseConnections() );
@@ -615,12 +620,12 @@ public class ConnectionServiceRestApiTest {
 
     when( connectionServiceImpl.getConnections( true ) ).thenReturn( connections );
 
-    IDatabaseConnectionList result = connectionService.getConnections( null, true );
+    LevelAwareDatabaseConnectionList result = connectionService.getConnections( null, true );
 
     assertNotNull( "Result should not be null", result );
     assertEquals( "Should have one connection", 1, result.getDatabaseConnections().size() );
     assertEquals( "Repository level should always be set",
-      "Repository", result.getDatabaseConnections().get( 0 ).getLevel() );
+      "Repository", getResponseLevel( result.getDatabaseConnections().get( 0 ) ) );
 
     String json = objectMapper.writeValueAsString( result.getDatabaseConnections().get( 0 ) );
     com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree( json );
@@ -638,12 +643,12 @@ public class ConnectionServiceRestApiTest {
 
     when( connectionServiceImpl.getConnections( true ) ).thenReturn( connections );
 
-    IDatabaseConnectionList result = connectionService.getConnections( null, false );
+    LevelAwareDatabaseConnectionList result = connectionService.getConnections( null, false );
 
     assertNotNull( "Result should not be null", result );
     assertEquals( "Should have one connection", 1, result.getDatabaseConnections().size() );
     assertEquals( "Level should always be set to Repository",
-      "Repository", result.getDatabaseConnections().get( 0 ).getLevel() );
+      "Repository", getResponseLevel( result.getDatabaseConnections().get( 0 ) ) );
   }
 
   /**


### PR DESCRIPTION
To avoid modifying pentaho-commons-database and still have 'level'