### PR TITLE
build[BACKLOG-50098]: Bump version of aspectjrt dependency to 1.9.25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
   </modules>
   <properties>
     <pentaho-reporting.version>11.1.0.0-SNAPSHOT</pentaho-reporting.version>
-    <aspectjrt.version>1.6.6</aspectjrt.version>
     <mockito.version>5.10.0</mockito.version>
     <objenesis.version>3.3</objenesis.version>
     <jmock-junit4.version>2.13.1</jmock-junit4.version>


### PR DESCRIPTION
## Summary
- remove the repo-local `aspectjrt.version` override
- inherit `org.aspectj:aspectjrt` version `1.9.25.1` from `pentaho-parent-pom`

## Validation
- `mvn -B -nsu -Dmaven.test.skip=true clean install`
