### PR TITLE
fix[BACKLOG-43744]: remove duplicate commons-text dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -624,11 +624,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>pentaho</groupId>
       <artifactId>metastore</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Summary
- Remove the duplicate test-scoped `org.apache.commons:commons-text` declaration from `core/pom.xml`.
- Retain the existing versioned compile-scoped dependency required by production classes.

## Validation
- `mvn --batch-mode -f pom.xml -pl core compile -DskipTests`
  - BUILD SUCCESS

Fixes the `org.apache.commons.text` compile errors reported by the data-access-plugin build after #1369 was merged.