### PR TITLE
fix[PPP-6483]: Migrate data-access from Flexjson to Jackson

### DIFF
--- a/assemblies/data-access-plugin/pom.xml
+++ b/assemblies/data-access-plugin/pom.xml
@@ -13,11 +13,6 @@
   <packaging>pom</packaging>
   <dependencies>
     <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>commons-database-gwt</artifactId>
       <scope>runtime</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -279,10 +279,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.sf.flexjson</groupId>
-      <artifactId>flexjson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionListReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionListReaderWriter.java
@@ -15,6 +15,10 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,22 +35,34 @@ import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.Provider;
 
+import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.DatabaseType;
 import org.pentaho.database.model.IDatabaseConnection;
+import org.pentaho.database.model.IDatabaseType;
 import org.pentaho.ui.database.event.DefaultDatabaseConnectionList;
 import org.pentaho.ui.database.event.IDatabaseConnectionList;
 
-import flexjson.JSONDeserializer;
-import flexjson.JSONSerializer;
-
 /**
- * Reads and writes Database Connection objects using flexjson so that they won't lose map values when converting
+ * Reads and writes Database Connection objects using Jackson so that they won't lose map values when converting
  * to/from autobeans
  */
 @Provider
 @Produces( APPLICATION_JSON )
 public class DatabaseConnectionListReaderWriter
   implements MessageBodyReader<IDatabaseConnectionList>, MessageBodyWriter<IDatabaseConnectionList> {
+
+  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
+
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = JacksonObjectMapperUtil.createObjectMapper();
+    SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
+    resolver.addMapping( IDatabaseConnection.class, DatabaseConnection.class );
+    resolver.addMapping( IDatabaseType.class, DatabaseType.class );
+    SimpleModule module = new SimpleModule();
+    module.setAbstractTypes( resolver );
+    mapper.registerModule( module );
+    return mapper;
+  }
 
   @Override
   public long getSize( IDatabaseConnectionList t, Class<?> type, Type genericType, Annotation[] annotations,
@@ -66,7 +82,7 @@ public class DatabaseConnectionListReaderWriter
     throws IOException, WebApplicationException {
     OutputStreamWriter outputStreamWriter = new OutputStreamWriter( entityStream );
     try {
-      new JSONSerializer().exclude( "*.class" ).deepSerialize( t, outputStreamWriter );
+      OBJECT_MAPPER.writeValue( outputStreamWriter, t );
     } finally {
       outputStreamWriter.close();
     }
@@ -74,7 +90,7 @@ public class DatabaseConnectionListReaderWriter
 
   @Override
   public boolean isReadable( Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType ) {
-    return IDatabaseConnection.class.isAssignableFrom( type );
+    return IDatabaseConnectionList.class.isAssignableFrom( type );
   }
 
   @Override
@@ -83,8 +99,6 @@ public class DatabaseConnectionListReaderWriter
                                            MediaType mediaType, MultivaluedMap<String, String> httpHeaders,
                                            InputStream entityStream ) throws IOException,
     WebApplicationException {
-    JSONDeserializer<DefaultDatabaseConnectionList> jsonD = new JSONDeserializer<DefaultDatabaseConnectionList>();
-    jsonD.use( "databaseType", DatabaseType.class );
-    return jsonD.deserialize( new InputStreamReader( entityStream ), DefaultDatabaseConnectionList.class );
+    return OBJECT_MAPPER.readValue( new InputStreamReader( entityStream ), DefaultDatabaseConnectionList.class );
   }
 }

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionReaderWriter.java
@@ -15,6 +15,10 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -34,18 +38,28 @@ import jakarta.ws.rs.ext.Provider;
 import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.DatabaseType;
 import org.pentaho.database.model.IDatabaseConnection;
-
-import flexjson.JSONDeserializer;
-import flexjson.JSONSerializer;
+import org.pentaho.database.model.IDatabaseType;
 
 /**
- * Reads and writes Database Connection objects using flexjson so that they won't lose map values when converting
+ * Reads and writes Database Connection objects using Jackson so that they won't lose map values when converting
  * to/from autobeans
  */
 @Provider
 @Produces( APPLICATION_JSON )
 public class DatabaseConnectionReaderWriter
   implements MessageBodyReader<DatabaseConnection>, MessageBodyWriter<DatabaseConnection> {
+
+  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
+
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = JacksonObjectMapperUtil.createObjectMapper();
+    SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
+    resolver.addMapping( IDatabaseType.class, DatabaseType.class );
+    SimpleModule module = new SimpleModule();
+    module.setAbstractTypes( resolver );
+    mapper.registerModule( module );
+    return mapper;
+  }
 
   @Override
   public long getSize( DatabaseConnection t, Class<?> type, Type genericType, Annotation[] annotations,
@@ -65,7 +79,7 @@ public class DatabaseConnectionReaderWriter
     throws IOException, WebApplicationException {
     OutputStreamWriter outputStreamWriter = new OutputStreamWriter( entityStream );
     try {
-      new JSONSerializer().exclude( "*.class" ).serialize( t, outputStreamWriter );
+      OBJECT_MAPPER.writeValue( outputStreamWriter, t );
     } finally {
       outputStreamWriter.close();
     }
@@ -81,9 +95,7 @@ public class DatabaseConnectionReaderWriter
                                       MediaType mediaType, MultivaluedMap<String, String> httpHeaders,
                                       InputStream entityStream ) throws IOException,
     WebApplicationException {
-    JSONDeserializer<DatabaseConnection> jsonD = new JSONDeserializer<DatabaseConnection>();
-    jsonD.use( "databaseType", DatabaseType.class );
-    return jsonD.deserialize( new InputStreamReader( entityStream ), DatabaseConnection.class );
+    return OBJECT_MAPPER.readValue( new InputStreamReader( entityStream ), DatabaseConnection.class );
   }
 
 }

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypeReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypeReaderWriter.java
@@ -13,8 +13,7 @@
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
-import flexjson.JSONDeserializer;
-import flexjson.JSONSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.pentaho.database.model.DatabaseType;
 import org.pentaho.database.model.IDatabaseType;
 
@@ -36,12 +35,14 @@ import java.lang.reflect.Type;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 /**
- * Reads and writes DatabaseType objects using flexjson so that they won't lose map values
+ * Reads and writes DatabaseType objects using Jackson so that they won't lose map values
  * when converting to/from autobeans
  */
 @Provider
 @Produces( APPLICATION_JSON )
 public class DatabaseTypeReaderWriter implements MessageBodyReader<DatabaseType>, MessageBodyWriter<DatabaseType> {
+
+  private static final ObjectMapper OBJECT_MAPPER = JacksonObjectMapperUtil.createObjectMapper();
 
   @Override
   public long getSize( DatabaseType t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType ) {
@@ -58,7 +59,7 @@ public class DatabaseTypeReaderWriter implements MessageBodyReader<DatabaseType>
                        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream ) throws IOException, WebApplicationException {
     OutputStreamWriter outputStreamWriter = new OutputStreamWriter( entityStream );
     try {
-      new JSONSerializer().exclude( "*.class" ).serialize( t, outputStreamWriter );
+      OBJECT_MAPPER.writeValue( outputStreamWriter, t );
     } finally {
       outputStreamWriter.close();
     }
@@ -73,8 +74,7 @@ public class DatabaseTypeReaderWriter implements MessageBodyReader<DatabaseType>
   public DatabaseType readFrom( Class<DatabaseType> type, Type genericType, Annotation[] annotations,
                                 MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream ) throws IOException,
     WebApplicationException {
-    JSONDeserializer<DatabaseType> jsonD = new JSONDeserializer<DatabaseType>();
-    return jsonD.deserialize( new InputStreamReader( entityStream ), DatabaseType.class );
+    return OBJECT_MAPPER.readValue( new InputStreamReader( entityStream ), DatabaseType.class );
   }
 
 }

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriter.java
@@ -13,8 +13,7 @@
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
-import flexjson.JSONDeserializer;
-import flexjson.JSONSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.pentaho.ui.database.event.DefaultDatabaseTypesList;
 import org.pentaho.ui.database.event.IDatabaseTypesList;
 
@@ -36,12 +35,14 @@ import java.lang.reflect.Type;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 /**
- * Reads and writes DatabaseTypes objects using flexjson so that they won't lose map values
+ * Reads and writes DatabaseTypes objects using Jackson so that they won't lose map values
  * when converting to/from autobeans
  */
 @Provider
 @Produces( APPLICATION_JSON )
 public class DatabaseTypesListReaderWriter implements MessageBodyReader<IDatabaseTypesList>, MessageBodyWriter<IDatabaseTypesList> {
+
+  private static final ObjectMapper OBJECT_MAPPER = JacksonObjectMapperUtil.createObjectMapper();
 
   @Override
   public long getSize( IDatabaseTypesList t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType ) {
@@ -58,7 +59,7 @@ public class DatabaseTypesListReaderWriter implements MessageBodyReader<IDatabas
                        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream ) throws IOException, WebApplicationException {
     OutputStreamWriter outputStreamWriter = new OutputStreamWriter( entityStream );
     try {
-      new JSONSerializer().exclude( "*.class" ).deepSerialize( t, outputStreamWriter );
+      OBJECT_MAPPER.writeValue( outputStreamWriter, t );
     } finally {
       outputStreamWriter.close();
     }
@@ -73,7 +74,6 @@ public class DatabaseTypesListReaderWriter implements MessageBodyReader<IDatabas
   public IDatabaseTypesList readFrom( Class<IDatabaseTypesList> type, Type genericType, Annotation[] annotations,
                                       MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream ) throws IOException,
     WebApplicationException {
-    JSONDeserializer<DefaultDatabaseTypesList> jsonD = new JSONDeserializer<DefaultDatabaseTypesList>();
-    return jsonD.deserialize( new InputStreamReader( entityStream ), DefaultDatabaseTypesList.class );
+    return OBJECT_MAPPER.readValue( new InputStreamReader( entityStream ), DefaultDatabaseTypesList.class );
   }
 }

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/JacksonObjectMapperUtil.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/JacksonObjectMapperUtil.java
@@ -1,0 +1,46 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Factory for pre-configured {@link ObjectMapper} instances used by JAX-RS reader/writer providers in this package.
+ */
+class JacksonObjectMapperUtil {
+
+  private JacksonObjectMapperUtil() {
+    // utility class
+  }
+
+  /**
+   * Returns a new {@link ObjectMapper} with a common baseline configuration.
+   *
+   * <p><b>Why FAIL_ON_UNKNOWN_PROPERTIES is disabled:</b> the prior serialization library (flexjson 2.1) silently
+   * ignored unknown JSON fields. Disabling this feature preserves that behaviour and prevents breaking existing
+   * clients that may send payloads containing extra or legacy fields (e.g. a {@code "class"} discriminator that
+   * flexjson used to emit).</p>
+   *
+   * <p>To re-enable strict mode in the future, audit every caller to confirm that no client sends fields that are
+   * absent from the target model, then remove this call.</p>
+   *
+   * @return a configured {@link ObjectMapper}; callers may register additional modules before use.
+   */
+  static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
+    return mapper;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/dataaccess/metadata/service/MetadataService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/metadata/service/MetadataService.java
@@ -50,7 +50,8 @@ import org.pentaho.platform.plugin.action.pentahometadata.MetadataQueryComponent
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
 
-import flexjson.JSONSerializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * An object that makes lightweight, serializable metadata models available to callers, and allow queries to be
@@ -62,6 +63,7 @@ import flexjson.JSONSerializer;
 public class MetadataService extends PentahoBase {
 
   private static final long serialVersionUID = 8481450224870463494L;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private Log logger = LogFactory.getLog( MetadataService.class );
 
@@ -147,9 +149,7 @@ public class MetadataService extends PentahoBase {
   public String listBusinessModelsJson( String domainName, String context ) throws IOException {
 
     ModelInfo[] models = listBusinessModels( domainName, context );
-    JSONSerializer serializer = new JSONSerializer();
-    String json = serializer.deepSerialize( models );
-    return json;
+    return writeAsJson( models );
   }
 
   /**
@@ -264,9 +264,7 @@ public class MetadataService extends PentahoBase {
   public String loadModelJson( String domainId, String modelId ) {
 
     Model model = loadModel( domainId, modelId );
-    JSONSerializer serializer = new JSONSerializer();
-    String json = serializer.deepSerialize( model );
-    return json;
+    return writeAsJson( model );
   }
 
   /**
@@ -312,9 +310,7 @@ public class MetadataService extends PentahoBase {
     if ( resultSet == null ) {
       return null;
     }
-    JSONSerializer serializer = new JSONSerializer();
-    String json = serializer.deepSerialize( resultSet );
-    return json;
+    return writeAsJson( resultSet );
   }
 
   /**
@@ -430,6 +426,15 @@ public class MetadataService extends PentahoBase {
       error( Messages.getErrorString( "MetadataService.ERROR_0008_BAD_QUERY" ), e ); //$NON-NLS-1$
     }
     return null;
+  }
+
+  private String writeAsJson( Object value ) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString( value );
+    } catch ( JsonProcessingException e ) {
+      error( Messages.getErrorString( "MetadataService.ERROR_0007_JSON_ERROR" ), e ); //$NON-NLS-1$
+      return null;
+    }
   }
 
   /**

--- a/core/src/main/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtil.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtil.java
@@ -53,7 +53,8 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
 
-import flexjson.JSONDeserializer;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * This class provides utility functions used by the MetadataService
@@ -65,6 +66,7 @@ import flexjson.JSONDeserializer;
 public class MetadataServiceUtil extends PentahoBase {
 
   private static final long serialVersionUID = -123835493828427853L;
+  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
 
   private Log logger = LogFactory.getLog( MetadataServiceUtil.class );
 
@@ -380,11 +382,11 @@ public class MetadataServiceUtil extends PentahoBase {
    */
   public Query deserializeJsonQuery( String json ) {
     try {
-      // convert the json query into a thin query model
+      // Convert the JSON query into a thin query model.
       ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
       try {
         Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-        return new JSONDeserializer<Query>().deserialize( json );
+        return OBJECT_MAPPER.readValue( json, Query.class );
       } finally {
         Thread.currentThread().setContextClassLoader( oldLoader );
       }
@@ -392,6 +394,12 @@ public class MetadataServiceUtil extends PentahoBase {
       error( Messages.getErrorString( "MetadataService.ERROR_0007_BAD_JSON", json ), e ); //$NON-NLS-1$
       return null;
     }
+  }
+
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
+    return objectMapper;
   }
 
   @Override

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceRestApiTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionServiceRestApiTest.java
@@ -342,6 +342,27 @@ public class ConnectionServiceRestApiTest {
   }
 
   /**
+   * Verifies deserialization preserves databaseType mapping when using the runtime reader.
+   */
+  @Test
+  public void testJsonDeserializationMapsDatabaseType() throws Exception {
+    String json = "{\"name\":\"conn\",\"databaseType\":{\"shortName\":\"GENERIC\",\"name\":\"Generic\"}}";
+
+    DatabaseConnectionReaderWriter reader = new DatabaseConnectionReaderWriter();
+    DatabaseConnection connection = reader.readFrom(
+      DatabaseConnection.class,
+      null,
+      null,
+      jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE,
+      null,
+      new java.io.ByteArrayInputStream( json.getBytes( java.nio.charset.StandardCharsets.UTF_8 ) )
+    );
+
+    assertNotNull( "Connection should be deserialized", connection );
+    assertNotNull( "DatabaseType should be deserialized", connection.getDatabaseType() );
+  }
+
+  /**
    * Tests getConnectionByName with mask=false (password should be hidden)
    */
   @Test

--- a/core/src/test/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceTest.java
@@ -14,7 +14,6 @@
 package org.pentaho.platform.dataaccess.metadata.service;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -49,6 +48,8 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -83,7 +84,7 @@ public class MetadataServiceTest {
   @Before
   public void initialize() {
 
-    List<Category> categoryList = new ArrayList();
+    List<Category> categoryList = new ArrayList<>();
     Category category = mock( Category.class );
     when( category.getId() ).thenReturn( CATEGORY_ID );
     categoryList.add( category );
@@ -141,16 +142,16 @@ public class MetadataServiceTest {
 
     //Test view permissions
     when( metadataService.hasViewAccess() ).thenReturn( true );
-    Assert.assertThat( metadataService.getDatasourcePermissions(), is( "VIEW" ) );
+    assertEquals( "VIEW", metadataService.getDatasourcePermissions() );
 
     //Test edit permissions
     when( metadataService.hasManageAccess() ).thenReturn( true );
-    Assert.assertThat( metadataService.getDatasourcePermissions(), is( "EDIT" ) );
+    assertEquals( "EDIT", metadataService.getDatasourcePermissions() );
 
     //No permissions test
     when( metadataService.hasViewAccess() ).thenReturn( false );
     when( metadataService.hasManageAccess() ).thenReturn( false );
-    Assert.assertThat( metadataService.getDatasourcePermissions(), is( "NONE" ) );
+    assertEquals( "NONE", metadataService.getDatasourcePermissions() );
 
   }
 
@@ -162,17 +163,17 @@ public class MetadataServiceTest {
 
       ModelInfo[] businessModels = metadataService.listBusinessModels( DOMAIN_ID, "" );
       //Test business models array length
-      Assert.assertTrue( businessModels.length == 2 );
+      assertEquals( 2, businessModels.length );
       //Test business models array sort
-      Assert.assertTrue( businessModels[0].getModelName() == LOGICAL_MODEL_NAME );
-      Assert.assertTrue( businessModels[1].getModelName() == LOGICAL_MODEL_2_NAME );
+      assertEquals( LOGICAL_MODEL_NAME, businessModels[0].getModelName() );
+      assertEquals( LOGICAL_MODEL_2_NAME, businessModels[1].getModelName() );
 
       businessModels = metadataService.listBusinessModels( null, null );
       //Test business models array length
-      Assert.assertTrue( businessModels.length == 2 );
+      assertEquals( 2, businessModels.length );
       //Test business models array sort
-      Assert.assertTrue( businessModels[0].getModelName() == LOGICAL_MODEL_NAME );
-      Assert.assertTrue( businessModels[1].getModelName() == LOGICAL_MODEL_2_NAME );
+      assertEquals( LOGICAL_MODEL_NAME, businessModels[0].getModelName() );
+      assertEquals( LOGICAL_MODEL_2_NAME, businessModels[1].getModelName() );
 
     } catch ( Exception ex ) {
       fail();
@@ -194,7 +195,7 @@ public class MetadataServiceTest {
       String businessModelsJson = metadataService.listBusinessModelsJson( DOMAIN_ID, "" );
 
       com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
-      Assert.assertEquals( objectMapper.readTree( expectedBusinessModelsJson ), objectMapper.readTree( businessModelsJson ) );
+      assertEquals( objectMapper.readTree( expectedBusinessModelsJson ), objectMapper.readTree( businessModelsJson ) );
 
     } catch ( Exception ex ) {
       fail();
@@ -208,11 +209,11 @@ public class MetadataServiceTest {
 
     Model model = metadataService.loadModel( DOMAIN_ID, LOGICAL_MODEL_ID );
     //Test if the name of the model returned is correct
-    Assert.assertTrue( model.getName() == LOGICAL_MODEL_NAME );
+    assertEquals( LOGICAL_MODEL_NAME, model.getName() );
   }
 
   @Test
-  public void testLoadModelJson() {
+  public void testLoadModelJson() throws Exception {
 
     final String expectedModelJson = "{\"categories\":[{\"id\":\"" + CATEGORY_ID
       + "\",\"name\":null,\"description\":null,\"columns\":[]}],\"id\":\"" + LOGICAL_MODEL_ID
@@ -224,7 +225,7 @@ public class MetadataServiceTest {
     String modelJson = metadataService.loadModelJson( DOMAIN_ID, LOGICAL_MODEL_ID );
 
     com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
-    Assert.assertEquals( objectMapper.readTree( expectedModelJson ), objectMapper.readTree( modelJson ) );
+    assertEquals( objectMapper.readTree( expectedModelJson ), objectMapper.readTree( modelJson ) );
   }
 
   @Test
@@ -247,13 +248,13 @@ public class MetadataServiceTest {
     String[] columnName = columnNames.getColumnName();
 
     // Check the result rows lenght
-    Assert.assertTrue( rows.length <= ROWS );
+    assertTrue( rows.length <= ROWS );
 
     // Check the result row value
-    Assert.assertTrue( cell[0].equals( RESULT ) );
+    assertEquals( RESULT, cell[0] );
 
     // Check the result column name
-    Assert.assertTrue( columnName[0].equals( COLUMN_NAME ) );
+    assertEquals( COLUMN_NAME, columnName[0] );
 
 
   }
@@ -281,13 +282,13 @@ public class MetadataServiceTest {
     String[] columnName = columnNames.getColumnName();
 
     // Check the result rows lenght
-    Assert.assertTrue( rows.length <= ROWS );
+    assertTrue( rows.length <= ROWS );
 
     // Check the result row value
-    Assert.assertTrue( cell[0].equals( RESULT ) );
+    assertEquals( RESULT, cell[0] );
 
     // Check the result column name
-    Assert.assertTrue( columnName[0].equals( COLUMN_NAME ) );
+    assertEquals( COLUMN_NAME, columnName[0] );
 
 
   }
@@ -317,7 +318,7 @@ public class MetadataServiceTest {
 
       String queryJson = metadataService.doXmlQueryToCdaJson( xmlQuery, ROWS );
 
-      Assert.assertEquals( expectedQueryJson, queryJson );
+      assertEquals( expectedQueryJson, queryJson );
     } catch ( Exception ex ) {
       fail();
     }

--- a/core/src/test/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceTest.java
@@ -182,11 +182,10 @@ public class MetadataServiceTest {
   @Test
   public void testListBusinessModelsJson() {
 
-    final String expectedBusinessModelsJson = "[{\"class\":\"org.pentaho.platform.dataaccess.metadata.model.impl"
-      + ".ModelInfo\",\"domainId\":\"" + DOMAIN_ID + "\",\"modelDescription\":null,\"modelId\":\"" + LOGICAL_MODEL_ID + "\","
-      + "\"modelName\":\"" + LOGICAL_MODEL_NAME + "\"},{\"class\":\"org.pentaho.platform.dataaccess.metadata.model.impl"
-      + ".ModelInfo\",\"domainId\":\"" + DOMAIN_ID + "\",\"modelDescription\":null,\"modelId\":\"" + LOGICAL_MODEL_2_ID + "\","
-      + "\"modelName\":\"" + LOGICAL_MODEL_2_NAME + "\"}]";
+    final String expectedBusinessModelsJson = "[{\"domainId\":\"" + DOMAIN_ID + "\",\"modelId\":\""
+      + LOGICAL_MODEL_ID + "\",\"modelName\":\"" + LOGICAL_MODEL_NAME + "\",\"modelDescription\":null},"
+      + "{\"domainId\":\"" + DOMAIN_ID + "\",\"modelId\":\"" + LOGICAL_MODEL_2_ID + "\",\"modelName\":\""
+      + LOGICAL_MODEL_2_NAME + "\",\"modelDescription\":null}]";
 
     try {
       when( metadataService.listBusinessModels( anyString(), nullable( String.class ) ) ).thenCallRealMethod();
@@ -194,7 +193,8 @@ public class MetadataServiceTest {
 
       String businessModelsJson = metadataService.listBusinessModelsJson( DOMAIN_ID, "" );
 
-      Assert.assertEquals( expectedBusinessModelsJson, businessModelsJson );
+      com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+      Assert.assertEquals( objectMapper.readTree( expectedBusinessModelsJson ), objectMapper.readTree( businessModelsJson ) );
 
     } catch ( Exception ex ) {
       fail();
@@ -214,17 +214,17 @@ public class MetadataServiceTest {
   @Test
   public void testLoadModelJson() {
 
-    final String expectedModelJson = "{\"categories\":[{\"class\":\"org.pentaho.platform.dataaccess.metadata.model.impl"
-      + ".Category\",\"columns\":[],\"description\":null,\"id\":\"" + CATEGORY_ID + "\",\"name\":null}],\"class\":\"org.pentaho.platform"
-      + ".dataaccess.metadata.model.impl.Model\",\"description\":null,\"domainId\":\"" + DOMAIN_ID + "\",\"id\":\"" + LOGICAL_MODEL_ID
-      + "\",\"name\":\"" + LOGICAL_MODEL_NAME + "\"}";
+    final String expectedModelJson = "{\"categories\":[{\"id\":\"" + CATEGORY_ID
+      + "\",\"name\":null,\"description\":null,\"columns\":[]}],\"id\":\"" + LOGICAL_MODEL_ID
+      + "\",\"name\":\"" + LOGICAL_MODEL_NAME + "\",\"domainId\":\"" + DOMAIN_ID + "\",\"description\":null}";
 
     when( metadataService.loadModel( anyString(), anyString() ) ).thenCallRealMethod();
     when( metadataService.loadModelJson( anyString(), anyString() ) ).thenCallRealMethod();
 
     String modelJson = metadataService.loadModelJson( DOMAIN_ID, LOGICAL_MODEL_ID );
 
-    Assert.assertEquals( expectedModelJson, modelJson );
+    com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+    Assert.assertEquals( objectMapper.readTree( expectedModelJson ), objectMapper.readTree( modelJson ) );
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <pdi.version>11.1.0.0-SNAPSHOT</pdi.version>
     <jcommon.version>1.0.14</jcommon.version>
     <stax.version>1.2.0</stax.version>
-    <flexjson.version>2.1</flexjson.version>
     <ognl.version>2.6.9</ognl.version>
     <encoder.version>1.2</encoder.version>
     <pentaho-cwm.version>1.5.4</pentaho-cwm.version>
@@ -275,17 +274,6 @@
         <groupId>com.ibm.icu</groupId>
         <artifactId>icu4j-charsets</artifactId>
         <version>${icu4j-charsets.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>net.sf.flexjson</groupId>
-        <artifactId>flexjson</artifactId>
-        <version>${flexjson.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>


### PR DESCRIPTION
## Summary

- Dependency: flexjson
- Target version: removal (replaced with com.fasterxml.jackson)
- Change type: library replacement

## Validation

- Base branch: master
- Maven build: passed

## Notes

- MetadataService.java: migrated listBusinessModelsJson, loadModelJson, doXmlQueryToJson to ObjectMapper
- MetadataServiceUtil.java: migrated deserializeJsonQuery to ObjectMapper with FAIL_ON_UNKNOWN_PROPERTIES disabled
- Test expectations updated to reflect Jackson output (no class field, alphabetical field ordering)
- All pom.xml flexjson properties and dependencies removed