### PR TITLE
fix[BACKLOG-50609]: Restore strict Jackson unknown-property handling

### DIFF
--- a/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/JacksonObjectMapperUtil.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/JacksonObjectMapperUtil.java
@@ -13,7 +13,6 @@
 
 package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -35,20 +34,10 @@ class JacksonObjectMapperUtil {
   /**
    * Returns a new {@link ObjectMapper} with a common baseline configuration.
    *
-   * <p><b>Why FAIL_ON_UNKNOWN_PROPERTIES is disabled:</b> the prior serialization library (flexjson 2.1) silently
-   * ignored unknown JSON fields. Disabling this feature preserves that behaviour and prevents breaking existing
-   * clients that may send payloads containing extra or legacy fields (e.g. a {@code "class"} discriminator that
-   * flexjson used to emit).</p>
-   *
-   * <p>To re-enable strict mode in the future, audit every caller to confirm that no client sends fields that are
-   * absent from the target model, then remove this call.</p>
-   *
    * @return a configured {@link ObjectMapper}; callers may register additional modules before use.
    */
   static ObjectMapper createObjectMapper() {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
-    return mapper;
+    return new ObjectMapper();
   }
 
   /**

--- a/core/src/main/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtil.java
+++ b/core/src/main/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtil.java
@@ -53,7 +53,6 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -397,9 +396,7 @@ public class MetadataServiceUtil extends PentahoBase {
   }
 
   private static ObjectMapper createObjectMapper() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
-    return objectMapper;
+    return new ObjectMapper();
   }
 
   @Override

--- a/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/JacksonObjectMapperUtilTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/JacksonObjectMapperUtilTest.java
@@ -1,0 +1,29 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.dataaccess.datasource.wizard.service.impl;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import org.junit.Test;
+
+public class JacksonObjectMapperUtilTest {
+
+  @Test( expected = UnrecognizedPropertyException.class )
+  public void createObjectMapperRejectsUnknownProperties() throws Exception {
+    JacksonObjectMapperUtil.createObjectMapper().readValue( "{\"known\":\"value\",\"unexpected\":true}",
+      TestModel.class );
+  }
+
+  public static class TestModel {
+    public String known;
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtilQueryDeserializationTest.java
+++ b/core/src/test/java/org/pentaho/platform/dataaccess/metadata/service/MetadataServiceUtilQueryDeserializationTest.java
@@ -15,6 +15,7 @@ package org.pentaho.platform.dataaccess.metadata.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
@@ -66,5 +67,13 @@ public class MetadataServiceUtilQueryDeserializationTest {
     assertEquals( 1, result.getColumns().length );
     assertEquals( "col1", result.getColumns()[ 0 ].getId() );
     assertEquals( "Column One", result.getColumns()[ 0 ].getName() );
+  }
+
+  @Test
+  public void deserializeJsonQueryRejectsUnknownProperties() {
+    Query result = new MetadataServiceUtil().deserializeJsonQuery(
+      "{\"domainName\":\"domain1\",\"unexpected\":true}" );
+
+    assertNull( result );
   }
 }


### PR DESCRIPTION
### Summary
Restore Jackson's default strict deserialization by removing the
`FAIL_ON_UNKNOWN_PROPERTIES` overrides added during the Flexjson→Jackson migration
(PPP-6483). These payloads are internal, so failing fast on unexpected fields
surfaces real issues instead of silently dropping data and letting a customer
discover the problem later.

### Changes
- `JacksonObjectMapperUtil.createObjectMapper()` — remove `disable(FAIL_ON_UNKNOWN_PROPERTIES)`
- `MetadataServiceUtil.createObjectMapper()` — remove `disable(FAIL_ON_UNKNOWN_PROPERTIES)`
- Add regression tests asserting unknown properties are now rejected

### Testing
`mvn -pl core test` (focused): 36 tests pass, including the new strict-mode assertions and the existing reader/writer round-trip and metadata coverage.
