### PR TITLE
[FUSE-562] Integrate CMS with pentaho-server's connection repository

### DIFF
--- a/api/src/main/resources/connection-api.yaml
+++ b/api/src/main/resources/connection-api.yaml
@@ -480,6 +480,10 @@ components:
           type: string
           description: Connection name
           example: "Production Database"
+        connectionId:
+          type: string
+          description: Connection Id from the connection-management-service
+          example: "2d3ccecc-93a4-4fa8-957e-925dca9b4a81"
         accessType:
           type: string
           description: Database access type (e.g., NATIVE, ODBC, OCI, POOL)

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ConnectionService.java
@@ -566,6 +566,7 @@ public class ConnectionService implements ConnectionsApi {
 
     responseConnection.setId( connection.getId() );
     responseConnection.setName( connection.getName() );
+    responseConnection.setConnectionId( connection.getConnectionId() );
     responseConnection.setHostname( connection.getHostname() );
     responseConnection.setDatabaseName( connection.getDatabaseName() );
     responseConnection.setDatabasePort( connection.getDatabasePort() );


### PR DESCRIPTION
### [FUSE-562](https://hv-eng.atlassian.net/browse/FUSE-562)

In order to add support of the [connection-management-service](https://github.com/pentaho/connection-management-service)'s connections to the data-access service, we need to add a new field to the request payload which will specify the connection Id from the connection-management-service. This Id will later be used to retrieve actual connection metadata and perform requested operations.

### What was changed?

Added new field to the IDatabaseConnection interface and to the ConnectionService's fields mapper.

[FUSE-562]: https://hv-eng.atlassian.net/browse/FUSE-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ