### PR TITLE
test(data-access): remove stale DataSourcePublishIT code [BACKLOG-43744]

### DIFF
--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
@@ -359,9 +359,9 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     } catch ( WebApplicationException e ) {
       assertEquals( expectedStatus, e.getResponse().getStatus() );
       return;
-  }
-    throw new AssertionError( "Expected analysis ACL lookup to fail with status " + expectedStatus );
     }
+    throw new AssertionError( "Expected analysis ACL lookup to fail with status " + expectedStatus );
+  }
 
   private void checkAnalysis( WebTarget webTarget, String catalogID, boolean hasAccess ) {
     final JaxbList analysisDatasourceIds = webTarget
@@ -566,9 +566,9 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     } catch ( WebApplicationException e ) {
       assertEquals( expectedStatus, e.getResponse().getStatus() );
       return;
-  }
-    throw new AssertionError( "Expected DSW ACL lookup to fail with status " + expectedStatus );
     }
+    throw new AssertionError( "Expected DSW ACL lookup to fail with status " + expectedStatus );
+  }
 
   private void checkDSW( WebTarget webTarget, String domainID, boolean hasAccess ) {
     final JaxbList dswIds = webTarget

--- a/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
+++ b/core/src/it/java/org/pentaho/platform/dataaccess/datasource/DataSourcePublishIT.java
@@ -18,7 +18,6 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -92,14 +91,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import jakarta.ws.rs.core.MediaType;
 import org.glassfish.jersey.test.JerseyTest;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Marshaller;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -359,13 +353,13 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     assertAnalysisAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), analysisResource, catalogID + "_not_exist" );
   }
 
-    private void assertAnalysisAclStatus( int expectedStatus, AnalysisResource analysisResource, String catalogId ) {
+  private void assertAnalysisAclStatus( int expectedStatus, AnalysisResource analysisResource, String catalogId ) {
     try {
       analysisResource.doGetAnalysisDatasourceAcl( catalogId );
     } catch ( WebApplicationException e ) {
       assertEquals( expectedStatus, e.getResponse().getStatus() );
       return;
-    }
+  }
     throw new AssertionError( "Expected analysis ACL lookup to fail with status " + expectedStatus );
     }
 
@@ -566,13 +560,13 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
     assertDswAclStatus( Response.Status.UNAUTHORIZED.getStatusCode(), dswResource, domainID + "_not_exist" );
   }
 
-    private void assertDswAclStatus( int expectedStatus, DataSourceWizardResource dswResource, String domainId ) {
+  private void assertDswAclStatus( int expectedStatus, DataSourceWizardResource dswResource, String domainId ) {
     try {
       dswResource.doGetDSWAcl( domainId );
     } catch ( WebApplicationException e ) {
       assertEquals( expectedStatus, e.getResponse().getStatus() );
       return;
-    }
+  }
     throw new AssertionError( "Expected DSW ACL lookup to fail with status " + expectedStatus );
     }
 
@@ -617,19 +611,6 @@ public class DataSourcePublishIT extends JerseyTest implements ApplicationContex
 
     aclDto.setAces( aces );
     return aclDto;
-  }
-
-  private static String marshalACL( RepositoryFileAclDto acl ) throws JAXBException {
-    JAXBContext context = JAXBContext.newInstance( RepositoryFileAclDto.class );
-    Marshaller marshaller = context.createMarshaller();
-    StringWriter sw = new StringWriter();
-    marshaller.marshal( acl, sw );
-
-    return sw.toString();
-  }
-
-  private static String serializeAclAsJson( RepositoryFileAclDto acl ) throws Exception {
-    return new ObjectMapper().writeValueAsString( acl );
   }
 
   @Override


### PR DESCRIPTION
## Summary
Removes stale ACL serialization helper code and unused imports from `DataSourcePublishIT`, and aligns the two ACL assertion helper declarations, including their closing braces.

This is a test-only cleanup for the same review findings present in the source change now on master.

## Validation
```text
mvn --batch-mode -pl core -DrunITs openapi-generator:generate@generate-api build-helper:add-source@add-source compiler:compile resources:testResources build-helper:add-test-source@test-integration_add-source resources:copy-resources@test-integration_add-resources compiler:testCompile@test-integration_compile -Dit.test=DataSourcePublishIT failsafe:integration-test failsafe:verify
```
Failsafe XML: 6 tests, 0 failures, 0 errors, 0 skipped.

Base: `pentaho/master` at `84f8df7866a37c0a4fa3d8bce77aa5daf2234d6a`.