### PR TITLE
build[SP-7260]: update Hibernate groupId

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -537,7 +537,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1170,7 +1170,7 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
         <version>${hibernate-core.version}</version>
         <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
   </modules>
   <properties>
     <pentaho-reporting.version>10.2.0.0-SNAPSHOT</pentaho-reporting.version>
-    <hibernate-core.version>5.4.24.Final</hibernate-core.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <aspectjrt.version>1.6.6</aspectjrt.version>
     <mockito.version>5.10.0</mockito.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7260 - Backport of PPP-6248 - (10.2 Suite) CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/SP-7260)
- **Base Case:** [PPP-6248 - CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/PPP-6248)
- **Original Master PR:** https://github.com/pentaho/data-access/pull/1349

## Changes
- Cherry-picked PR #1349 (build[PPP-6248]: update Hibernate groupId).
- Commit: d4d2cc97

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
