### PR TITLE
[PPP-6549] CVE fix: CVE-2016-3093 in ognl:ognl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <pdi.version>11.1.0.0-SNAPSHOT</pdi.version>
     <jcommon.version>1.0.14</jcommon.version>
     <stax.version>1.2.0</stax.version>
-    <ognl.version>2.6.9</ognl.version>
+    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix, 3.0.21) -->
     <encoder.version>1.2</encoder.version>
     <pentaho-cwm.version>1.5.4</pentaho-cwm.version>
     <maven-failsafe-plugin.reuseForks>false</maven-failsafe-plugin.reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <pdi.version>11.1.0.0-SNAPSHOT</pdi.version>
     <jcommon.version>1.0.14</jcommon.version>
     <stax.version>1.2.0</stax.version>
-    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix, 3.0.21) -->
+    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix) -->
     <encoder.version>1.2</encoder.version>
     <pentaho-cwm.version>1.5.4</pentaho-cwm.version>
     <maven-failsafe-plugin.reuseForks>false</maven-failsafe-plugin.reuseForks>


### PR DESCRIPTION
## CVE fix: CVE-2016-3093 in ognl:ognl

Advisory: CVE-2016-3093 -- OGNL < 3.0.12 DoS (CWE-20), CVSS 5.3 MEDIUM. Fixed upstream in OGNL 3.0.12.

Change: removes the local `<ognl.version>2.6.9</ognl.version>` property override in the root `pom.xml` so it now inherits the centralized fix (`3.0.21`) from `pentaho-ce-jar-parent-pom` (see pentaho/maven-parent-poms#899).

No direct OGNL API usage in this repo -- companion fix in pentaho/pentaho-kettle (the one repo with real OGNL code usage).

### Proof
`mvn help:evaluate -Dexpression=ognl.version` on the root module now returns `3.0.21` (was `2.6.9` before this change).

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.