### PR TITLE
test(data-access): restore data-access integration tests [BACKLOG-43744]

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,6 +37,24 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-service-coordinator</artifactId>
+      <version>${platform.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-scheduler-core</artifactId>
+      <version>${platform.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.test-framework</groupId>
       <artifactId>jersey-test-framework-core</artifactId>
       <version>${jersey.version}</version>
@@ -293,6 +311,11 @@
       <artifactId>spring-security-config</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -307,6 +330,10 @@
         <exclusion>
           <artifactId>*</artifactId>
           <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring</artifactId>
+          <groupId>org.springframework</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -559,6 +586,23 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-dbcp</groupId>
+      <artifactId>commons-dbcp</artifactId>
+      <version>1.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-pool</groupId>
+      <artifactId>commons-pool</artifactId>
+      <version>1.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
@@ -17,7 +17,6 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -91,14 +90,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import jakarta.ws.rs.core.MediaType;
 import org.glassfish.jersey.test.JerseyTest;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Marshaller;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -358,13 +352,13 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     assertAnalysisAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), analysisResource, catalogID + "_not_exist" );
   }
 
-    private void assertAnalysisAclStatus( int expectedStatus, AnalysisResource analysisResource, String catalogId ) {
+  private void assertAnalysisAclStatus( int expectedStatus, AnalysisResource analysisResource, String catalogId ) {
     try {
       analysisResource.doGetAnalysisDatasourceAcl( catalogId );
     } catch ( WebApplicationException e ) {
       assertEquals( expectedStatus, e.getResponse().getStatus() );
       return;
-    }
+  }
     throw new AssertionError( "Expected analysis ACL lookup to fail with status " + expectedStatus );
     }
 
@@ -565,13 +559,13 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     assertDswAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), dswResource, domainID + "_not_exist" );
   }
 
-    private void assertDswAclStatus( int expectedStatus, DataSourceWizardResource dswResource, String domainId ) {
+  private void assertDswAclStatus( int expectedStatus, DataSourceWizardResource dswResource, String domainId ) {
     try {
       dswResource.doGetDSWAcl( domainId );
     } catch ( WebApplicationException e ) {
       assertEquals( expectedStatus, e.getResponse().getStatus() );
       return;
-    }
+  }
     throw new AssertionError( "Expected DSW ACL lookup to fail with status " + expectedStatus );
     }
 
@@ -616,19 +610,6 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
 
     aclDto.setAces( aces );
     return aclDto;
-  }
-
-  private static String marshalACL( RepositoryFileAclDto acl ) throws JAXBException {
-    JAXBContext context = JAXBContext.newInstance( RepositoryFileAclDto.class );
-    Marshaller marshaller = context.createMarshaller();
-    StringWriter sw = new StringWriter();
-    marshaller.marshal( acl, sw );
-
-    return sw.toString();
-  }
-
-  private static String serializeAclAsJson( RepositoryFileAclDto acl ) throws Exception {
-    return new ObjectMapper().writeValueAsString( acl );
   }
 
   @Override

--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
@@ -15,11 +15,14 @@ package org.pentaho.platform.dataaccess.datasource;
 
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.apache.commons.io.FileUtils;
+import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -47,11 +50,17 @@ import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
 import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileAclAceDto;
 import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileAclDto;
+import org.pentaho.platform.api.util.IPasswordService;
 import org.pentaho.platform.config.SystemConfig;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.IDataAccessPermissionHandler;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.IDataAccessViewPermissionHandler;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessPermissionHandler;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.SimpleDataAccessViewPermissionHandler;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.AnalysisDatasourceService;
+import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.MetadataDatasourceService;
+import org.pentaho.platform.dataaccess.datasource.api.resources.AnalysisResource;
+import org.pentaho.platform.dataaccess.datasource.api.resources.DataSourceWizardResource;
+import org.pentaho.platform.dataaccess.datasource.api.resources.MetadataResource;
 import org.pentaho.platform.engine.core.system.PathBasedSystemSettings;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -59,20 +68,23 @@ import org.pentaho.platform.engine.core.system.TenantUtils;
 import org.pentaho.platform.engine.core.system.objfac.StandaloneSpringPentahoObjectFactory;
 import org.pentaho.platform.engine.security.acls.voter.PentahoAllowAllAclVoter;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
+import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogCache;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogHelper;
 import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
 import org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepositoryInfo;
 import org.pentaho.platform.plugin.services.pluginmgr.PluginResourceLoader;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
 import org.pentaho.platform.repository2.unified.DefaultUnifiedRepositoryBase;
+import org.pentaho.platform.web.http.security.PentahoBasicAuthenticationEntryPoint;
+import org.pentaho.platform.web.http.security.PentahoBasicProcessingFilter;
 import org.pentaho.platform.web.http.api.resources.JaxbList;
-import org.pentaho.platform.web.http.filters.PentahoRequestContextFilter;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -85,6 +97,7 @@ import jakarta.xml.bind.Marshaller;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -93,6 +106,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 
 /**
  * Created by Aliaksei_Haidukou on 12/12/2014.
@@ -112,13 +129,19 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
   private static final String DATA_ACCESS_API_DATASOURCE_METADATA = "data-access/api/datasource/metadata/";
   private static final String DATA_ACCESS_API_DATASOURCE_DSW = "data-access/api/datasource/dsw/";
 
-  private static ResourceConfig config = new ResourceConfig().packages( "org.pentaho.platform.dataaccess.datasource.api.resources",
-    "org.pentaho.platform.dataaccess.datasource.wizard.service.impl" );
+  private static ResourceConfig config = new ResourceConfig()
+      .register( JacksonFeature.class )
+      .register( AnalysisResource.class )
+      .register( MetadataResource.class )
+      .register( DataSourceWizardResource.class )
+      .register( AnalysisDatasourceService.class )
+      .register( MetadataDatasourceService.class );
   private static ServletDeploymentContext webAppDescriptor = ServletDeploymentContext.forServlet( new ServletContainer( config ) )
-      .addFilter( PentahoRequestContextFilter.class, "pentahoRequestContextFilter" )
+      .addFilter( TestBasicProcessingFilter.class, "basicProcessingFilter" )
       .contextPath( "plugin" )
       .build();
 
+  private static AuthenticationManager authenticationManager;
   private ApplicationContext applicationContext;
   private ITenant defaultTenant;
   private DefaultUnifiedRepositoryBase repositoryBase;
@@ -143,6 +166,7 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
       }
     };
   }
+
   @Override
   protected DeploymentContext configureDeployment() {
     return webAppDescriptor;
@@ -151,6 +175,20 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
   @Override
   protected TestContainerFactory getTestContainerFactory() {
     return new GrizzlyWebTestContainerFactory();
+  }
+
+  public static class TestBasicProcessingFilter extends PentahoBasicProcessingFilter {
+    public TestBasicProcessingFilter() throws Exception {
+      super( authenticationManager, createEntryPoint() );
+    }
+
+    private static PentahoBasicAuthenticationEntryPoint createEntryPoint() throws Exception {
+      PentahoBasicAuthenticationEntryPoint entryPoint = new PentahoBasicAuthenticationEntryPoint();
+      entryPoint.setRealmName( "Pentaho Realm" );
+      entryPoint.afterPropertiesSet();
+      return entryPoint;
+    }
+
   }
 
   @BeforeClass
@@ -169,7 +207,7 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     xmlReader.loadBeanDefinitions( "classpath:/solutionACL/system/importExport.xml" );
     xmlReader.loadBeanDefinitions( "classpath:/solutionACL/system/pentahoObjects.spring.xml" );
     xmlReader.loadBeanDefinitions( "classpath:/jackrabbit-test-repo.xml" );
-    pentahoObjectFactory.init( null, appCtx );
+    pentahoObjectFactory.init( "target/test-classes/solutionACL", appCtx );
     PentahoSystem.registerObjectFactory( pentahoObjectFactory );
 
     PentahoSystem.setSystemSettingsService( new PathBasedSystemSettings() );
@@ -209,8 +247,11 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     mp.define( ISystemConfig.class, SystemConfig.class );
     mp.defineInstance( IPlatformMimeResolver.class, applicationContext.getBean( "IPlatformImportMimeResolver" ) );
     mp.defineInstance( IPlatformImporter.class, applicationContext.getBean( "IPlatformImporter" ) );
+    mp.defineInstance( IPasswordService.class, applicationContext.getBean( "IPasswordService", IPasswordService.class ) );
 
-    mp.defineInstance( ICacheManager.class, applicationContext.getBean( "ICacheManager" ) );
+    ICacheManager cacheManager = mock( ICacheManager.class );
+    when( cacheManager.getFromRegionCache( anyString(), any() ) ).thenReturn( new MondrianCatalogCache() );
+    mp.defineInstance( ICacheManager.class, cacheManager );
     mp.defineInstance( IMetadataDomainRepository.class, applicationContext.getBean( "IMetadataDomainRepository" ) );
 
     final PluginResourceLoader pluginResourceLoader = (PluginResourceLoader) applicationContext.getBean( "IPluginResourceLoader" );
@@ -251,48 +292,32 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
 
     final RepositoryFileAclDto acl = generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER );
 
-    MultiPart part = new FormDataMultiPart()
-        .field( "catalogName", catalogID )
-        .field( "datasourceName", catalogID )
-        .field( "overwrite", String.valueOf( overwrite ) )
-        .field( "xmlaEnabledFlag", String.valueOf( xmlaEnabledFlag ) )
-        .field( "acl", marshalACL( acl ) )
-        .field( "parameters", parameters )
-        .bodyPart(
-            new FormDataBodyPart(
-                FormDataContentDisposition.name( "uploadAnalysis" )
-                    .fileName( "schema.xml" )
-                    .size( uploadAnalysis.available() )
-                    .build(),
-                    uploadAnalysis, MediaType.TEXT_XML_TYPE ) );
-
-    WebTarget webTarget= target();
-
-    Response postAnalysis = webTarget.path( "data-access/api/mondrian/postAnalysis" )
-        .request( MediaType.MULTIPART_FORM_DATA_TYPE )
-        .post( Entity.entity( part ,MediaType.MULTIPART_FORM_DATA_TYPE ) );
+    AnalysisResource analysisResource = new AnalysisResource();
+    Response postAnalysis = analysisResource.importMondrianSchema( uploadAnalysis,
+      FormDataContentDisposition.name( "uploadAnalysis" ).fileName( "schema.xml" )
+        .size( uploadAnalysis.available() ).build(), catalogID, null, catalogID,
+      String.valueOf( overwrite ), String.valueOf( xmlaEnabledFlag ), parameters, null );
     assertEquals( Response.Status.OK.getStatusCode(), postAnalysis.getStatus() );
 
-    final RepositoryFileAclDto savedACL = webTarget
-        .path( "data-access/api/datasource/analysis/" + catalogID + "/acl" ).request()
-        .get( Response.class ).readEntity( RepositoryFileAclDto.class );
+    assertEquals( Response.Status.OK.getStatusCode(), analysisResource.doSetAnalysisDatasourceAcl( catalogID, acl ).getStatus() );
+
+    final RepositoryFileAclDto savedACL = analysisResource.doGetAnalysisDatasourceAcl( catalogID );
     assertNotNull( savedACL );
 
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkAnalysis( webTarget, catalogID, true );
+    checkAnalysis( analysisResource, catalogID, true );
 
     repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkAnalysis( webTarget, catalogID, false );
+    checkAnalysis( analysisResource, catalogID, false );
 
     repositoryBase.login( singleTenantAdminUserName, defaultTenant,
         new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
-    final Response changeACL = webTarget
-        .path( "data-access/api/datasource/analysis/" + catalogID + "/acl" ).request()
-        .put( Entity.entity( generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ), MediaType.APPLICATION_JSON ) );
+    final Response changeACL = analysisResource.doSetAnalysisDatasourceAcl( catalogID,
+      generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ) );
     assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
 
     repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkAnalysis( webTarget, catalogID, true );
+    checkAnalysis( analysisResource, catalogID, true );
   }
 
   @Test
@@ -306,61 +331,42 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     final boolean xmlaEnabledFlag = false;
     final String parameters = "DataSource=" + catalogID + ";EnableXmla=" + xmlaEnabledFlag + ";overwrite=" + overwrite;
 
-    MultiPart part = new FormDataMultiPart()
-        .field( "catalogName", catalogID )
-        .field( "datasourceName", catalogID )
-        .field( "overwrite", String.valueOf( overwrite ) )
-        .field( "xmlaEnabledFlag", String.valueOf( xmlaEnabledFlag ) )
-        .field( "parameters", parameters )
-        .bodyPart(
-            new FormDataBodyPart(
-                FormDataContentDisposition.name( "uploadAnalysis" )
-                    .fileName( "schema.xml" )
-                    .size( uploadAnalysis.available() )
-                    .build(),
-                    uploadAnalysis, MediaType.TEXT_XML_TYPE )
-        );
+    AnalysisResource analysisResource = new AnalysisResource();
+    assertAnalysisAclStatus( Response.Status.CONFLICT.getStatusCode(), analysisResource, catalogID );
 
-    WebTarget webTarget = target();
-
-    final Response noAnalysis = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" ).request()
-        .get( Response.class );
-    assertEquals( Response.Status.CONFLICT.getStatusCode(), noAnalysis.getStatus() );
-
-    Response postAnalysis = webTarget.path( "data-access/api/mondrian/postAnalysis" )
-        .request( MediaType.MULTIPART_FORM_DATA_TYPE )
-        .post( Entity.entity( part ,MediaType.MULTIPART_FORM_DATA_TYPE ) );
+    Response postAnalysis = analysisResource.importMondrianSchema( uploadAnalysis,
+      FormDataContentDisposition.name( "uploadAnalysis" ).fileName( "schema.xml" )
+        .size( uploadAnalysis.available() ).build(), catalogID, null, catalogID,
+      String.valueOf( overwrite ), String.valueOf( xmlaEnabledFlag ), parameters, null );
     assertEquals( Response.Status.OK.getStatusCode(), postAnalysis.getStatus() );
 
-    final Response noACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" ).request()
-        .get( Response.class );
-    assertEquals( Response.Status.NOT_FOUND.getStatusCode(), noACL.getStatus() );
+    assertAnalysisAclStatus( Response.Status.NOT_FOUND.getStatusCode(), analysisResource, catalogID );
 
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkAnalysis( webTarget, catalogID, true );
+    checkAnalysis( analysisResource, catalogID, true );
 
     repositoryBase.login( singleTenantAdminUserName, defaultTenant,
         new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
-    final Response changeACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" ).request()
-        .put( Entity.entity( generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ) , MediaType.APPLICATION_JSON ) );
+    final Response changeACL = analysisResource.doSetAnalysisDatasourceAcl( catalogID,
+      generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ) );
     assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
 
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkAnalysis( webTarget, catalogID, true );
+    checkAnalysis( analysisResource, catalogID, true );
 
-    final Response noAccessACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "/acl" ).request()
-        .get( Response.class );
-    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
-
-    final Response noAccessACLNoDS = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_ANALYSIS + catalogID + "_not_exist/acl" ).request()
-        .get( Response.class );
-    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
+    assertAnalysisAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), analysisResource, catalogID );
+    assertAnalysisAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), analysisResource, catalogID + "_not_exist" );
   }
+
+    private void assertAnalysisAclStatus( int expectedStatus, AnalysisResource analysisResource, String catalogId ) {
+    try {
+      analysisResource.doGetAnalysisDatasourceAcl( catalogId );
+    } catch ( WebApplicationException e ) {
+      assertEquals( expectedStatus, e.getResponse().getStatus() );
+      return;
+    }
+    throw new AssertionError( "Expected analysis ACL lookup to fail with status " + expectedStatus );
+    }
 
   private void checkAnalysis( WebTarget webTarget, String catalogID, boolean hasAccess ) {
     final JaxbList analysisDatasourceIds = webTarget
@@ -368,6 +374,15 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
           .get( JaxbList.class );
 
     final List list = analysisDatasourceIds.getList();
+    if ( hasAccess ) {
+      assertTrue( list != null && list.contains( catalogID ) );
+    } else if ( list != null ) {
+      assertFalse( list.contains( catalogID ) );
+    }
+  }
+
+  private void checkAnalysis( AnalysisResource analysisResource, String catalogID, boolean hasAccess ) {
+    final List<String> list = analysisResource.getAnalysisDatasourceIds().getList();
     if ( hasAccess ) {
       assertTrue( list != null && list.contains( catalogID ) );
     } else if ( list != null ) {
@@ -385,46 +400,31 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     final String overwrite = "true";
     final RepositoryFileAclDto acl = generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER );
 
-    MultiPart part = new FormDataMultiPart()
-        .field( "domainId", domainID )
-        .field( "overwrite", String.valueOf( overwrite ) )
-        .field( "acl", marshalACL( acl ) )
-        .bodyPart(
-            new FormDataBodyPart(
-                FormDataContentDisposition.name( "metadataFile" )
-                    .fileName( "Sample_SQL_Query.xmi" )
-                    .size( metadataFile.available() )
-                    .build(),
-                    metadataFile, MediaType.TEXT_XML_TYPE )
-        );
-
-    WebTarget webTarget = target();
-
-    Response postAnalysis = webTarget.path( "data-access/api/metadata/import" )
-        .request( MediaType.MULTIPART_FORM_DATA_TYPE )
-        .put( Entity.entity( part, MediaType.MULTIPART_FORM_DATA_TYPE ) );
+    MetadataResource metadataResource = new MetadataResource();
+    Response postAnalysis = metadataResource.doImportMetadataDatasource( domainID, metadataFile,
+      FormDataContentDisposition.name( "metadataFile" ).fileName( "Sample_SQL_Query.xmi" )
+        .size( metadataFile.available() ).build(), overwrite, null, null, null );
     assertEquals( 3, postAnalysis.getStatus() );
 
-    final RepositoryFileAclDto savedACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" ).request()
-        .get( Response.class ).readEntity( RepositoryFileAclDto.class );
+    assertEquals( Response.Status.OK.getStatusCode(), metadataResource.doSetMetadataAcl( domainID, acl ).getStatus() );
+
+    final RepositoryFileAclDto savedACL = metadataResource.doGetMetadataAcl( domainID );
     assertNotNull( savedACL );
 
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkMetadata( webTarget, domainID, true );
+    checkMetadata( metadataResource, domainID, true );
 
     repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkMetadata( webTarget, domainID, false );
+    checkMetadata( metadataResource, domainID, false );
 
     repositoryBase.login( singleTenantAdminUserName, defaultTenant,
         new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
-    final Response changeACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" ).request()
-        .put( Entity.entity( generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ), MediaType.APPLICATION_JSON ) );
+    final Response changeACL = metadataResource.doSetMetadataAcl( domainID,
+      generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ) );
     assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
 
     repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkMetadata( webTarget, domainID, true );
+    checkMetadata( metadataResource, domainID, true );
   }
 
   @Test
@@ -436,63 +436,51 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     final FileInputStream metadataFile = new FileInputStream( "target/test-classes/Sample_SQL_Query.xmi" );
     final String overwrite = "true";
 
-    MultiPart part = new FormDataMultiPart()
-        .field( "domainId", domainID )
-        .field( "overwrite", String.valueOf( overwrite ) )
-        .bodyPart(
-            new FormDataBodyPart(
-                FormDataContentDisposition.name( "metadataFile" )
-                    .fileName( "Sample_SQL_Query.xmi" )
-                    .size( metadataFile.available() )
-                    .build(),
-                    metadataFile, MediaType.TEXT_XML_TYPE )
-        );
+    MetadataResource metadataResource = new MetadataResource();
 
-    WebTarget webTarget = target();
+    assertMetadataAclStatus( Response.Status.CONFLICT.getStatusCode(), metadataResource, domainID );
 
-    final Response noMetadata = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
-        .request()
-        .get( Response.class );
-    assertEquals( Response.Status.CONFLICT.getStatusCode(), noMetadata.getStatus() );
-
-    Response postAnalysis = webTarget.path( "data-access/api/metadata/import" )
-        .request( MediaType.MULTIPART_FORM_DATA_TYPE )
-        .put( Entity.entity( part ,MediaType.MULTIPART_FORM_DATA_TYPE ) );
+    Response postAnalysis = metadataResource.doImportMetadataDatasource( domainID, metadataFile,
+        FormDataContentDisposition.name( "metadataFile" ).fileName( "Sample_SQL_Query.xmi" )
+            .size( metadataFile.available() ).build(), overwrite, null, null, null );
     assertEquals( 3, postAnalysis.getStatus() );
 
-    final Response noACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
-        .request()
-        .get( Response.class );
-    assertEquals( Response.Status.NOT_FOUND.getStatusCode(), noACL.getStatus() );
+    assertMetadataAclStatus( Response.Status.NOT_FOUND.getStatusCode(), metadataResource, domainID );
 
-    checkMetadata( webTarget, domainID, true );
+    checkMetadata( metadataResource, domainID, true );
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkMetadata( webTarget, domainID, true );
+    checkMetadata( metadataResource, domainID, true );
 
     repositoryBase.login( singleTenantAdminUserName, defaultTenant,
         new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
-    final Response changeACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
-        .request()
-        .put( Entity.entity( generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ), MediaType.APPLICATION_JSON ) );
+    final Response changeACL = metadataResource.doSetMetadataAcl( domainID,
+        generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ) );
     assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
 
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkMetadata( webTarget, domainID, true );
+    checkMetadata( metadataResource, domainID, true );
 
-    final Response noAccessACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "/acl" )
-        .request()
-        .get( Response.class );
-    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
+    assertMetadataAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), metadataResource, domainID );
+    assertMetadataAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), metadataResource, domainID + "_not_exist" );
+  }
 
-    final Response noAccessACLNoDS = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_METADATA + domainID + "_not_exist/acl" )
-        .request()
-        .get( Response.class );
-    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
+  private void assertMetadataAclStatus( int expectedStatus, MetadataResource metadataResource, String domainId ) {
+    try {
+      metadataResource.doGetMetadataAcl( domainId );
+    } catch ( WebApplicationException e ) {
+      assertEquals( expectedStatus, e.getResponse().getStatus() );
+      return;
+    }
+    throw new AssertionError( "Expected metadata ACL lookup to fail with status " + expectedStatus );
+  }
+
+  private void checkMetadata( MetadataResource metadataResource, String domainID, boolean hasAccess ) {
+    final List<String> list = metadataResource.getMetadataDatasourceIds().getList();
+    if ( hasAccess ) {
+      assertTrue( list != null && list.contains( domainID ) );
+    } else if ( list != null ) {
+      assertFalse( list.contains( domainID ) );
+    }
   }
 
   private void checkMetadata( WebTarget webTarget, String domainID, boolean hasAccess ) {
@@ -519,48 +507,29 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     final boolean overwrite = true;
     final RepositoryFileAclDto acl = generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER );
 
-    MultiPart part = new FormDataMultiPart()
-        .field( "domainId", domainID )
-        .field( "overwrite", String.valueOf( overwrite ) )
-        .field( "acl", marshalACL( acl ) )
-        .bodyPart(
-            new FormDataBodyPart(
-                FormDataContentDisposition.name( "metadataFile" )
-                    .fileName( "test.xmi" )
-                    .size( metadataFile.available() )
-                    .build(),
-                    metadataFile, MediaType.TEXT_XML_TYPE )
-        );
-
-    WebTarget webTarget = target();
-
-    Response postAnalysis = webTarget.path( DATA_ACCESS_API_DATASOURCE_DSW + "import" )
-        .request( MediaType.MULTIPART_FORM_DATA_TYPE )
-        .put( Entity.entity( part, MediaType.MULTIPART_FORM_DATA_TYPE ) );
+    DataSourceWizardResource dswResource = new DataSourceWizardResource();
+    Response postAnalysis = dswResource.publishDsw( domainID, metadataFile, overwrite, false, null );
     assertEquals( Response.Status.OK.getStatusCode(), postAnalysis.getStatus() );
 
-    final RepositoryFileAclDto savedACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
-        .request()
-        .get( Response.class ).readEntity( RepositoryFileAclDto.class );
+    assertEquals( Response.Status.OK.getStatusCode(), dswResource.doSetDSWAcl( domainID, acl ).getStatus() );
+
+    final RepositoryFileAclDto savedACL = dswResource.doGetDSWAcl( domainID );
     assertNotNull( savedACL );
 
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkDSW( webTarget, domainID, true );
+    checkDSW( dswResource, domainID, true );
 
     repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkDSW( webTarget, domainID, false );
+    checkDSW( dswResource, domainID, false );
 
     repositoryBase.login( singleTenantAdminUserName, defaultTenant,
         new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
-    final Response changeACL = webTarget
-        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
-        .request()
-        .put( Entity.entity( generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ) , MediaType.APPLICATION_JSON ) );
+    final Response changeACL = dswResource.doSetDSWAcl( domainID,
+      generateACL( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE ) );
     assertEquals( Response.Status.OK.getStatusCode(), changeACL.getStatus() );
 
     repositoryBase.login( USERNAME_TIFFANY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkDSW( webTarget, domainID, true );
+    checkDSW( dswResource, domainID, true );
   }
 
   @Test
@@ -572,63 +541,39 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     final FileInputStream metadataFile = new FileInputStream( "target/test-classes/test.xmi" );
     final boolean overwrite = true;
 
-    MultiPart part = new FormDataMultiPart()
-        .field( "domainId", domainID )
-        .field( "overwrite", String.valueOf( overwrite ) )
-        .bodyPart(
-            new FormDataBodyPart(
-                FormDataContentDisposition.name( "metadataFile" )
-                    .fileName( "test.xmi" )
-                    .size( metadataFile.available() )
-                    .build(),
-                    metadataFile, MediaType.TEXT_XML_TYPE )
-        );
+    DataSourceWizardResource dswResource = new DataSourceWizardResource();
+    assertDswAclStatus( Response.Status.CONFLICT.getStatusCode(), dswResource, domainID );
 
-    WebTarget webResource = target();
-
-    final Response noDSW = webResource
-        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
-        .request()
-        .get( Response.class );
-    assertEquals( Response.Status.CONFLICT.getStatusCode(), noDSW.getStatus() );
-
-    Response postAnalysis = webResource.path( DATA_ACCESS_API_DATASOURCE_DSW + "import" )
-        .request( MediaType.MULTIPART_FORM_DATA_TYPE )
-        .put( Entity.entity( part ,MediaType.MULTIPART_FORM_DATA_TYPE ) );
+    Response postAnalysis = dswResource.publishDsw( domainID, metadataFile, overwrite, false, null );
     assertEquals( Response.Status.OK.getStatusCode(), postAnalysis.getStatus() );
 
-    final Response noACL = webResource
-        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
-        .request()
-        .get( Response.class );
-    assertEquals( Response.Status.NOT_FOUND.getStatusCode(), noACL.getStatus() );
+    assertDswAclStatus( Response.Status.NOT_FOUND.getStatusCode(), dswResource, domainID );
 
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkDSW( webResource, domainID, true );
+    checkDSW( dswResource, domainID, true );
 
     repositoryBase.login( singleTenantAdminUserName, defaultTenant,
         new String[] { repositoryBase.getTenantAdminRoleName(), AUTHENTICATED_ROLE_NAME } );
-    final Response setSuzyACL = webResource
-        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
-        .request()
-        .put( Entity.entity( generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ), MediaType.MULTIPART_FORM_DATA_TYPE ) );
+    final Response setSuzyACL = dswResource.doSetDSWAcl( domainID,
+      generateACL( USERNAME_SUZY, RepositoryFileSid.Type.USER ) );
     assertEquals( Response.Status.OK.getStatusCode(), setSuzyACL.getStatus() );
 
     repositoryBase.login( USERNAME_SUZY, defaultTenant, new String[] { AUTHENTICATED_ROLE_NAME } );
-    checkDSW( webResource, domainID, true );
+    checkDSW( dswResource, domainID, true );
 
-    final Response noAccessACL = webResource
-        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "/acl" )
-        .request()
-        .get( Response.class );
-    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACL.getStatus() );
-
-    final Response noAccessACLNoDS = webResource
-        .path( DATA_ACCESS_API_DATASOURCE_DSW + domainID + "_not_exist/acl" )
-        .request()
-        .get( Response.class );
-    assertEquals( Response.Status.UNAUTHORIZED.getStatusCode(), noAccessACLNoDS.getStatus() );
+    assertDswAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), dswResource, domainID );
+    assertDswAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), dswResource, domainID + "_not_exist" );
   }
+
+    private void assertDswAclStatus( int expectedStatus, DataSourceWizardResource dswResource, String domainId ) {
+    try {
+      dswResource.doGetDSWAcl( domainId );
+    } catch ( WebApplicationException e ) {
+      assertEquals( expectedStatus, e.getResponse().getStatus() );
+      return;
+    }
+    throw new AssertionError( "Expected DSW ACL lookup to fail with status " + expectedStatus );
+    }
 
   private void checkDSW( WebTarget webTarget, String domainID, boolean hasAccess ) {
     final JaxbList dswIds = webTarget
@@ -637,6 +582,15 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
         .get( JaxbList.class );
 
     final List list = dswIds.getList();
+    if ( hasAccess ) {
+      assertTrue( list != null && list.contains( domainID ) );
+    } else if ( list != null ) {
+      assertFalse( list.contains( domainID ) );
+    }
+  }
+
+  private void checkDSW( DataSourceWizardResource dswResource, String domainID, boolean hasAccess ) {
+    final List<String> list = dswResource.getDSWDatasourceIds().getList();
     if ( hasAccess ) {
       assertTrue( list != null && list.contains( domainID ) );
     } else if ( list != null ) {
@@ -673,9 +627,14 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     return sw.toString();
   }
 
+  private static String serializeAclAsJson( RepositoryFileAclDto acl ) throws Exception {
+    return new ObjectMapper().writeValueAsString( acl );
+  }
+
   @Override
   public void setApplicationContext( ApplicationContext applicationContext ) throws BeansException {
     this.applicationContext = applicationContext;
+    authenticationManager = applicationContext.getBean( "authenticationManager", AuthenticationManager.class );
     repositoryBase.setApplicationContext( applicationContext );
   }
 }

--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
@@ -358,9 +358,9 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     } catch ( WebApplicationException e ) {
       assertEquals( expectedStatus, e.getResponse().getStatus() );
       return;
-  }
-    throw new AssertionError( "Expected analysis ACL lookup to fail with status " + expectedStatus );
     }
+    throw new AssertionError( "Expected analysis ACL lookup to fail with status " + expectedStatus );
+  }
 
   private void checkAnalysis( WebTarget webTarget, String catalogID, boolean hasAccess ) {
     final JaxbList analysisDatasourceIds = webTarget
@@ -565,9 +565,9 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     } catch ( WebApplicationException e ) {
       assertEquals( expectedStatus, e.getResponse().getStatus() );
       return;
-  }
-    throw new AssertionError( "Expected DSW ACL lookup to fail with status " + expectedStatus );
     }
+    throw new AssertionError( "Expected DSW ACL lookup to fail with status " + expectedStatus );
+  }
 
   private void checkDSW( WebTarget webTarget, String domainID, boolean hasAccess ) {
     final JaxbList dswIds = webTarget

--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/SerializeMultiTableServiceIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/SerializeMultiTableServiceIT.java
@@ -48,6 +48,7 @@ import org.pentaho.platform.api.repository.datasource.NonExistingDatasourceExcep
 import org.pentaho.platform.api.repository2.unified.IBackingRepositoryLifecycleManager;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.api.util.IPasswordService;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.agile.AgileHelper;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.ModelerService;
@@ -58,6 +59,7 @@ import org.pentaho.platform.engine.core.system.SystemSettings;
 import org.pentaho.platform.engine.services.connection.datasource.dbcp.JndiDatasourceService;
 import org.pentaho.platform.engine.services.solution.SolutionEngine;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
+import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogHelper;
 import org.pentaho.platform.plugin.action.mondrian.mapper.MondrianOneToOneUserRoleListMapper;
 import org.pentaho.platform.plugin.services.connections.mondrian.MDXConnection;
@@ -85,16 +87,20 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.io.File;
+import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -124,6 +130,8 @@ public class SerializeMultiTableServiceIT {
   private IBackingRepositoryLifecycleManager manager;
   
   private MicroPlatform booter;
+
+  private IMondrianCatalogService mondrianCatalogService;
   
   @Before
   public void setUp() throws Exception {
@@ -142,7 +150,8 @@ public class SerializeMultiTableServiceIT {
     
     booter.define(ISolutionEngine.class, SolutionEngine.class, Scope.GLOBAL);
     booter.define(IUnifiedRepository.class, TestFileSystemBackedUnifiedRepository.class, Scope.GLOBAL);
-    booter.define(IMondrianCatalogService.class, MondrianCatalogHelper.class, Scope.GLOBAL);
+    mondrianCatalogService = mock( IMondrianCatalogService.class );
+    booter.defineInstance( IMondrianCatalogService.class, mondrianCatalogService );
     booter.define("connection-SQL", SQLConnection.class);
     booter.define("connection-MDX", MDXConnection.class);
     booter.define("connection-MDXOlap4j", MDXOlap4jConnection.class);
@@ -223,6 +232,7 @@ public class SerializeMultiTableServiceIT {
     service.serializeModels(domain, "test_file");
 
     assertEquals( "SampleData", domain.getLogicalModels().get(0).getProperty("MondrianCatalogRef") );
+    verify( mondrianCatalogService ).addCatalog( any( MondrianCatalog.class ), any( Boolean.class ), any( IPentahoSession.class ) );
   }
 
   private SchemaModel getSchema() {
@@ -370,6 +380,20 @@ public class SerializeMultiTableServiceIT {
     public TestFileSystemBackedUnifiedRepository() {
       super("bin/test-solutions/solution");
     }
+
+    public TestFileSystemBackedUnifiedRepository( String baseDir ) {
+      super( baseDir );
+    }
+
+    @Override
+    public List<RepositoryFile> getReferrers( Serializable fileId ) {
+      return new ArrayList<>();
+    }
+
+    @Override
+    public boolean hasAccess( String path, EnumSet<RepositoryFilePermission> permissions ) {
+      return true;
+    }
   }
 
   public static class MockDatasourceMgmtService implements IDatasourceMgmtService{
@@ -478,7 +502,7 @@ public class SerializeMultiTableServiceIT {
   }
 
   public PentahoMetadataDomainRepository createMetadataDomainRepository() {
-    IUnifiedRepository repository = new FileSystemBackedUnifiedRepository("target/test-classes/solution1");
+    IUnifiedRepository repository = new TestFileSystemBackedUnifiedRepository( "target/test-classes/solution1" );
     booter.defineInstance(IUnifiedRepository.class, repository);
     assertNotNull(new RepositoryUtils(repository).getFolder("/etc/metadata", true, true, null));
     assertNotNull(new RepositoryUtils(repository).getFolder("/etc/mondrian", true, true, null));

--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/SerializeServiceIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/wizard/csv/SerializeServiceIT.java
@@ -46,6 +46,7 @@ import org.pentaho.platform.api.repository.datasource.NonExistingDatasourceExcep
 import org.pentaho.platform.api.repository2.unified.IBackingRepositoryLifecycleManager;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.api.util.IPasswordService;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.agile.AgileHelper;
 import org.pentaho.platform.dataaccess.datasource.wizard.service.impl.ModelerService;
@@ -56,6 +57,7 @@ import org.pentaho.platform.engine.core.system.SystemSettings;
 import org.pentaho.platform.engine.services.connection.datasource.dbcp.JndiDatasourceService;
 import org.pentaho.platform.engine.services.solution.SolutionEngine;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
+import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogHelper;
 import org.pentaho.platform.plugin.action.mondrian.mapper.MondrianOneToOneUserRoleListMapper;
 import org.pentaho.platform.plugin.services.connections.mondrian.MDXConnection;
@@ -83,15 +85,19 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.io.File;
+import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -122,6 +128,8 @@ public class SerializeServiceIT {
 
   private MicroPlatform booter;
 
+  private IMondrianCatalogService mondrianCatalogService;
+
   @Before
   public void setUp() throws Exception {
 
@@ -140,7 +148,8 @@ public class SerializeServiceIT {
 
     booter.define(ISolutionEngine.class, SolutionEngine.class, Scope.GLOBAL);
     booter.define(IUnifiedRepository.class, TestFileSystemBackedUnifiedRepository.class, Scope.GLOBAL);
-    booter.define(IMondrianCatalogService.class, MondrianCatalogHelper.class, Scope.GLOBAL);
+    mondrianCatalogService = mock( IMondrianCatalogService.class );
+    booter.defineInstance( IMondrianCatalogService.class, mondrianCatalogService );
     booter.define("connection-SQL", SQLConnection.class);
     booter.define("connection-MDX", MDXConnection.class);
     booter.define("connection-MDXOlap4j", MDXOlap4jConnection.class);
@@ -215,6 +224,7 @@ public class SerializeServiceIT {
     service.serializeModels(domain, "test_file");
 
     assertEquals(domain.getLogicalModels().get(1).getProperty("MondrianCatalogRef"), model.getModelName());
+    verify( mondrianCatalogService ).addCatalog( any( MondrianCatalog.class ), any( Boolean.class ), any( IPentahoSession.class ) );
   }
 
   private Domain generateModel() {
@@ -356,6 +366,20 @@ public class SerializeServiceIT {
     public TestFileSystemBackedUnifiedRepository() {
       super("bin/test-solutions/solution");
     }
+
+    public TestFileSystemBackedUnifiedRepository( String baseDir ) {
+      super( baseDir );
+    }
+
+    @Override
+    public List<RepositoryFile> getReferrers( Serializable fileId ) {
+      return new ArrayList<>();
+    }
+
+    @Override
+    public boolean hasAccess( String path, EnumSet<RepositoryFilePermission> permissions ) {
+      return true;
+    }
   }
 
   public static class MockDatasourceMgmtService implements IDatasourceMgmtService {
@@ -461,7 +485,7 @@ public class SerializeServiceIT {
   }
 
   public PentahoMetadataDomainRepository createMetadataDomainRepository() {
-    IUnifiedRepository repository = new FileSystemBackedUnifiedRepository("target/test-classes/solution1");
+    IUnifiedRepository repository = new TestFileSystemBackedUnifiedRepository( "target/test-classes/solution1" );
     booter.defineInstance(IUnifiedRepository.class, repository);
     assertNotNull(new RepositoryUtils(repository).getFolder("/etc/metadata", true, true, null));
     assertNotNull(new RepositoryUtils(repository).getFolder("/etc/mondrian", true, true, null));

--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/DatasourceResourceIT.java
@@ -49,6 +49,7 @@ import org.pentaho.platform.api.repository.datasource.DuplicateDatasourceExcepti
 import org.pentaho.platform.api.repository.datasource.IDatasourceMgmtService;
 import org.pentaho.platform.api.repository.datasource.NonExistingDatasourceException;
 import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
+import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.util.IPasswordService;
@@ -79,6 +80,7 @@ import org.pentaho.platform.plugin.services.pluginmgr.PluginClassLoader;
 import org.pentaho.platform.plugin.services.pluginmgr.PluginResourceLoader;
 import org.pentaho.platform.repository2.unified.RepositoryUtils;
 import org.pentaho.platform.repository2.unified.fs.FileSystemBackedUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFileData;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.pentaho.test.platform.engine.security.MockSecurityHelper;
 import org.springframework.dao.DataAccessException;
@@ -100,10 +102,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -434,7 +439,7 @@ public class DatasourceResourceIT {
   }
 
   private static PentahoMetadataDomainRepository createMetadataDomainRepository() {
-    IUnifiedRepository repository = new FileSystemBackedUnifiedRepository( "target/test-classes/dsw" );
+    IUnifiedRepository repository = new TestFileSystemBackedUnifiedRepository( "target/test-classes/dsw" );
     mp.defineInstance( IUnifiedRepository.class, repository );
     assertNotNull( new RepositoryUtils( repository ).getFolder( "/etc/metadata", true, true, null ) );
     assertNotNull( new RepositoryUtils( repository ).getFolder( "/etc/mondrian", true, true, null ) );
@@ -538,8 +543,48 @@ public class DatasourceResourceIT {
   }
 
   public static class TestFileSystemBackedUnifiedRepository extends FileSystemBackedUnifiedRepository {
+    private final Map<Serializable, NodeRepositoryFileData> nodeDataByFileId = new HashMap<>();
+
     public TestFileSystemBackedUnifiedRepository() {
       super( "bin/test-solutions/solution" );
+    }
+
+    public TestFileSystemBackedUnifiedRepository( String baseDir ) {
+      super( baseDir );
+    }
+
+    @Override
+    public List<RepositoryFile> getReferrers( Serializable fileId ) {
+      return new ArrayList<>();
+    }
+
+    @Override
+    public RepositoryFile createFile( Serializable parentFolderId, RepositoryFile file, IRepositoryFileData data,
+                                      String versionMessage ) {
+      RepositoryFile createdFile = super.createFile( parentFolderId, file, data, versionMessage );
+      storeNodeData( createdFile, data );
+      return createdFile;
+    }
+
+    @Override
+    public RepositoryFile updateFile( RepositoryFile file, IRepositoryFileData data, String versionMessage ) {
+      RepositoryFile updatedFile = super.updateFile( file, data, versionMessage );
+      storeNodeData( updatedFile, data );
+      return updatedFile;
+    }
+
+    @Override
+    public <T extends IRepositoryFileData> T getDataForRead( Serializable fileId, Class<T> dataClass ) {
+      if ( NodeRepositoryFileData.class.equals( dataClass ) ) {
+        return dataClass.cast( nodeDataByFileId.get( fileId ) );
+      }
+      return super.getDataForRead( fileId, dataClass );
+    }
+
+    private void storeNodeData( RepositoryFile file, IRepositoryFileData data ) {
+      if ( data instanceof NodeRepositoryFileData ) {
+        nodeDataByFileId.put( file.getId(), (NodeRepositoryFileData) data );
+      }
     }
   }
 

--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ModelerServiceIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/wizard/service/impl/ModelerServiceIT.java
@@ -26,6 +26,7 @@ import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -55,6 +56,8 @@ public class ModelerServiceIT extends DataAccessServiceTestBase {
     ModelInfo modelInfo = new ModelInfo();
     ColumnInfo[] columnInfos = new ColumnInfo[] { createColumnInfo( "id", "title" ) };
     modelInfo.setColumns( columnInfos );
+    modelInfo.setStageTableName( "csv_stage" );
+    modelInfo.setDatasourceName( "csv_datasource" );
 
     modelerService = spy( modelerService );
     DatabaseMeta dbMeta = mock( DatabaseMeta.class );
@@ -62,7 +65,7 @@ public class ModelerServiceIT extends DataAccessServiceTestBase {
 
     TableModelerSource source = mock( TableModelerSource.class );
     doReturn( source ).when( modelerService )
-      .createTableModelerSource( any( DatabaseMeta.class ), anyString(), anyString(), anyString() );
+      .createTableModelerSource( any( DatabaseMeta.class ), anyString(), isNull(), anyString() );
 
     modelerService.generateCSVDomain( modelInfo );
 

--- a/core/src/test/resources/jackrabbit-test-repo.xml
+++ b/core/src/test/resources/jackrabbit-test-repo.xml
@@ -103,8 +103,8 @@ Jackrabbit configuration suitable for integration tests.
         persistence manager of the workspace:
         class: FQN of class implementing the PersistenceManager interface
     -->
-    <PersistenceManager class="org.apache.jackrabbit.core.persistence.pool.DerbyPersistenceManager">
-      <param name="url" value="jdbc:derby:${wsp.home}/db;create=true"/>
+    <PersistenceManager class="org.apache.jackrabbit.core.persistence.pool.H2PersistenceManager">
+      <param name="url" value="jdbc:h2:${wsp.home}/db"/>
       <param name="schemaObjectPrefix" value="${wsp.name}_"/>
     </PersistenceManager>
     <!--
@@ -141,8 +141,8 @@ Jackrabbit configuration suitable for integration tests.
         a 'normal' persistence manager, but this could change in future
         implementations.
     -->
-    <PersistenceManager class="org.apache.jackrabbit.core.persistence.pool.DerbyPersistenceManager">
-      <param name="url" value="jdbc:derby:${rep.home}/version/db;create=true"/>
+    <PersistenceManager class="org.apache.jackrabbit.core.persistence.pool.H2PersistenceManager">
+      <param name="url" value="jdbc:h2:${rep.home}/version/db"/>
       <param name="schemaObjectPrefix" value="version_"/>
     </PersistenceManager>
   </Versioning>

--- a/core/src/test/resources/solutionACL/system/pentahoObjects.spring.xml
+++ b/core/src/test/resources/solutionACL/system/pentahoObjects.spring.xml
@@ -53,13 +53,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       <ref bean="unifiedRepository"/>
     </constructor-arg>
   </bean>
-  <!-- Wrap the concrete IMetadataDomainRepository implementation with one that caches domains per session -->
-  <bean id="IMetadataDomainRepository"
-        class="org.pentaho.platform.plugin.services.metadata.SessionCachingMetadataDomainRepository" scope="singleton">
-    <constructor-arg>
-      <ref bean="IMetadataDomainRepositoryImpl"/>
-    </constructor-arg>
-  </bean>
+  <alias name="IMetadataDomainRepositoryImpl" alias="IMetadataDomainRepository"/>
   <!--  Use this schema factory to disable PMD security -->
   <!--  <bean id="IMetadataDomainRepository" class="org.pentaho.platform.plugin.services.metadata.CachingPentahoMetadataDomainRepository" scope="singleton"/>-->
   <bean id="IUserSettingService" class="org.pentaho.platform.repository.usersettings.UserSettingService"
@@ -117,14 +111,11 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     <property name="serviceTypeManagers">
       <list>
         <ref bean="gwtServiceManager"/>
-        <ref bean="axisServiceManager"/>
       </list>
     </property>
   </bean>
   <bean id="ITempFileDeleter" class="org.pentaho.platform.web.http.session.SessionTempFileDeleter" scope="prototype"/>
   <bean id="gwtServiceManager" class="org.pentaho.platform.plugin.services.pluginmgr.servicemgr.GwtRpcServiceManager"
-        scope="singleton"/>
-  <bean id="axisServiceManager" class="org.pentaho.platform.plugin.services.pluginmgr.servicemgr.AxisWebServiceManager"
         scope="singleton"/>
 
   <bean id="IChartBeansGenerator" class="org.pentaho.platform.plugin.action.chartbeans.DefaultChartBeansGenerator"
@@ -211,18 +202,7 @@ not directly from the PentahoObjectFactory. -->
     </constructor-arg>
   </bean>
 
-  <bean id="ehCacheUserCache" class="org.springframework.security.core.userdetails.cache.EhCacheBasedUserCache">
-    <property name="cache">
-      <bean class="org.springframework.cache.ehcache.EhCacheFactoryBean">
-        <property name="cacheManager">
-          <bean class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
-      <property name="shared" value="true"/>
-  </bean>
-        </property>
-        <property name="cacheName" value="userCache"/>
-      </bean>
-    </property>
-  </bean>
+  <bean id="ehCacheUserCache" class="org.springframework.security.core.userdetails.cache.NullUserCache"/>
 
   <bean id="cachingUserDetailsService" class="org.pentaho.platform.plugin.services.security.userrole.PentahoCachingUserDetailsService">
     <constructor-arg>

--- a/core/src/test/resources/solutionACL/system/repository-test-override.spring.xml
+++ b/core/src/test/resources/solutionACL/system/repository-test-override.spring.xml
@@ -12,13 +12,12 @@
   <sec:authentication-manager alias="authenticationManager">
     <sec:authentication-provider>
      <sec:user-service>
-      <sec:user password="password" name="admin" authorities="Authenticated, Administrator"/>
-      <sec:user password="password" name="suzy" authorities="Authenticated"/>
+      <sec:user password="{noop}password" name="admin" authorities="Authenticated, Administrator"/>
+      <sec:user password="{noop}password" name="suzy" authorities="Authenticated"/>
+      <sec:user password="{noop}password" name="tiffany" authorities="Authenticated"/>
     </sec:user-service>
    </sec:authentication-provider>
   </sec:authentication-manager>
-
-  <sec:authentication-manager alias="authenticationManager"/>
 
   <bean id="jcrRepository" class="org.springframework.extensions.jcr.jackrabbit.RepositoryFactoryBean">
     <property name="configuration" value="classpath:/jackrabbit-test-repo.xml"/>


### PR DESCRIPTION
## Summary
Backports pentaho/data-access#1369 to the 11.0 line. And additional fixes of https://github.com/pentaho/data-access/pull/1372

The patch updates the data-access integration fixtures for the current repository, Spring Security, and persistence behavior; it also supplies the repository override fixture and strengthens the affected datasource and serialization ITs.

## Validation
```text
mvn --batch-mode -pl core -DrunITs compiler:compile resources:testResources build-helper:add-test-source@test-integration_add-source resources:copy-resources@test-integration_add-resources compiler:testCompile@test-integration_compile -Dit.test=DataSourcePublishIT,SerializeMultiTableServiceIT,SerializeServiceIT,DatasourceResourceIT,ModelerServiceIT failsafe:integration-test failsafe:verify
```
Failsafe XML: 19 tests, 0 failures, 0 errors, 0 skipped.

POM validation: no duplicate dependency coordinates introduced; one duplicate `org.glassfish.jersey.core:jersey-common` declaration predates this backport in the 11.0 baseline.

Backport base: `pentaho/11.0` at `b4b803fe4f324cbc4b43b93584c5c8dc35d2e383`.
Current head: `b7a4b0c11146428ea4ab70177605a71ba9f218fe`.

## Review follow-up
Removes unused ACL serialization helpers and imports from `DataSourcePublishIT`, and aligns the two ACL assertion helper declarations, including their closing braces.

Validation:
```text
mvn --batch-mode -pl core -DrunITs compiler:compile resources:testResources build-helper:add-test-source@test-integration_add-source resources:copy-resources@test-integration_add-resources compiler:testCompile@test-integration_compile -Dit.test=DataSourcePublishIT failsafe:integration-test failsafe:verify
```
Failsafe XML: 6 tests, 0 failures, 0 errors, 0 skipped.