### PR TITLE
fix[BACKLOG-50609]: Register Jackson abstract-type resolver for IDatabaseType

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionListReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionListReaderWriter.java
@@ -16,8 +16,6 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,10 +33,6 @@ import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.Provider;
 
-import org.pentaho.database.model.DatabaseConnection;
-import org.pentaho.database.model.DatabaseType;
-import org.pentaho.database.model.IDatabaseConnection;
-import org.pentaho.database.model.IDatabaseType;
 import org.pentaho.ui.database.event.DefaultDatabaseConnectionList;
 import org.pentaho.ui.database.event.IDatabaseConnectionList;
 
@@ -51,18 +45,7 @@ import org.pentaho.ui.database.event.IDatabaseConnectionList;
 public class DatabaseConnectionListReaderWriter
   implements MessageBodyReader<IDatabaseConnectionList>, MessageBodyWriter<IDatabaseConnectionList> {
 
-  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
-
-  private static ObjectMapper createObjectMapper() {
-    ObjectMapper mapper = JacksonObjectMapperUtil.createObjectMapper();
-    SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
-    resolver.addMapping( IDatabaseConnection.class, DatabaseConnection.class );
-    resolver.addMapping( IDatabaseType.class, DatabaseType.class );
-    SimpleModule module = new SimpleModule();
-    module.setAbstractTypes( resolver );
-    mapper.registerModule( module );
-    return mapper;
-  }
+  private static final ObjectMapper OBJECT_MAPPER = JacksonObjectMapperUtil.createDatabaseConnectionObjectMapper();
 
   @Override
   public long getSize( IDatabaseConnectionList t, Class<?> type, Type genericType, Annotation[] annotations,

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionReaderWriter.java
@@ -16,8 +16,6 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,9 +34,7 @@ import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.Provider;
 
 import org.pentaho.database.model.DatabaseConnection;
-import org.pentaho.database.model.DatabaseType;
 import org.pentaho.database.model.IDatabaseConnection;
-import org.pentaho.database.model.IDatabaseType;
 
 /**
  * Reads and writes Database Connection objects using Jackson so that they won't lose map values when converting
@@ -49,17 +45,7 @@ import org.pentaho.database.model.IDatabaseType;
 public class DatabaseConnectionReaderWriter
   implements MessageBodyReader<DatabaseConnection>, MessageBodyWriter<DatabaseConnection> {
 
-  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
-
-  private static ObjectMapper createObjectMapper() {
-    ObjectMapper mapper = JacksonObjectMapperUtil.createObjectMapper();
-    SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
-    resolver.addMapping( IDatabaseType.class, DatabaseType.class );
-    SimpleModule module = new SimpleModule();
-    module.setAbstractTypes( resolver );
-    mapper.registerModule( module );
-    return mapper;
-  }
+  private static final ObjectMapper OBJECT_MAPPER = JacksonObjectMapperUtil.createDatabaseTypeObjectMapper();
 
   @Override
   public long getSize( DatabaseConnection t, Class<?> type, Type genericType, Annotation[] annotations,

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriter.java
@@ -14,6 +14,10 @@
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.pentaho.database.model.DatabaseType;
+import org.pentaho.database.model.IDatabaseType;
 import org.pentaho.ui.database.event.DefaultDatabaseTypesList;
 import org.pentaho.ui.database.event.IDatabaseTypesList;
 
@@ -42,7 +46,17 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 @Produces( APPLICATION_JSON )
 public class DatabaseTypesListReaderWriter implements MessageBodyReader<IDatabaseTypesList>, MessageBodyWriter<IDatabaseTypesList> {
 
-  private static final ObjectMapper OBJECT_MAPPER = JacksonObjectMapperUtil.createObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
+
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = JacksonObjectMapperUtil.createObjectMapper();
+    SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
+    resolver.addMapping( IDatabaseType.class, DatabaseType.class );
+    SimpleModule module = new SimpleModule();
+    module.setAbstractTypes( resolver );
+    mapper.registerModule( module );
+    return mapper;
+  }
 
   @Override
   public long getSize( IDatabaseTypesList t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType ) {

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriter.java
@@ -14,8 +14,6 @@
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.pentaho.database.model.DatabaseType;
-import org.pentaho.database.model.IDatabaseType;
 import org.pentaho.ui.database.event.DefaultDatabaseTypesList;
 import org.pentaho.ui.database.event.IDatabaseTypesList;
 

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriter.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriter.java
@@ -14,8 +14,6 @@
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.pentaho.database.model.DatabaseType;
 import org.pentaho.database.model.IDatabaseType;
 import org.pentaho.ui.database.event.DefaultDatabaseTypesList;
@@ -46,17 +44,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 @Produces( APPLICATION_JSON )
 public class DatabaseTypesListReaderWriter implements MessageBodyReader<IDatabaseTypesList>, MessageBodyWriter<IDatabaseTypesList> {
 
-  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
-
-  private static ObjectMapper createObjectMapper() {
-    ObjectMapper mapper = JacksonObjectMapperUtil.createObjectMapper();
-    SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
-    resolver.addMapping( IDatabaseType.class, DatabaseType.class );
-    SimpleModule module = new SimpleModule();
-    module.setAbstractTypes( resolver );
-    mapper.registerModule( module );
-    return mapper;
-  }
+  private static final ObjectMapper OBJECT_MAPPER = JacksonObjectMapperUtil.createDatabaseTypeObjectMapper();
 
   @Override
   public long getSize( IDatabaseTypesList t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType ) {

--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/JacksonObjectMapperUtil.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/JacksonObjectMapperUtil.java
@@ -15,6 +15,13 @@ package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.pentaho.database.model.DatabaseConnection;
+import org.pentaho.database.model.DatabaseType;
+import org.pentaho.database.model.IDatabaseConnection;
+import org.pentaho.database.model.IDatabaseType;
 
 /**
  * Factory for pre-configured {@link ObjectMapper} instances used by JAX-RS reader/writer providers in this package.
@@ -41,6 +48,39 @@ class JacksonObjectMapperUtil {
   static ObjectMapper createObjectMapper() {
     ObjectMapper mapper = new ObjectMapper();
     mapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
+    return mapper;
+  }
+
+  /**
+   * Baseline mapper that can deserialize {@link IDatabaseType}-typed fields into their concrete
+   * {@link DatabaseType} implementation.
+   *
+   * @return a configured {@link ObjectMapper} with the {@code IDatabaseType -> DatabaseType} abstract-type mapping.
+   */
+  static ObjectMapper createDatabaseTypeObjectMapper() {
+    SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
+    resolver.addMapping( IDatabaseType.class, DatabaseType.class );
+    return withAbstractTypes( resolver );
+  }
+
+  /**
+   * Baseline mapper that can deserialize {@link IDatabaseConnection}- and {@link IDatabaseType}-typed fields into
+   * their concrete {@link DatabaseConnection} and {@link DatabaseType} implementations.
+   *
+   * @return a configured {@link ObjectMapper} with the connection and type abstract-type mappings.
+   */
+  static ObjectMapper createDatabaseConnectionObjectMapper() {
+    SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
+    resolver.addMapping( IDatabaseConnection.class, DatabaseConnection.class );
+    resolver.addMapping( IDatabaseType.class, DatabaseType.class );
+    return withAbstractTypes( resolver );
+  }
+
+  private static ObjectMapper withAbstractTypes( SimpleAbstractTypeResolver resolver ) {
+    ObjectMapper mapper = createObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.setAbstractTypes( resolver );
+    mapper.registerModule( module );
     return mapper;
   }
 }

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionListReaderWriterTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionListReaderWriterTest.java
@@ -1,0 +1,78 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.Test;
+import org.pentaho.database.model.DatabaseConnection;
+import org.pentaho.database.model.DatabaseType;
+import org.pentaho.database.model.IDatabaseConnection;
+import org.pentaho.ui.database.event.DefaultDatabaseConnectionList;
+import org.pentaho.ui.database.event.IDatabaseConnectionList;
+
+/**
+ * Regression coverage for {@link DatabaseConnectionListReaderWriter} (same interface-deserialization
+ * concern as the BACKLOG-50609 / PPP-6483 flexjson &rarr; Jackson migration).
+ *
+ * <p>{@link DefaultDatabaseConnectionList#getDatabaseConnections()} is a {@code List<IDatabaseConnection>}
+ * and each connection exposes an {@code IDatabaseType} (both interfaces). The reader/writer therefore
+ * relies on {@code JacksonObjectMapperUtil.createDatabaseConnectionObjectMapper()}, which registers the
+ * {@code IDatabaseConnection -> DatabaseConnection} and {@code IDatabaseType -> DatabaseType} abstract-type
+ * mappings.</p>
+ *
+ * <p>Given a connection list holding a {@link DatabaseConnection} that references a {@link DatabaseType},<br>
+ * When it is written and then read back through {@link DatabaseConnectionListReaderWriter},<br>
+ * Then the connection and its nested database type survive the round trip.</p>
+ */
+public class DatabaseConnectionListReaderWriterTest {
+
+  @Test
+  public void readFromPopulatedConnectionListRoundTrips() throws Exception {
+    // Given
+    DatabaseType type = new DatabaseType( "MySQL", "mysql", Collections.emptyList(), 3306, null );
+    DatabaseConnection connection = new DatabaseConnection();
+    connection.setName( "myConnection" );
+    connection.setDatabaseType( type );
+
+    DefaultDatabaseConnectionList list = new DefaultDatabaseConnectionList();
+    list.setDatabaseConnections( Collections.singletonList( connection ) );
+
+    DatabaseConnectionListReaderWriter readerWriter = new DatabaseConnectionListReaderWriter();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    readerWriter.writeTo( list, IDatabaseConnectionList.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, out );
+
+    // When
+    IDatabaseConnectionList result = readerWriter.readFrom( IDatabaseConnectionList.class, null, null,
+      MediaType.APPLICATION_JSON_TYPE, null, new ByteArrayInputStream( out.toByteArray() ) );
+
+    // Then
+    assertNotNull( result );
+    assertNotNull( result.getDatabaseConnections() );
+    assertEquals( 1, result.getDatabaseConnections().size() );
+
+    IDatabaseConnection restored = result.getDatabaseConnections().get( 0 );
+    assertEquals( "myConnection", restored.getName() );
+    assertNotNull( restored.getDatabaseType() );
+    assertEquals( "MySQL", restored.getDatabaseType().getName() );
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionReaderWriterTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseConnectionReaderWriterTest.java
@@ -1,0 +1,66 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.Test;
+import org.pentaho.database.model.DatabaseConnection;
+import org.pentaho.database.model.DatabaseType;
+
+/**
+ * Regression coverage for {@link DatabaseConnectionReaderWriter} (same interface-deserialization
+ * concern as the BACKLOG-50609 / PPP-6483 flexjson &rarr; Jackson migration).
+ *
+ * <p>{@link DatabaseConnection#getDatabaseType()} is typed as the {@code IDatabaseType} interface, so the
+ * reader/writer relies on {@code JacksonObjectMapperUtil.createDatabaseTypeObjectMapper()} to resolve it to
+ * the concrete {@link DatabaseType} on read.</p>
+ *
+ * <p>Given a {@link DatabaseConnection} that references a {@link DatabaseType},<br>
+ * When it is written and then read back through {@link DatabaseConnectionReaderWriter},<br>
+ * Then the connection and its nested database type survive the round trip.</p>
+ */
+public class DatabaseConnectionReaderWriterTest {
+
+  @Test
+  public void readFromConnectionWithDatabaseTypeRoundTrips() throws Exception {
+    // Given
+    DatabaseType type = new DatabaseType( "MySQL", "mysql", Collections.emptyList(), 3306, null );
+    DatabaseConnection connection = new DatabaseConnection();
+    connection.setName( "myConnection" );
+    connection.setDatabaseType( type );
+
+    DatabaseConnectionReaderWriter readerWriter = new DatabaseConnectionReaderWriter();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    readerWriter.writeTo( connection, DatabaseConnection.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, out );
+
+    // When
+    DatabaseConnection result = readerWriter.readFrom( DatabaseConnection.class, null, null,
+      MediaType.APPLICATION_JSON_TYPE, null, new ByteArrayInputStream( out.toByteArray() ) );
+
+    // Then
+    assertNotNull( result );
+    assertEquals( "myConnection", result.getName() );
+    assertNotNull( result.getDatabaseType() );
+    assertEquals( "MySQL", result.getDatabaseType().getName() );
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriterTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriterTest.java
@@ -1,0 +1,71 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+
+import jakarta.ws.rs.core.MediaType;
+
+import org.junit.Test;
+import org.pentaho.database.model.DatabaseType;
+import org.pentaho.ui.database.event.DefaultDatabaseTypesList;
+import org.pentaho.ui.database.event.IDatabaseTypesList;
+
+/**
+ * PPP-6483 at-risk validation for {@link DatabaseTypesListReaderWriter}.
+ *
+ * <p>The reader deserializes into {@link DefaultDatabaseTypesList}, whose {@code types} field is
+ * declared as {@code List<IDatabaseType>} (an interface). The Jackson mapper created by
+ * {@code JacksonObjectMapperUtil.createObjectMapper()} registers <em>no</em> abstract-type
+ * resolver, unlike the sibling connection reader/writers.</p>
+ *
+ * <p>Given a {@code DefaultDatabaseTypesList} that contains a concrete {@link DatabaseType},<br>
+ * When it is written and then read back through {@link DatabaseTypesListReaderWriter},<br>
+ * Then the type should survive the round trip.</p>
+ *
+ * <p>Expected result: FAIL &mdash; deserializing a populated {@code List<IDatabaseType>} without a
+ * resolver throws {@code InvalidDefinitionException} (same root cause as BACKLOG-50609). This is a
+ * latent defect: today the read path is only exercised server&rarr;client, but the code is
+ * reachable and incorrect.</p>
+ */
+public class DatabaseTypesListReaderWriterTest {
+
+  @Test
+  public void readFromPopulatedTypesListRoundTrips() throws Exception {
+    // Given
+    DatabaseType type = new DatabaseType( "MySQL", "mysql", Collections.emptyList(), 3306, null );
+    DefaultDatabaseTypesList list = new DefaultDatabaseTypesList();
+    list.setDbTypes( Collections.singletonList( type ) );
+
+    DatabaseTypesListReaderWriter readerWriter = new DatabaseTypesListReaderWriter();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    readerWriter.writeTo( list, IDatabaseTypesList.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, out );
+
+    // When
+    IDatabaseTypesList result = readerWriter.readFrom( IDatabaseTypesList.class, null, null,
+      MediaType.APPLICATION_JSON_TYPE, null, new ByteArrayInputStream( out.toByteArray() ) );
+
+    // Then
+    assertNotNull( result );
+    assertNotNull( result.getDbTypes() );
+    assertEquals( 1, result.getDbTypes().size() );
+    assertEquals( "MySQL", result.getDbTypes().get( 0 ).getName() );
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriterTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatabaseTypesListReaderWriterTest.java
@@ -28,21 +28,22 @@ import org.pentaho.ui.database.event.DefaultDatabaseTypesList;
 import org.pentaho.ui.database.event.IDatabaseTypesList;
 
 /**
- * PPP-6483 at-risk validation for {@link DatabaseTypesListReaderWriter}.
+ * BACKLOG-50609 regression coverage for {@link DatabaseTypesListReaderWriter} (root cause: the
+ * PPP-6483 flexjson &rarr; Jackson migration).
  *
  * <p>The reader deserializes into {@link DefaultDatabaseTypesList}, whose {@code types} field is
- * declared as {@code List<IDatabaseType>} (an interface). The Jackson mapper created by
- * {@code JacksonObjectMapperUtil.createObjectMapper()} registers <em>no</em> abstract-type
- * resolver, unlike the sibling connection reader/writers.</p>
+ * declared as {@code List<IDatabaseType>} (an interface). {@link DatabaseTypesListReaderWriter} now
+ * registers an {@code IDatabaseType -> DatabaseType} abstract-type mapping on its {@code ObjectMapper},
+ * matching the sibling connection reader/writers.</p>
  *
  * <p>Given a {@code DefaultDatabaseTypesList} that contains a concrete {@link DatabaseType},<br>
  * When it is written and then read back through {@link DatabaseTypesListReaderWriter},<br>
- * Then the type should survive the round trip.</p>
+ * Then the type survives the round trip.</p>
  *
- * <p>Expected result: FAIL &mdash; deserializing a populated {@code List<IDatabaseType>} without a
- * resolver throws {@code InvalidDefinitionException} (same root cause as BACKLOG-50609). This is a
- * latent defect: today the read path is only exercised server&rarr;client, but the code is
- * reachable and incorrect.</p>
+ * <p>Before the fix this failed: deserializing a populated {@code List<IDatabaseType>} without a
+ * resolver threw {@code InvalidDefinitionException} (same root cause as the interactive-reporting
+ * {@code ThinDataSource} regression). It was a latent defect &mdash; the read path is only exercised
+ * server&rarr;client &mdash; but the code was reachable and incorrect.</p>
  */
 public class DatabaseTypesListReaderWriterTest {
 

--- a/core/src/test/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtilQueryDeserializationTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtilQueryDeserializationTest.java
@@ -1,0 +1,70 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.platform.dataaccess.metadata.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.pentaho.platform.dataaccess.metadata.model.impl.Column;
+import org.pentaho.platform.dataaccess.metadata.model.impl.Query;
+
+/**
+ * PPP-6483 at-risk validation for {@link MetadataServiceUtil#deserializeJsonQuery(String)}.
+ *
+ * <p>After the Flexjson &rarr; Jackson migration this method reads a JSON payload into the
+ * <em>thin</em> {@link org.pentaho.platform.dataaccess.metadata.model.impl.Query} model with a
+ * bare {@code ObjectMapper} (no abstract-type resolver). This test verifies whether that thin
+ * model is polymorphic (and therefore vulnerable to the {@code InvalidDefinitionException} seen
+ * in BACKLOG-50609) or flat (and therefore safe).</p>
+ *
+ * <p>Given a serialized thin {@code Query} that carries a {@code Column},<br>
+ * When it is deserialized through {@code deserializeJsonQuery},<br>
+ * Then the query and its column should be preserved.</p>
+ *
+ * <p>Expected result: PASS &mdash; the thin {@code Query} graph
+ * ({@code Column}/{@code Condition}/{@code Order}/{@code Parameter}) is composed of concrete
+ * String-based fields with no interface/abstract members, so Jackson can deserialize it.</p>
+ */
+public class MetadataServiceUtilQueryDeserializationTest {
+
+  @Test
+  public void deserializeJsonQueryPreservesColumns() throws Exception {
+    // Given
+    Query query = new Query();
+    query.setDomainName( "domain1" );
+    query.setModelId( "model1" );
+    Column column = new Column();
+    column.setId( "col1" );
+    column.setName( "Column One" );
+    column.setCategory( "cat1" );
+    column.setType( "STRING" );
+    query.setColumns( new Column[] { column } );
+
+    String json = new ObjectMapper().writeValueAsString( query );
+
+    // When
+    Query result = new MetadataServiceUtil().deserializeJsonQuery( json );
+
+    // Then
+    assertNotNull( "deserializeJsonQuery returned null (deserialization failed)", result );
+    assertEquals( "domain1", result.getDomainName() );
+    assertEquals( "model1", result.getModelId() );
+    assertNotNull( result.getColumns() );
+    assertEquals( 1, result.getColumns().length );
+    assertEquals( "col1", result.getColumns()[ 0 ].getId() );
+    assertEquals( "Column One", result.getColumns()[ 0 ].getName() );
+  }
+}


### PR DESCRIPTION
## Summary
Fixes a latent Jackson deserialization defect introduced by the **PPP-6483** flexjson → Jackson migration.

`DatabaseTypesListReaderWriter` deserializes into `DefaultDatabaseTypesList`, whose `types` field is `List<IDatabaseType>` (an interface). The migration wired it to a bare `ObjectMapper` (via `JacksonObjectMapperUtil.createObjectMapper()`) with **no** abstract-type resolver — unlike the sibling `DatabaseConnectionListReaderWriter`. Reading a populated list therefore throws:

```
InvalidDefinitionException: Cannot construct instance of `org.pentaho.database.model.IDatabaseType`
(through reference chain: DefaultDatabaseTypesList["dbTypes"]->java.util.ArrayList[0])
```

This is the same class of regression as the interactive-reporting `ThinDataSource` failure reported in BACKLOG-50609.

## Fix
- Register a `SimpleAbstractTypeResolver` mapping `IDatabaseType → DatabaseType`, mirroring the existing `DatabaseConnectionListReaderWriter` pattern.

## Tests (BDD/TDD)
- `DatabaseTypesListReaderWriterTest` — reproduces the failure (red before the fix) and now round-trips a populated types list.
- `MetadataServiceUtilQueryDeserializationTest` — safety-net proving the thin `impl.Query` path (also touched by PPP-6483) is flat and unaffected.

## Root cause
Introduced by the PPP-6483 flexjson → Jackson migration; tracked/fixed under **BACKLOG-50609**.
